### PR TITLE
feat(bifrost): Add Gateway admin UI for Bifrost management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,7 @@ services:
   #     - ORBIT_REGISTRY_TOKEN=orbit-registry-token
   #     - ORBIT_REGISTRY_JWT_SECRET=${ORBIT_REGISTRY_JWT_SECRET:-orbit-registry-jwt-secret-dev-only-32chars}
   #     - NEXT_PUBLIC_KAFKA_SERVICE_URL=http://kafka-service:50055
+  #     - BIFROST_ADMIN_URL=http://bifrost:50060
   #   env_file:
   #     - ./orbit-www/.env
   #   depends_on:

--- a/orbit-www/.env.example
+++ b/orbit-www/.env.example
@@ -20,3 +20,7 @@ ORBIT_INTERNAL_API_KEY=your-secure-api-key-here
 RESEND_API_KEY=re_xxxxxxxxxxxx
 # The "from" email address - must be a verified domain in Resend
 RESEND_FROM_EMAIL=noreply@yourdomain.com
+
+# Bifrost Gateway Admin API
+# URL of the Bifrost admin gRPC service
+BIFROST_ADMIN_URL=http://localhost:50060

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialForm.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialForm.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { ArrowLeft, RefreshCw } from 'lucide-react'
+import type { VirtualClusterConfig, PermissionTemplateType } from '@/app/actions/bifrost-admin'
+
+interface CredentialFormProps {
+  virtualClusters: VirtualClusterConfig[]
+  onCancel: () => void
+  onSuccess: (data: { username: string; password: string }) => void
+}
+
+function generatePassword(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*'
+  let password = ''
+  for (let i = 0; i < 24; i++) {
+    password += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return password
+}
+
+export function CredentialForm({
+  virtualClusters,
+  onCancel,
+  onSuccess,
+}: CredentialFormProps) {
+  const [formData, setFormData] = useState({
+    virtualClusterId: '',
+    username: '',
+    password: generatePassword(),
+    template: 'producer' as PermissionTemplateType,
+  })
+
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const { createCredential } = await import('@/app/actions/bifrost-admin')
+      const result = await createCredential({
+        virtualClusterId: formData.virtualClusterId,
+        username: formData.username,
+        password: formData.password,
+        template: formData.template,
+      })
+
+      if (result.success && result.data) {
+        onSuccess({
+          username: result.data.username,
+          password: result.data.password,
+        })
+      } else {
+        setError(result.error || 'Failed to create credential')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create credential')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const regeneratePassword = () => {
+    setFormData({ ...formData, password: generatePassword() })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <CardTitle>Create Credential</CardTitle>
+            <CardDescription>
+              Create a new service account credential for Bifrost access
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="p-4 bg-destructive/10 text-destructive rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="virtualClusterId">Virtual Cluster *</Label>
+              <Select
+                value={formData.virtualClusterId}
+                onValueChange={(value) => setFormData({ ...formData, virtualClusterId: value })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select virtual cluster" />
+                </SelectTrigger>
+                <SelectContent>
+                  {virtualClusters.map((vc) => (
+                    <SelectItem key={vc.id} value={vc.id}>
+                      {vc.id} ({vc.workspaceSlug} / {vc.environment})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="username">Username *</Label>
+              <Input
+                id="username"
+                value={formData.username}
+                onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                placeholder="my-service-account"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password *</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="password"
+                  value={formData.password}
+                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                  required
+                  className="font-mono"
+                />
+                <Button type="button" variant="outline" size="icon" onClick={regeneratePassword}>
+                  <RefreshCw className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="template">Permission Template *</Label>
+              <Select
+                value={formData.template}
+                onValueChange={(value) => setFormData({ ...formData, template: value as PermissionTemplateType })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select permissions" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="producer">Producer - Write access to topics</SelectItem>
+                  <SelectItem value="consumer">Consumer - Read access to topics</SelectItem>
+                  <SelectItem value="admin">Admin - Full access</SelectItem>
+                  <SelectItem value="custom">Custom - Define custom permissions</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 pt-4">
+            <Button type="submit" disabled={isSubmitting || !formData.virtualClusterId}>
+              {isSubmitting ? 'Creating...' : 'Create Credential'}
+            </Button>
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Plus, RefreshCw, Key, User } from 'lucide-react'
+import { Plus, RefreshCw, Key, User, Copy, Check } from 'lucide-react'
 import type { CredentialConfig, VirtualClusterConfig } from '@/app/actions/bifrost-admin'
 import { CredentialForm } from './CredentialForm'
 
@@ -39,6 +39,7 @@ export function CredentialsTab({
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [showForm, setShowForm] = useState(false)
   const [newCredential, setNewCredential] = useState<{ username: string; password: string } | null>(null)
+  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null)
 
   const handleRefresh = async () => {
     setIsRefreshing(true)
@@ -76,6 +77,12 @@ export function CredentialsTab({
     return vc ? `${vc.workspaceSlug} / ${vc.environment}` : vcId
   }
 
+  const handleCopy = async (field: 'username' | 'password', value: string) => {
+    await navigator.clipboard.writeText(value)
+    setCopiedField(field)
+    setTimeout(() => setCopiedField(null), 2000)
+  }
+
   // Show newly created credential
   if (newCredential) {
     return (
@@ -87,16 +94,45 @@ export function CredentialsTab({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="p-4 bg-muted rounded-lg space-y-2">
+          <div className="p-4 bg-muted rounded-lg space-y-3">
             <div>
-              <p className="text-xs text-muted-foreground">Username</p>
-              <p className="font-mono">{newCredential.username}</p>
+              <p className="text-xs text-muted-foreground mb-1">Username</p>
+              <div className="flex items-center gap-2">
+                <p className="font-mono flex-1">{newCredential.username}</p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopy('username', newCredential.username)}
+                >
+                  {copiedField === 'username' ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
             </div>
             <div>
-              <p className="text-xs text-muted-foreground">Password</p>
-              <p className="font-mono break-all">{newCredential.password}</p>
+              <p className="text-xs text-muted-foreground mb-1">Password</p>
+              <div className="flex items-center gap-2">
+                <p className="font-mono break-all flex-1">{newCredential.password}</p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopy('password', newCredential.password)}
+                >
+                  {copiedField === 'password' ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
+          <p className="text-sm text-amber-600 dark:text-amber-500">
+            This password will not be shown again. Copy and save it securely now.
+          </p>
           <Button onClick={() => setNewCredential(null)}>Done</Button>
         </CardContent>
       </Card>

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
@@ -34,7 +34,7 @@ export function CredentialsTab({
   credentials,
   virtualClusters,
   onRefresh,
-  onCredentialsChange,
+  onCredentialsChange: _onCredentialsChange,
 }: CredentialsTabProps) {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [showForm, setShowForm] = useState(false)

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/CredentialsTab.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Plus, RefreshCw, Key, User } from 'lucide-react'
+import type { CredentialConfig, VirtualClusterConfig } from '@/app/actions/bifrost-admin'
+import { CredentialForm } from './CredentialForm'
+
+interface CredentialsTabProps {
+  credentials: CredentialConfig[]
+  virtualClusters: VirtualClusterConfig[]
+  onRefresh: () => Promise<void>
+  onCredentialsChange: (credentials: CredentialConfig[]) => void
+}
+
+function getTemplateBadge(template: string): { label: string; variant: 'default' | 'secondary' | 'outline' } {
+  switch (template) {
+    case 'producer':
+      return { label: 'Producer', variant: 'default' }
+    case 'consumer':
+      return { label: 'Consumer', variant: 'secondary' }
+    case 'admin':
+      return { label: 'Admin', variant: 'outline' }
+    case 'custom':
+      return { label: 'Custom', variant: 'outline' }
+    default:
+      return { label: template, variant: 'outline' }
+  }
+}
+
+export function CredentialsTab({
+  credentials,
+  virtualClusters,
+  onRefresh,
+  onCredentialsChange,
+}: CredentialsTabProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [newCredential, setNewCredential] = useState<{ username: string; password: string } | null>(null)
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    try {
+      await onRefresh()
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
+  const handleRevoke = async (credentialId: string, username: string) => {
+    if (!confirm(`Are you sure you want to revoke the credential for "${username}"? This will immediately disconnect any clients using this credential.`)) {
+      return
+    }
+
+    try {
+      const { revokeCredential } = await import('@/app/actions/bifrost-admin')
+      const result = await revokeCredential(credentialId)
+      if (result.success) {
+        await onRefresh()
+      }
+    } catch (err) {
+      console.error('Failed to revoke credential:', err)
+    }
+  }
+
+  const handleFormSuccess = async (data: { username: string; password: string }) => {
+    setNewCredential(data)
+    setShowForm(false)
+    await onRefresh()
+  }
+
+  const getVirtualClusterName = (vcId: string) => {
+    const vc = virtualClusters.find((v) => v.id === vcId)
+    return vc ? `${vc.workspaceSlug} / ${vc.environment}` : vcId
+  }
+
+  // Show newly created credential
+  if (newCredential) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Credential Created</CardTitle>
+          <CardDescription>
+            Save these credentials now. The password will not be shown again.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="p-4 bg-muted rounded-lg space-y-2">
+            <div>
+              <p className="text-xs text-muted-foreground">Username</p>
+              <p className="font-mono">{newCredential.username}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Password</p>
+              <p className="font-mono break-all">{newCredential.password}</p>
+            </div>
+          </div>
+          <Button onClick={() => setNewCredential(null)}>Done</Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (showForm) {
+    return (
+      <CredentialForm
+        virtualClusters={virtualClusters}
+        onCancel={() => setShowForm(false)}
+        onSuccess={handleFormSuccess}
+      />
+    )
+  }
+
+  // Empty state
+  if (credentials.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-4">
+        <div className="rounded-full bg-muted p-4 mb-4">
+          <Key className="h-8 w-8 text-muted-foreground" />
+        </div>
+        <h3 className="text-lg font-semibold mb-2">No Credentials</h3>
+        <p className="text-muted-foreground text-center mb-6 max-w-md">
+          Credentials provide authentication for applications connecting through Bifrost.
+          Create credentials for your virtual clusters.
+        </p>
+        <Button onClick={() => setShowForm(true)} disabled={virtualClusters.length === 0}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Credential
+        </Button>
+        {virtualClusters.length === 0 && (
+          <p className="text-sm text-muted-foreground mt-2">
+            Create a virtual cluster first
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header with actions */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {credentials.length} credential{credentials.length !== 1 ? 's' : ''} configured
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button size="sm" onClick={() => setShowForm(true)} disabled={virtualClusters.length === 0}>
+            <Plus className="h-4 w-4" />
+            Create Credential
+          </Button>
+        </div>
+      </div>
+
+      {/* Credentials grid */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {credentials.map((credential) => {
+          const templateBadge = getTemplateBadge(credential.template)
+
+          return (
+            <Card key={credential.id}>
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <User className="h-5 w-5 text-muted-foreground" />
+                    <CardTitle className="text-base">{credential.username}</CardTitle>
+                  </div>
+                  <Badge variant={templateBadge.variant}>{templateBadge.label}</Badge>
+                </div>
+                <CardDescription className="text-xs">
+                  {getVirtualClusterName(credential.virtualClusterId)}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleRevoke(credential.id, credential.username)}
+                  >
+                    Revoke
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/GatewayStatusTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/GatewayStatusTab.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { RefreshCw, Activity, Server, Users, Shield } from 'lucide-react'
+import type { GatewayStatus } from '@/app/actions/bifrost-admin'
+
+interface GatewayStatusTabProps {
+  status: GatewayStatus | null
+  onRefresh: () => Promise<void>
+}
+
+function getStatusBadge(status: string): { variant: 'default' | 'secondary' | 'destructive'; className?: string } {
+  switch (status.toLowerCase()) {
+    case 'healthy':
+    case 'ok':
+      return { variant: 'default', className: 'bg-green-500 hover:bg-green-500/80 text-white' }
+    case 'degraded':
+      return { variant: 'secondary', className: 'bg-yellow-500 hover:bg-yellow-500/80 text-white' }
+    case 'unhealthy':
+    case 'error':
+      return { variant: 'destructive' }
+    default:
+      return { variant: 'secondary' }
+  }
+}
+
+export function GatewayStatusTab({
+  status,
+  onRefresh,
+}: GatewayStatusTabProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    try {
+      await onRefresh()
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
+  // Unreachable state
+  if (!status) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-4">
+        <div className="rounded-full bg-destructive/10 p-4 mb-4">
+          <Activity className="h-8 w-8 text-destructive" />
+        </div>
+        <h3 className="text-lg font-semibold mb-2">Gateway Unreachable</h3>
+        <p className="text-muted-foreground text-center mb-6 max-w-md">
+          Unable to connect to the Bifrost gateway. Check that the service is running
+          and accessible.
+        </p>
+        <Button onClick={handleRefresh} disabled={isRefreshing}>
+          <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+          Retry Connection
+        </Button>
+      </div>
+    )
+  }
+
+  const statusBadge = getStatusBadge(status.status)
+
+  return (
+    <div className="space-y-6">
+      {/* Header with refresh */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Gateway health and configuration overview
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={isRefreshing}
+        >
+          <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Status cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription className="flex items-center gap-2">
+              <Activity className="h-4 w-4" />
+              Gateway Status
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Badge variant={statusBadge.variant} className={statusBadge.className}>
+              {status.status}
+            </Badge>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Active Connections
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{status.activeConnections}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription className="flex items-center gap-2">
+              <Server className="h-4 w-4" />
+              Virtual Clusters
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{status.virtualClusterCount}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription className="flex items-center gap-2">
+              <Shield className="h-4 w-4" />
+              Version
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm font-mono">
+              {status.versionInfo?.version || status.versionInfo?.['bifrost.version'] || 'Unknown'}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Version info details */}
+      {Object.keys(status.versionInfo).length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Version Information</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
+              {Object.entries(status.versionInfo).map(([key, value]) => (
+                <div key={key} className="text-sm">
+                  <p className="text-muted-foreground">{key}</p>
+                  <p className="font-mono">{value}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/GatewayTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/GatewayTab.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AlertCircle } from 'lucide-react'
+import type { VirtualClusterConfig, CredentialConfig, GatewayStatus } from '@/app/actions/bifrost-admin'
+import { VirtualClustersTab } from './VirtualClustersTab'
+import { CredentialsTab } from './CredentialsTab'
+import { GatewayStatusTab } from './GatewayStatusTab'
+
+interface GatewayTabProps {
+  initialVirtualClusters: VirtualClusterConfig[]
+  initialCredentials: CredentialConfig[]
+  initialStatus: GatewayStatus | null
+  connectionError?: string
+}
+
+export function GatewayTab({
+  initialVirtualClusters,
+  initialCredentials,
+  initialStatus,
+  connectionError,
+}: GatewayTabProps) {
+  const [activeSubTab, setActiveSubTab] = useState('virtual-clusters')
+  const [virtualClusters, setVirtualClusters] = useState(initialVirtualClusters)
+  const [credentials, setCredentials] = useState(initialCredentials)
+  const [status, setStatus] = useState(initialStatus)
+  const [error, setError] = useState<string | null>(connectionError || null)
+
+  // Refresh functions
+  const refreshVirtualClusters = async () => {
+    try {
+      const { listVirtualClusters } = await import('@/app/actions/bifrost-admin')
+      const result = await listVirtualClusters()
+      if (result.success && result.data) {
+        setVirtualClusters(result.data)
+        setError(null)
+      } else {
+        setError(result.error || 'Failed to refresh virtual clusters')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh virtual clusters')
+    }
+  }
+
+  const refreshCredentials = async () => {
+    try {
+      const { listCredentials } = await import('@/app/actions/bifrost-admin')
+      const result = await listCredentials()
+      if (result.success && result.data) {
+        setCredentials(result.data)
+        setError(null)
+      } else {
+        setError(result.error || 'Failed to refresh credentials')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh credentials')
+    }
+  }
+
+  const refreshStatus = async () => {
+    try {
+      const { getGatewayStatus } = await import('@/app/actions/bifrost-admin')
+      const result = await getGatewayStatus()
+      if (result.success && result.data) {
+        setStatus(result.data)
+        setError(null)
+      } else {
+        setError(result.error || 'Failed to refresh status')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh status')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Connection error banner */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription className="flex items-center justify-between">
+            <span>{error}</span>
+            <button
+              onClick={() => setError(null)}
+              className="text-sm underline hover:no-underline"
+            >
+              Dismiss
+            </button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Tabs value={activeSubTab} onValueChange={setActiveSubTab}>
+        <TabsList>
+          <TabsTrigger value="virtual-clusters">
+            Virtual Clusters
+            {virtualClusters.length > 0 && (
+              <span className="ml-2 text-xs bg-muted px-2 py-0.5 rounded-full">
+                {virtualClusters.length}
+              </span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="credentials">
+            Credentials
+            {credentials.length > 0 && (
+              <span className="ml-2 text-xs bg-muted px-2 py-0.5 rounded-full">
+                {credentials.length}
+              </span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="status">
+            Status
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="virtual-clusters" className="mt-6">
+          <VirtualClustersTab
+            virtualClusters={virtualClusters}
+            onRefresh={refreshVirtualClusters}
+            onVirtualClustersChange={setVirtualClusters}
+          />
+        </TabsContent>
+
+        <TabsContent value="credentials" className="mt-6">
+          <CredentialsTab
+            credentials={credentials}
+            virtualClusters={virtualClusters}
+            onRefresh={refreshCredentials}
+            onCredentialsChange={setCredentials}
+          />
+        </TabsContent>
+
+        <TabsContent value="status" className="mt-6">
+          <GatewayStatusTab
+            status={status}
+            onRefresh={refreshStatus}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/KafkaAdminClient.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/KafkaAdminClient.tsx
@@ -7,6 +7,11 @@ import type {
   KafkaClusterConfig,
   KafkaEnvironmentMappingConfig,
 } from '@/app/actions/kafka-admin'
+import type {
+  VirtualClusterConfig,
+  CredentialConfig,
+  GatewayStatus,
+} from '@/app/actions/bifrost-admin'
 
 // Import tab components
 import { ProvidersTab } from './ProvidersTab'
@@ -16,11 +21,16 @@ import { ProviderDetail } from './ProviderDetail'
 import { ProviderForm, type ProviderFormData } from './ProviderForm'
 import { ClusterDetail } from './ClusterDetail'
 import { MappingForm } from './MappingForm'
+import { GatewayTab } from './GatewayTab'
 
 interface KafkaAdminClientProps {
   initialProviders: KafkaProviderConfig[]
   initialClusters: KafkaClusterConfig[]
   initialMappings: KafkaEnvironmentMappingConfig[]
+  initialVirtualClusters?: VirtualClusterConfig[]
+  initialCredentials?: CredentialConfig[]
+  initialGatewayStatus?: GatewayStatus | null
+  gatewayConnectionError?: string
 }
 
 type PanelContent = 'list' | 'provider-detail' | 'cluster-detail' | 'cluster-form' | 'mapping-form'
@@ -30,6 +40,10 @@ export function KafkaAdminClient({
   initialProviders,
   initialClusters,
   initialMappings,
+  initialVirtualClusters = [],
+  initialCredentials = [],
+  initialGatewayStatus = null,
+  gatewayConnectionError,
 }: KafkaAdminClientProps) {
   // Default to providers tab if no clusters exist
   const defaultTab = initialClusters.length === 0 ? 'providers' : 'clusters'
@@ -506,6 +520,14 @@ export function KafkaAdminClient({
               </span>
             )}
           </TabsTrigger>
+          <TabsTrigger value="gateway">
+            Gateway
+            {initialVirtualClusters.length > 0 && (
+              <span className="ml-2 text-xs bg-muted px-2 py-0.5 rounded-full">
+                {initialVirtualClusters.length}
+              </span>
+            )}
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="clusters" className="mt-6">
@@ -533,6 +555,15 @@ export function KafkaAdminClient({
             onSelectProvider={showProviderDetail}
             onAddProvider={handleAddProvider}
             onRefresh={refreshProviders}
+          />
+        </TabsContent>
+
+        <TabsContent value="gateway" className="mt-6">
+          <GatewayTab
+            initialVirtualClusters={initialVirtualClusters}
+            initialCredentials={initialCredentials}
+            initialStatus={initialGatewayStatus}
+            connectionError={gatewayConnectionError}
           />
         </TabsContent>
       </Tabs>

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClusterForm.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClusterForm.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { ArrowLeft } from 'lucide-react'
+import type { VirtualClusterConfig } from '@/app/actions/bifrost-admin'
+
+interface VirtualClusterFormProps {
+  cluster: VirtualClusterConfig | null
+  onCancel: () => void
+  onSuccess: () => void
+}
+
+export function VirtualClusterForm({
+  cluster,
+  onCancel,
+  onSuccess,
+}: VirtualClusterFormProps) {
+  const isEditing = !!cluster
+
+  const [formData, setFormData] = useState({
+    id: cluster?.id || '',
+    workspaceSlug: cluster?.workspaceSlug || '',
+    environment: cluster?.environment || 'dev',
+    topicPrefix: cluster?.topicPrefix || '',
+    groupPrefix: cluster?.groupPrefix || '',
+    transactionIdPrefix: cluster?.transactionIdPrefix || '',
+    advertisedHost: cluster?.advertisedHost || '',
+    advertisedPort: cluster?.advertisedPort || 9092,
+    physicalBootstrapServers: cluster?.physicalBootstrapServers || '',
+  })
+
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const { createVirtualCluster } = await import('@/app/actions/bifrost-admin')
+      const result = await createVirtualCluster({
+        id: formData.id || undefined,
+        workspaceSlug: formData.workspaceSlug,
+        environment: formData.environment,
+        topicPrefix: formData.topicPrefix,
+        groupPrefix: formData.groupPrefix,
+        transactionIdPrefix: formData.transactionIdPrefix,
+        advertisedHost: formData.advertisedHost,
+        advertisedPort: formData.advertisedPort,
+        physicalBootstrapServers: formData.physicalBootstrapServers,
+      })
+
+      if (result.success) {
+        onSuccess()
+      } else {
+        setError(result.error || 'Failed to save virtual cluster')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save virtual cluster')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <CardTitle>{isEditing ? 'Edit Virtual Cluster' : 'Create Virtual Cluster'}</CardTitle>
+            <CardDescription>
+              {isEditing
+                ? 'Update virtual cluster configuration'
+                : 'Configure a new virtual cluster for tenant isolation'}
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="p-4 bg-destructive/10 text-destructive rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="id">ID (optional)</Label>
+              <Input
+                id="id"
+                value={formData.id}
+                onChange={(e) => setFormData({ ...formData, id: e.target.value })}
+                placeholder="Auto-generated if empty"
+                disabled={isEditing}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="workspaceSlug">Workspace Slug *</Label>
+              <Input
+                id="workspaceSlug"
+                value={formData.workspaceSlug}
+                onChange={(e) => setFormData({ ...formData, workspaceSlug: e.target.value })}
+                placeholder="my-workspace"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="environment">Environment *</Label>
+              <Select
+                value={formData.environment}
+                onValueChange={(value) => setFormData({ ...formData, environment: value })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select environment" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="dev">Development</SelectItem>
+                  <SelectItem value="staging">Staging</SelectItem>
+                  <SelectItem value="prod">Production</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="physicalBootstrapServers">Physical Bootstrap Servers *</Label>
+              <Input
+                id="physicalBootstrapServers"
+                value={formData.physicalBootstrapServers}
+                onChange={(e) => setFormData({ ...formData, physicalBootstrapServers: e.target.value })}
+                placeholder="broker1:9092,broker2:9092"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="topicPrefix">Topic Prefix *</Label>
+              <Input
+                id="topicPrefix"
+                value={formData.topicPrefix}
+                onChange={(e) => setFormData({ ...formData, topicPrefix: e.target.value })}
+                placeholder="workspace.app."
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="groupPrefix">Group Prefix *</Label>
+              <Input
+                id="groupPrefix"
+                value={formData.groupPrefix}
+                onChange={(e) => setFormData({ ...formData, groupPrefix: e.target.value })}
+                placeholder="workspace.app."
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="transactionIdPrefix">Transaction ID Prefix</Label>
+              <Input
+                id="transactionIdPrefix"
+                value={formData.transactionIdPrefix}
+                onChange={(e) => setFormData({ ...formData, transactionIdPrefix: e.target.value })}
+                placeholder="workspace.app."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="advertisedHost">Advertised Host *</Label>
+              <Input
+                id="advertisedHost"
+                value={formData.advertisedHost}
+                onChange={(e) => setFormData({ ...formData, advertisedHost: e.target.value })}
+                placeholder="bifrost.example.com"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="advertisedPort">Advertised Port *</Label>
+              <Input
+                id="advertisedPort"
+                type="number"
+                value={formData.advertisedPort}
+                onChange={(e) => setFormData({ ...formData, advertisedPort: parseInt(e.target.value) || 9092 })}
+                placeholder="9092"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 pt-4">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : isEditing ? 'Update Virtual Cluster' : 'Create Virtual Cluster'}
+            </Button>
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClustersTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClustersTab.tsx
@@ -17,7 +17,7 @@ interface VirtualClustersTabProps {
 export function VirtualClustersTab({
   virtualClusters,
   onRefresh,
-  onVirtualClustersChange,
+  onVirtualClustersChange: _onVirtualClustersChange,
 }: VirtualClustersTabProps) {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [showForm, setShowForm] = useState(false)

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClustersTab.tsx
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/VirtualClustersTab.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Plus, RefreshCw, Server, Lock, LockOpen } from 'lucide-react'
+import type { VirtualClusterConfig } from '@/app/actions/bifrost-admin'
+import { VirtualClusterForm } from './VirtualClusterForm'
+
+interface VirtualClustersTabProps {
+  virtualClusters: VirtualClusterConfig[]
+  onRefresh: () => Promise<void>
+  onVirtualClustersChange: (clusters: VirtualClusterConfig[]) => void
+}
+
+export function VirtualClustersTab({
+  virtualClusters,
+  onRefresh,
+  onVirtualClustersChange,
+}: VirtualClustersTabProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [editingCluster, setEditingCluster] = useState<VirtualClusterConfig | null>(null)
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    try {
+      await onRefresh()
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
+  const handleToggleReadOnly = async (cluster: VirtualClusterConfig) => {
+    try {
+      const { setVirtualClusterReadOnly } = await import('@/app/actions/bifrost-admin')
+      const result = await setVirtualClusterReadOnly(cluster.id, !cluster.readOnly)
+      if (result.success) {
+        await onRefresh()
+      }
+    } catch (err) {
+      console.error('Failed to toggle read-only:', err)
+    }
+  }
+
+  const handleDelete = async (clusterId: string) => {
+    if (!confirm('Are you sure you want to delete this virtual cluster? Associated credentials will become orphaned.')) {
+      return
+    }
+
+    try {
+      const { deleteVirtualCluster } = await import('@/app/actions/bifrost-admin')
+      const result = await deleteVirtualCluster(clusterId)
+      if (result.success) {
+        await onRefresh()
+      }
+    } catch (err) {
+      console.error('Failed to delete virtual cluster:', err)
+    }
+  }
+
+  const handleFormClose = () => {
+    setShowForm(false)
+    setEditingCluster(null)
+  }
+
+  const handleFormSuccess = async () => {
+    await onRefresh()
+    handleFormClose()
+  }
+
+  // Empty state
+  if (virtualClusters.length === 0 && !showForm) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-4">
+        <div className="rounded-full bg-muted p-4 mb-4">
+          <Server className="h-8 w-8 text-muted-foreground" />
+        </div>
+        <h3 className="text-lg font-semibold mb-2">No Virtual Clusters</h3>
+        <p className="text-muted-foreground text-center mb-6 max-w-md">
+          Virtual clusters provide tenant isolation for Kafka access. Create your first
+          virtual cluster to start routing traffic through Bifrost.
+        </p>
+        <Button onClick={() => setShowForm(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Virtual Cluster
+        </Button>
+      </div>
+    )
+  }
+
+  if (showForm) {
+    return (
+      <VirtualClusterForm
+        cluster={editingCluster}
+        onCancel={handleFormClose}
+        onSuccess={handleFormSuccess}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header with actions */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {virtualClusters.length} virtual cluster{virtualClusters.length !== 1 ? 's' : ''} configured
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button size="sm" onClick={() => setShowForm(true)}>
+            <Plus className="h-4 w-4" />
+            Create Virtual Cluster
+          </Button>
+        </div>
+      </div>
+
+      {/* Virtual clusters grid */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {virtualClusters.map((cluster) => (
+          <Card
+            key={cluster.id}
+            className="cursor-pointer transition-colors hover:bg-accent/50"
+            onClick={() => {
+              setEditingCluster(cluster)
+              setShowForm(true)
+            }}
+          >
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <Server className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-base">{cluster.id}</CardTitle>
+                </div>
+                <div className="flex items-center gap-2">
+                  {cluster.readOnly ? (
+                    <Badge variant="secondary" className="flex items-center gap-1">
+                      <Lock className="h-3 w-3" />
+                      Read-Only
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline" className="flex items-center gap-1">
+                      <LockOpen className="h-3 w-3" />
+                      Read/Write
+                    </Badge>
+                  )}
+                </div>
+              </div>
+              <CardDescription className="text-xs">
+                {cluster.workspaceSlug} / {cluster.environment}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="text-sm">
+                <p className="text-xs text-muted-foreground mb-0.5">Topic Prefix</p>
+                <p className="font-mono text-xs truncate">{cluster.topicPrefix}</p>
+              </div>
+              <div className="text-sm">
+                <p className="text-xs text-muted-foreground mb-0.5">Bootstrap Servers</p>
+                <p className="font-mono text-xs truncate">{cluster.physicalBootstrapServers}</p>
+              </div>
+              <div className="flex items-center gap-2 pt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleToggleReadOnly(cluster)
+                  }}
+                >
+                  {cluster.readOnly ? 'Enable Writes' : 'Set Read-Only'}
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleDelete(cluster.id)
+                  }}
+                >
+                  Delete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/platform/kafka/components/index.ts
+++ b/orbit-www/src/app/(frontend)/platform/kafka/components/index.ts
@@ -8,3 +8,11 @@ export { ProviderForm } from './ProviderForm'
 export type { ProviderFormData } from './ProviderForm'
 export { ClusterDetail } from './ClusterDetail'
 export { MappingForm } from './MappingForm'
+
+// Bifrost Gateway UI Components
+export { GatewayTab } from './GatewayTab'
+export { VirtualClustersTab } from './VirtualClustersTab'
+export { VirtualClusterForm } from './VirtualClusterForm'
+export { CredentialsTab } from './CredentialsTab'
+export { CredentialForm } from './CredentialForm'
+export { GatewayStatusTab } from './GatewayStatusTab'

--- a/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
+++ b/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
@@ -363,4 +363,21 @@ describe('bifrost-admin module', () => {
       expect(typeof setVirtualClusterReadOnly).toBe('function')
     })
   })
+
+  describe('credential server actions', () => {
+    it('should export listCredentials function', async () => {
+      const { listCredentials } = await import('../bifrost-admin')
+      expect(typeof listCredentials).toBe('function')
+    })
+
+    it('should export createCredential function', async () => {
+      const { createCredential } = await import('../bifrost-admin')
+      expect(typeof createCredential).toBe('function')
+    })
+
+    it('should export revokeCredential function', async () => {
+      const { revokeCredential } = await import('../bifrost-admin')
+      expect(typeof revokeCredential).toBe('function')
+    })
+  })
 })

--- a/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
+++ b/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies before importing the module under test
+vi.mock('payload', () => ({
+  getPayload: vi.fn(),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}))
+
+vi.mock('@/lib/grpc/bifrost-client', () => ({
+  bifrostClient: {
+    listVirtualClusters: vi.fn(),
+    upsertVirtualCluster: vi.fn(),
+    deleteVirtualCluster: vi.fn(),
+    setVirtualClusterReadOnly: vi.fn(),
+    listCredentials: vi.fn(),
+    upsertCredential: vi.fn(),
+    revokeCredential: vi.fn(),
+    getStatus: vi.fn(),
+    getFullConfig: vi.fn(),
+    listPolicies: vi.fn(),
+    upsertPolicy: vi.fn(),
+    deletePolicy: vi.fn(),
+  },
+}))
+
+// Import types and mapping functions after mocks are set up
+import {
+  // Type exports - these are compile-time checks
+  type VirtualClusterConfig,
+  type CredentialConfig,
+  type PermissionTemplateType,
+  type CustomPermission,
+  type GatewayStatus,
+  type FullConfig,
+  type PolicyConfig,
+  // Mapping function exports
+  mapProtoToVirtualCluster,
+  mapProtoToCredential,
+  mapPermissionTemplate,
+  mapPermissionTemplateToProto,
+  mapProtoToPolicy,
+  // Auth helper (tested in integration context)
+  requireAdmin,
+} from '../bifrost-admin'
+
+import { PermissionTemplate } from '@/lib/proto/idp/gateway/v1/gateway_pb'
+
+describe('bifrost-admin module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('module exports', () => {
+    it('should export type definitions (compile-time verification)', () => {
+      // These type assertions verify the types are exported correctly
+      // If types are missing or wrong, TypeScript will fail to compile
+      const virtualCluster: VirtualClusterConfig = {
+        id: 'vc-1',
+        applicationId: 'app-1',
+        applicationSlug: 'my-app',
+        workspaceSlug: 'my-workspace',
+        environment: 'production',
+        topicPrefix: 'my-workspace.my-app.production.',
+        groupPrefix: 'my-workspace.my-app.production.',
+        transactionIdPrefix: 'my-workspace.my-app.production.',
+        advertisedHost: 'gateway.example.com',
+        advertisedPort: 9092,
+        physicalBootstrapServers: 'kafka:9092',
+        readOnly: false,
+      }
+      expect(virtualCluster).toBeDefined()
+
+      const credential: CredentialConfig = {
+        id: 'cred-1',
+        virtualClusterId: 'vc-1',
+        username: 'service-account-1',
+        passwordHash: 'hashed',
+        template: 'producer',
+        customPermissions: [],
+      }
+      expect(credential).toBeDefined()
+
+      const permission: PermissionTemplateType = 'admin'
+      expect(permission).toBe('admin')
+
+      const customPerm: CustomPermission = {
+        resourceType: 'topic',
+        resourcePattern: 'orders.*',
+        operations: ['read', 'write'],
+      }
+      expect(customPerm).toBeDefined()
+
+      const status: GatewayStatus = {
+        status: 'healthy',
+        activeConnections: 10,
+        virtualClusterCount: 5,
+        versionInfo: { version: '1.0.0' },
+      }
+      expect(status).toBeDefined()
+
+      const policy: PolicyConfig = {
+        id: 'policy-1',
+        environment: 'production',
+        maxPartitions: 32,
+        minPartitions: 1,
+        maxRetentionMs: 604800000n,
+        minReplicationFactor: 3,
+        allowedCleanupPolicies: ['delete', 'compact'],
+        namingPattern: '^[a-z][a-z0-9-]*$',
+        maxNameLength: 255,
+      }
+      expect(policy).toBeDefined()
+
+      const fullConfig: FullConfig = {
+        virtualClusters: [virtualCluster],
+        credentials: [credential],
+        policies: [policy],
+      }
+      expect(fullConfig).toBeDefined()
+    })
+
+    it('should export mapping functions', () => {
+      expect(typeof mapProtoToVirtualCluster).toBe('function')
+      expect(typeof mapProtoToCredential).toBe('function')
+      expect(typeof mapPermissionTemplate).toBe('function')
+      expect(typeof mapPermissionTemplateToProto).toBe('function')
+      expect(typeof mapProtoToPolicy).toBe('function')
+    })
+
+    it('should export requireAdmin function', () => {
+      expect(typeof requireAdmin).toBe('function')
+    })
+  })
+
+  describe('mapProtoToVirtualCluster', () => {
+    it('should map proto VirtualClusterConfig to our interface', () => {
+      const proto = {
+        id: 'vc-123',
+        applicationId: 'app-456',
+        applicationSlug: 'orders-service',
+        workspaceSlug: 'acme-corp',
+        environment: 'production',
+        topicPrefix: 'acme-corp.orders-service.production.',
+        groupPrefix: 'acme-corp.orders-service.production.',
+        transactionIdPrefix: 'acme-corp.orders-service.production.',
+        advertisedHost: 'kafka-gateway.example.com',
+        advertisedPort: 9092,
+        physicalBootstrapServers: 'broker1:9092,broker2:9092',
+        readOnly: false,
+      }
+
+      const result = mapProtoToVirtualCluster(proto)
+
+      expect(result).toEqual({
+        id: 'vc-123',
+        applicationId: 'app-456',
+        applicationSlug: 'orders-service',
+        workspaceSlug: 'acme-corp',
+        environment: 'production',
+        topicPrefix: 'acme-corp.orders-service.production.',
+        groupPrefix: 'acme-corp.orders-service.production.',
+        transactionIdPrefix: 'acme-corp.orders-service.production.',
+        advertisedHost: 'kafka-gateway.example.com',
+        advertisedPort: 9092,
+        physicalBootstrapServers: 'broker1:9092,broker2:9092',
+        readOnly: false,
+      })
+    })
+
+    it('should handle readOnly=true', () => {
+      const proto = {
+        id: 'vc-readonly',
+        applicationId: 'app-1',
+        applicationSlug: 'app',
+        workspaceSlug: 'ws',
+        environment: 'staging',
+        topicPrefix: 'prefix.',
+        groupPrefix: 'prefix.',
+        transactionIdPrefix: 'prefix.',
+        advertisedHost: 'host',
+        advertisedPort: 9092,
+        physicalBootstrapServers: 'kafka:9092',
+        readOnly: true,
+      }
+
+      const result = mapProtoToVirtualCluster(proto)
+      expect(result.readOnly).toBe(true)
+    })
+  })
+
+  describe('mapProtoToCredential', () => {
+    it('should map proto CredentialConfig to our interface with producer template', () => {
+      const proto = {
+        id: 'cred-123',
+        virtualClusterId: 'vc-456',
+        username: 'orders-producer',
+        passwordHash: 'argon2:$hashvalue',
+        template: PermissionTemplate.PRODUCER,
+        customPermissions: [],
+      }
+
+      const result = mapProtoToCredential(proto)
+
+      expect(result).toEqual({
+        id: 'cred-123',
+        virtualClusterId: 'vc-456',
+        username: 'orders-producer',
+        passwordHash: 'argon2:$hashvalue',
+        template: 'producer',
+        customPermissions: [],
+      })
+    })
+
+    it('should map proto CredentialConfig with custom permissions', () => {
+      const proto = {
+        id: 'cred-custom',
+        virtualClusterId: 'vc-789',
+        username: 'custom-user',
+        passwordHash: 'hash',
+        template: PermissionTemplate.CUSTOM,
+        customPermissions: [
+          {
+            resourceType: 'topic',
+            resourcePattern: 'orders.*',
+            operations: ['read', 'write'],
+          },
+          {
+            resourceType: 'group',
+            resourcePattern: 'order-consumers',
+            operations: ['read'],
+          },
+        ],
+      }
+
+      const result = mapProtoToCredential(proto)
+
+      expect(result.template).toBe('custom')
+      expect(result.customPermissions).toHaveLength(2)
+      expect(result.customPermissions[0]).toEqual({
+        resourceType: 'topic',
+        resourcePattern: 'orders.*',
+        operations: ['read', 'write'],
+      })
+    })
+
+    it('should map all permission template types', () => {
+      const templates = [
+        { proto: PermissionTemplate.PRODUCER, expected: 'producer' },
+        { proto: PermissionTemplate.CONSUMER, expected: 'consumer' },
+        { proto: PermissionTemplate.ADMIN, expected: 'admin' },
+        { proto: PermissionTemplate.CUSTOM, expected: 'custom' },
+      ]
+
+      for (const { proto, expected } of templates) {
+        const result = mapProtoToCredential({
+          id: 'cred',
+          virtualClusterId: 'vc',
+          username: 'user',
+          passwordHash: 'hash',
+          template: proto,
+          customPermissions: [],
+        })
+        expect(result.template).toBe(expected)
+      }
+    })
+  })
+
+  describe('mapPermissionTemplate', () => {
+    it('should map proto enum to string type', () => {
+      expect(mapPermissionTemplate(PermissionTemplate.PRODUCER)).toBe('producer')
+      expect(mapPermissionTemplate(PermissionTemplate.CONSUMER)).toBe('consumer')
+      expect(mapPermissionTemplate(PermissionTemplate.ADMIN)).toBe('admin')
+      expect(mapPermissionTemplate(PermissionTemplate.CUSTOM)).toBe('custom')
+    })
+
+    it('should default to custom for unspecified', () => {
+      expect(mapPermissionTemplate(PermissionTemplate.UNSPECIFIED)).toBe('custom')
+    })
+
+    it('should default to custom for unknown values', () => {
+      expect(mapPermissionTemplate(999 as PermissionTemplate)).toBe('custom')
+    })
+  })
+
+  describe('mapPermissionTemplateToProto', () => {
+    it('should map string type to proto enum', () => {
+      expect(mapPermissionTemplateToProto('producer')).toBe(PermissionTemplate.PRODUCER)
+      expect(mapPermissionTemplateToProto('consumer')).toBe(PermissionTemplate.CONSUMER)
+      expect(mapPermissionTemplateToProto('admin')).toBe(PermissionTemplate.ADMIN)
+      expect(mapPermissionTemplateToProto('custom')).toBe(PermissionTemplate.CUSTOM)
+    })
+  })
+
+  describe('mapProtoToPolicy', () => {
+    it('should map proto PolicyConfig to our interface', () => {
+      const proto = {
+        id: 'policy-1',
+        environment: 'production',
+        maxPartitions: 32,
+        minPartitions: 1,
+        maxRetentionMs: 604800000n, // 7 days in ms
+        minReplicationFactor: 3,
+        allowedCleanupPolicies: ['delete', 'compact'],
+        namingPattern: '^[a-z][a-z0-9-]*$',
+        maxNameLength: 255,
+      }
+
+      const result = mapProtoToPolicy(proto)
+
+      expect(result).toEqual({
+        id: 'policy-1',
+        environment: 'production',
+        maxPartitions: 32,
+        minPartitions: 1,
+        maxRetentionMs: 604800000n,
+        minReplicationFactor: 3,
+        allowedCleanupPolicies: ['delete', 'compact'],
+        namingPattern: '^[a-z][a-z0-9-]*$',
+        maxNameLength: 255,
+      })
+    })
+  })
+})

--- a/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
+++ b/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
@@ -380,4 +380,16 @@ describe('bifrost-admin module', () => {
       expect(typeof revokeCredential).toBe('function')
     })
   })
+
+  describe('status server actions', () => {
+    it('should export getGatewayStatus function', async () => {
+      const { getGatewayStatus } = await import('../bifrost-admin')
+      expect(typeof getGatewayStatus).toBe('function')
+    })
+
+    it('should export getFullConfig function', async () => {
+      const { getFullConfig } = await import('../bifrost-admin')
+      expect(typeof getFullConfig).toBe('function')
+    })
+  })
 })

--- a/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
+++ b/orbit-www/src/app/actions/__tests__/bifrost-admin.test.ts
@@ -58,7 +58,12 @@ import {
   requireAdmin,
 } from '../bifrost-admin'
 
-import { PermissionTemplate } from '@/lib/proto/idp/gateway/v1/gateway_pb'
+import {
+  PermissionTemplate,
+  type VirtualClusterConfig as ProtoVirtualClusterConfig,
+  type CredentialConfig as ProtoCredentialConfig,
+  type PolicyConfig as ProtoPolicyConfig,
+} from '@/lib/proto/idp/gateway/v1/gateway_pb'
 
 describe('bifrost-admin module', () => {
   beforeEach(() => {
@@ -149,6 +154,7 @@ describe('bifrost-admin module', () => {
 
   describe('mapProtoToVirtualCluster', () => {
     it('should map proto VirtualClusterConfig to our interface', () => {
+      // Use type assertion since we're creating a mock proto object
       const proto = {
         id: 'vc-123',
         applicationId: 'app-456',
@@ -162,7 +168,7 @@ describe('bifrost-admin module', () => {
         advertisedPort: 9092,
         physicalBootstrapServers: 'broker1:9092,broker2:9092',
         readOnly: false,
-      }
+      } as unknown as ProtoVirtualClusterConfig
 
       const result = mapProtoToVirtualCluster(proto)
 
@@ -196,7 +202,7 @@ describe('bifrost-admin module', () => {
         advertisedPort: 9092,
         physicalBootstrapServers: 'kafka:9092',
         readOnly: true,
-      }
+      } as unknown as ProtoVirtualClusterConfig
 
       const result = mapProtoToVirtualCluster(proto)
       expect(result.readOnly).toBe(true)
@@ -212,7 +218,7 @@ describe('bifrost-admin module', () => {
         passwordHash: 'argon2:$hashvalue',
         template: PermissionTemplate.PRODUCER,
         customPermissions: [],
-      }
+      } as unknown as ProtoCredentialConfig
 
       const result = mapProtoToCredential(proto)
 
@@ -245,7 +251,7 @@ describe('bifrost-admin module', () => {
             operations: ['read'],
           },
         ],
-      }
+      } as unknown as ProtoCredentialConfig
 
       const result = mapProtoToCredential(proto)
 
@@ -274,7 +280,7 @@ describe('bifrost-admin module', () => {
           passwordHash: 'hash',
           template: proto,
           customPermissions: [],
-        })
+        } as unknown as ProtoCredentialConfig)
         expect(result.template).toBe(expected)
       }
     })
@@ -333,6 +339,28 @@ describe('bifrost-admin module', () => {
         namingPattern: '^[a-z][a-z0-9-]*$',
         maxNameLength: 255,
       })
+    })
+  })
+
+  describe('virtual cluster server actions', () => {
+    it('should export listVirtualClusters function', async () => {
+      const { listVirtualClusters } = await import('../bifrost-admin')
+      expect(typeof listVirtualClusters).toBe('function')
+    })
+
+    it('should export createVirtualCluster function', async () => {
+      const { createVirtualCluster } = await import('../bifrost-admin')
+      expect(typeof createVirtualCluster).toBe('function')
+    })
+
+    it('should export deleteVirtualCluster function', async () => {
+      const { deleteVirtualCluster } = await import('../bifrost-admin')
+      expect(typeof deleteVirtualCluster).toBe('function')
+    })
+
+    it('should export setVirtualClusterReadOnly function', async () => {
+      const { setVirtualClusterReadOnly } = await import('../bifrost-admin')
+      expect(typeof setVirtualClusterReadOnly).toBe('function')
     })
   })
 })

--- a/orbit-www/src/app/actions/bifrost-admin.ts
+++ b/orbit-www/src/app/actions/bifrost-admin.ts
@@ -1,0 +1,326 @@
+'use server'
+
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import {
+  PermissionTemplate,
+  type VirtualClusterConfig as ProtoVirtualClusterConfig,
+  type CredentialConfig as ProtoCredentialConfig,
+  type CustomPermission as ProtoCustomPermission,
+  type PolicyConfig as ProtoPolicy,
+} from '@/lib/proto/idp/gateway/v1/gateway_pb'
+
+// ============================================================================
+// Payload Type Definitions (for internal use)
+// ============================================================================
+
+/**
+ * Represents a workspace role assignment from the Payload CMS.
+ */
+interface WorkspaceRoleAssignment {
+  id: string
+  user: string | { id: string }
+  workspace: string | { id: string }
+  role:
+    | string
+    | {
+        id: string
+        name: string
+        slug: string
+        scope: 'platform' | 'workspace'
+      }
+  createdAt?: string
+  updatedAt?: string
+}
+
+// ============================================================================
+// Type Definitions (exported for UI consumption)
+// ============================================================================
+
+/**
+ * Configuration for a Bifrost virtual cluster.
+ * Virtual clusters provide tenant isolation for Kafka applications.
+ */
+export interface VirtualClusterConfig {
+  /** Unique identifier for the virtual cluster */
+  id: string
+  /** The application ID this virtual cluster belongs to */
+  applicationId: string
+  /** URL-safe slug for the application */
+  applicationSlug: string
+  /** URL-safe slug for the workspace */
+  workspaceSlug: string
+  /** Environment (dev, staging, production) */
+  environment: string
+  /** Prefix applied to all topic names */
+  topicPrefix: string
+  /** Prefix applied to all consumer group IDs */
+  groupPrefix: string
+  /** Prefix applied to all transactional IDs */
+  transactionIdPrefix: string
+  /** The host clients connect to */
+  advertisedHost: string
+  /** The port clients connect to */
+  advertisedPort: number
+  /** Underlying physical Kafka bootstrap servers */
+  physicalBootstrapServers: string
+  /** Whether the cluster is in read-only mode */
+  readOnly: boolean
+}
+
+/**
+ * Permission template types for service account credentials.
+ */
+export type PermissionTemplateType = 'producer' | 'consumer' | 'admin' | 'custom'
+
+/**
+ * Custom permission definition for fine-grained access control.
+ */
+export interface CustomPermission {
+  /** Type of resource (topic, group, transactional_id) */
+  resourceType: string
+  /** Pattern to match resources (literal or regex) */
+  resourcePattern: string
+  /** List of allowed operations (read, write, create, delete, alter) */
+  operations: string[]
+}
+
+/**
+ * Configuration for a service account credential.
+ */
+export interface CredentialConfig {
+  /** Unique identifier for the credential */
+  id: string
+  /** The virtual cluster this credential belongs to */
+  virtualClusterId: string
+  /** Username for SASL authentication */
+  username: string
+  /** Hashed password (never store plaintext) */
+  passwordHash: string
+  /** Permission template applied to this credential */
+  template: PermissionTemplateType
+  /** Custom permissions (used when template is 'custom') */
+  customPermissions: CustomPermission[]
+}
+
+/**
+ * Gateway status information.
+ */
+export interface GatewayStatus {
+  /** Current status (healthy, degraded, unhealthy) */
+  status: string
+  /** Number of active client connections */
+  activeConnections: number
+  /** Number of configured virtual clusters */
+  virtualClusterCount: number
+  /** Version and build information */
+  versionInfo: Record<string, string>
+}
+
+/**
+ * Policy configuration for topic creation constraints.
+ */
+export interface PolicyConfig {
+  /** Unique identifier for the policy */
+  id: string
+  /** Environment this policy applies to */
+  environment: string
+  /** Maximum allowed partitions */
+  maxPartitions: number
+  /** Minimum required partitions */
+  minPartitions: number
+  /** Maximum retention time in milliseconds */
+  maxRetentionMs: bigint
+  /** Minimum required replication factor */
+  minReplicationFactor: number
+  /** List of allowed cleanup policies */
+  allowedCleanupPolicies: string[]
+  /** Regex pattern for valid topic names */
+  namingPattern: string
+  /** Maximum length for topic names */
+  maxNameLength: number
+}
+
+/**
+ * Complete gateway configuration snapshot.
+ */
+export interface FullConfig {
+  /** All configured virtual clusters */
+  virtualClusters: VirtualClusterConfig[]
+  /** All configured credentials */
+  credentials: CredentialConfig[]
+  /** All configured policies */
+  policies: PolicyConfig[]
+}
+
+// ============================================================================
+// Mapping Functions (proto types to our interfaces)
+// ============================================================================
+
+/**
+ * Maps a proto VirtualClusterConfig to our interface.
+ */
+export function mapProtoToVirtualCluster(proto: ProtoVirtualClusterConfig): VirtualClusterConfig {
+  return {
+    id: proto.id,
+    applicationId: proto.applicationId,
+    applicationSlug: proto.applicationSlug,
+    workspaceSlug: proto.workspaceSlug,
+    environment: proto.environment,
+    topicPrefix: proto.topicPrefix,
+    groupPrefix: proto.groupPrefix,
+    transactionIdPrefix: proto.transactionIdPrefix,
+    advertisedHost: proto.advertisedHost,
+    advertisedPort: proto.advertisedPort,
+    physicalBootstrapServers: proto.physicalBootstrapServers,
+    readOnly: proto.readOnly,
+  }
+}
+
+/**
+ * Maps a proto PermissionTemplate enum to our string type.
+ */
+export function mapPermissionTemplate(proto: PermissionTemplate): PermissionTemplateType {
+  switch (proto) {
+    case PermissionTemplate.PRODUCER:
+      return 'producer'
+    case PermissionTemplate.CONSUMER:
+      return 'consumer'
+    case PermissionTemplate.ADMIN:
+      return 'admin'
+    case PermissionTemplate.CUSTOM:
+      return 'custom'
+    case PermissionTemplate.UNSPECIFIED:
+    default:
+      return 'custom'
+  }
+}
+
+/**
+ * Maps our string type to a proto PermissionTemplate enum.
+ */
+export function mapPermissionTemplateToProto(template: PermissionTemplateType): PermissionTemplate {
+  switch (template) {
+    case 'producer':
+      return PermissionTemplate.PRODUCER
+    case 'consumer':
+      return PermissionTemplate.CONSUMER
+    case 'admin':
+      return PermissionTemplate.ADMIN
+    case 'custom':
+      return PermissionTemplate.CUSTOM
+  }
+}
+
+/**
+ * Maps a proto CustomPermission to our interface.
+ */
+function mapProtoCustomPermission(proto: ProtoCustomPermission): CustomPermission {
+  return {
+    resourceType: proto.resourceType,
+    resourcePattern: proto.resourcePattern,
+    operations: [...proto.operations],
+  }
+}
+
+/**
+ * Maps a proto CredentialConfig to our interface.
+ */
+export function mapProtoToCredential(proto: ProtoCredentialConfig): CredentialConfig {
+  return {
+    id: proto.id,
+    virtualClusterId: proto.virtualClusterId,
+    username: proto.username,
+    passwordHash: proto.passwordHash,
+    template: mapPermissionTemplate(proto.template),
+    customPermissions: proto.customPermissions.map(mapProtoCustomPermission),
+  }
+}
+
+/**
+ * Maps a proto PolicyConfig to our interface.
+ */
+export function mapProtoToPolicy(proto: ProtoPolicy): PolicyConfig {
+  return {
+    id: proto.id,
+    environment: proto.environment,
+    maxPartitions: proto.maxPartitions,
+    minPartitions: proto.minPartitions,
+    maxRetentionMs: proto.maxRetentionMs,
+    minReplicationFactor: proto.minReplicationFactor,
+    allowedCleanupPolicies: [...proto.allowedCleanupPolicies],
+    namingPattern: proto.namingPattern,
+    maxNameLength: proto.maxNameLength,
+  }
+}
+
+// ============================================================================
+// Authentication Helper
+// ============================================================================
+
+/**
+ * Checks if the current user has admin privileges.
+ * Throws an error if the user is not authenticated or not an admin.
+ *
+ * This function follows the same pattern as kafka-admin.ts requireAdmin.
+ */
+export async function requireAdmin(): Promise<{ userId: string }> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
+
+  if (!session?.user) {
+    throw new Error('Unauthorized: Authentication required')
+  }
+
+  const payload = await getPayload({ config })
+
+  // First, find the Payload user by email (bridges Better-Auth and Payload user systems)
+  const payloadUsers = await payload.find({
+    collection: 'users',
+    where: {
+      email: { equals: session.user.email },
+    },
+    limit: 1,
+  })
+
+  const payloadUser = payloadUsers.docs[0]
+  if (!payloadUser) {
+    throw new Error('Unauthorized: User not found in system')
+  }
+
+  // Check for platform-level admin role using the Payload user ID
+  // Note: Using type assertion for collection name since Payload types may not include custom collections
+  // We fetch all assignments with depth to populate relationships, then filter by user
+  const roleAssignments = await payload.find({
+    collection: 'user-workspace-roles' as 'users', // Type workaround for custom collection
+    depth: 2,
+    limit: 1000,
+  })
+
+  const isAdmin = roleAssignments.docs.some((assignment: unknown) => {
+    const typedAssignment = assignment as WorkspaceRoleAssignment
+
+    // Check if this assignment belongs to our user
+    const assignmentUserId = typeof typedAssignment.user === 'object'
+      ? (typedAssignment.user as { id?: string })?.id
+      : typedAssignment.user
+    if (assignmentUserId !== payloadUser.id) return false
+
+    const role = typeof typedAssignment.role === 'object' ? typedAssignment.role : null
+    if (!role) return false
+    // Check if user has platform admin role (super-admin, admin, or platform-admin)
+    return (
+      role.scope === 'platform' &&
+      (role.slug === 'admin' || role.slug === 'platform-admin' || role.slug === 'super-admin')
+    )
+  })
+
+  if (!isAdmin) {
+    throw new Error('Unauthorized: Admin privileges required')
+  }
+
+  return { userId: session.user.id }
+}

--- a/orbit-www/src/app/actions/bifrost-admin.ts
+++ b/orbit-www/src/app/actions/bifrost-admin.ts
@@ -534,7 +534,13 @@ export async function createCredential(data: {
 
     const id = `cred-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
 
-    // Hash the password before sending (using simple hash for demo - production should use bcrypt)
+    // Hash the password using SHA-256 to match Bifrost's credential.go implementation.
+    // Note: SHA-256 is used here because:
+    // 1. Bifrost's SASL handler expects SHA-256 hashed passwords (see services/bifrost/internal/auth/credential.go)
+    // 2. These are machine-generated 24-character random passwords, not user-chosen weak passwords
+    // 3. The password is only shown once and must be saved securely by the user
+    // For user-facing passwords, bcrypt/argon2 would be preferred, but changing this requires
+    // coordinating with Bifrost's Go service implementation.
     const encoder = new TextEncoder()
     const passwordData = encoder.encode(data.password)
     const hashBuffer = await crypto.subtle.digest('SHA-256', passwordData)

--- a/orbit-www/src/app/actions/bifrost-admin.ts
+++ b/orbit-www/src/app/actions/bifrost-admin.ts
@@ -602,3 +602,66 @@ export async function revokeCredential(id: string): Promise<{
     return { success: false, error: errorMessage }
   }
 }
+
+// ============================================================================
+// Status Server Actions
+// ============================================================================
+
+/**
+ * Gets the current gateway status from Bifrost.
+ */
+export async function getGatewayStatus(): Promise<{
+  success: boolean
+  data?: GatewayStatus
+  error?: string
+}> {
+  try {
+    await requireAdmin()
+
+    const response = await bifrostClient.getStatus({})
+
+    return {
+      success: true,
+      data: {
+        status: response.status,
+        activeConnections: response.activeConnections,
+        virtualClusterCount: response.virtualClusterCount,
+        versionInfo: { ...response.versionInfo },
+      },
+    }
+  } catch (error) {
+    console.error('Failed to get gateway status:', error)
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to get gateway status'
+    return { success: false, error: errorMessage }
+  }
+}
+
+/**
+ * Gets the full configuration from Bifrost.
+ */
+export async function getFullConfig(): Promise<{
+  success: boolean
+  data?: FullConfig
+  error?: string
+}> {
+  try {
+    await requireAdmin()
+
+    const response = await bifrostClient.getFullConfig({})
+
+    return {
+      success: true,
+      data: {
+        virtualClusters: response.virtualClusters.map(mapProtoToVirtualCluster),
+        credentials: response.credentials.map(mapProtoToCredential),
+        policies: response.policies.map(mapProtoToPolicy),
+      },
+    }
+  } catch (error) {
+    console.error('Failed to get full config:', error)
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to get full config'
+    return { success: false, error: errorMessage }
+  }
+}

--- a/orbit-www/src/lib/grpc/__tests__/bifrost-client.test.ts
+++ b/orbit-www/src/lib/grpc/__tests__/bifrost-client.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+
+describe('bifrostClient', () => {
+  it('is defined and exported', async () => {
+    const { bifrostClient } = await import('../bifrost-client')
+    expect(bifrostClient).toBeDefined()
+  })
+
+  describe('has all BifrostAdminService methods', () => {
+    it('has listVirtualClusters method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.listVirtualClusters).toBe('function')
+    })
+
+    it('has upsertVirtualCluster method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.upsertVirtualCluster).toBe('function')
+    })
+
+    it('has deleteVirtualCluster method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.deleteVirtualCluster).toBe('function')
+    })
+
+    it('has setVirtualClusterReadOnly method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.setVirtualClusterReadOnly).toBe('function')
+    })
+
+    it('has listCredentials method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.listCredentials).toBe('function')
+    })
+
+    it('has upsertCredential method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.upsertCredential).toBe('function')
+    })
+
+    it('has revokeCredential method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.revokeCredential).toBe('function')
+    })
+
+    it('has getStatus method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.getStatus).toBe('function')
+    })
+
+    it('has getFullConfig method', async () => {
+      const { bifrostClient } = await import('../bifrost-client')
+      expect(typeof bifrostClient.getFullConfig).toBe('function')
+    })
+  })
+
+  it('exports BifrostClient type', async () => {
+    // Type check - this test passes at compile time if the type is exported correctly
+    const { bifrostClient } = await import('../bifrost-client')
+    type BifrostClient = typeof bifrostClient
+    const client: BifrostClient = bifrostClient
+    expect(client).toBeDefined()
+  })
+})

--- a/orbit-www/src/lib/grpc/bifrost-client.ts
+++ b/orbit-www/src/lib/grpc/bifrost-client.ts
@@ -1,0 +1,46 @@
+/**
+ * Bifrost Admin gRPC Client
+ *
+ * Provides a configured Connect-ES client for the Bifrost Admin service.
+ * This service manages virtual clusters, credentials, and gateway configuration
+ * for the Kafka gateway proxy.
+ *
+ * Usage:
+ * ```ts
+ * import { bifrostClient } from '@/lib/grpc/bifrost-client'
+ *
+ * const response = await bifrostClient.listVirtualClusters({})
+ * ```
+ */
+
+import { createClient } from '@connectrpc/connect'
+import { createGrpcTransport } from '@connectrpc/connect-node'
+import { BifrostAdminService } from '@/lib/proto/idp/gateway/v1/gateway_pb'
+
+/**
+ * Transport configuration for the Bifrost Admin gRPC service.
+ * Uses gRPC transport for server-side calls to native gRPC services.
+ * Defaults to localhost:50060 for development.
+ * Override with BIFROST_ADMIN_URL environment variable.
+ */
+const transport = createGrpcTransport({
+  baseUrl: process.env.BIFROST_ADMIN_URL || 'http://localhost:50060',
+})
+
+/**
+ * Singleton client instance for the Bifrost Admin service.
+ *
+ * Available methods:
+ * - Virtual Cluster Management: listVirtualClusters, upsertVirtualCluster, deleteVirtualCluster, setVirtualClusterReadOnly
+ * - Credential Management: listCredentials, upsertCredential, revokeCredential
+ * - Policy Management: listPolicies, upsertPolicy, deletePolicy
+ * - Topic ACL Management: listTopicACLs, upsertTopicACL, revokeTopicACL
+ * - Configuration & Status: getFullConfig, getStatus
+ */
+export const bifrostClient = createClient(BifrostAdminService, transport)
+
+/**
+ * Helper type for extracting request types from the client
+ * Useful for component props and function signatures
+ */
+export type BifrostClient = typeof bifrostClient


### PR DESCRIPTION
## Summary

- Adds a "Gateway" tab to the Kafka Platform UI (`/platform/kafka/`) for managing the Bifrost Kafka gateway
- Provides full admin control: virtual cluster management, credential provisioning, and gateway status monitoring
- Uses Connect-ES for direct gRPC communication with Bifrost's admin API
- Gracefully handles when Bifrost gateway is unreachable (non-blocking page load)

## Features

### Virtual Clusters
- List, create, edit, and delete virtual clusters
- Toggle read-only mode for maintenance
- Configure topic/group/transaction ID prefixes
- Set physical bootstrap servers

### Credentials
- Create credentials with permission templates (producer, consumer, admin, custom)
- Auto-generated strong passwords (24 characters)
- One-time password display with copy-to-clipboard functionality
- Revoke credentials

### Gateway Status
- Real-time gateway health monitoring
- Active connections count
- Virtual cluster count
- Version information

## Test Plan

- [x] All 33 bifrost-related tests passing (11 client + 22 server actions)
- [x] Lint passes for all new components
- [ ] Manual testing with running Bifrost gateway
- [ ] Verify virtual cluster CRUD operations
- [ ] Verify credential creation and revocation
- [ ] Verify gateway status display
- [ ] Verify graceful degradation when gateway unreachable

## Files Changed

### Core Implementation
- `src/lib/grpc/bifrost-client.ts` - Connect-ES gRPC client
- `src/app/actions/bifrost-admin.ts` - Server actions (668 lines)

### React Components (8 new files)
- `GatewayTab.tsx` - Container with sub-tabs
- `VirtualClustersTab.tsx` - Virtual cluster management
- `VirtualClusterForm.tsx` - Create/edit form
- `CredentialsTab.tsx` - Credential management
- `CredentialForm.tsx` - Create credential form
- `GatewayStatusTab.tsx` - Status display

### Integration
- Updated `KafkaAdminClient.tsx` - Added Gateway tab
- Updated `page.tsx` - Parallel fetch for gateway data
- Updated `components/index.ts` - New exports

### Configuration
- `.env.example` - Added BIFROST_ADMIN_URL
- `docker-compose.yml` - Added env var to orbit-www service

🤖 Generated with [Claude Code](https://claude.ai/code)