### PR TITLE
fix: knowledge space creation — RBAC, access hooks, and empty state UX

### DIFF
--- a/orbit-www/src/app/(frontend)/workspaces/[slug]/knowledge/page.tsx
+++ b/orbit-www/src/app/(frontend)/workspaces/[slug]/knowledge/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
@@ -126,6 +127,12 @@ export default async function KnowledgePage({ params }: PageProps) {
                         Documentation and knowledge for {workspace.name}
                       </p>
                     </div>
+                    <Button asChild>
+                      <Link href={`/workspaces/${slug}/knowledge/new`}>
+                        <BookOpen className="h-4 w-4 mr-2" />
+                        New Space
+                      </Link>
+                    </Button>
                   </div>
                 </div>
 
@@ -139,6 +146,12 @@ export default async function KnowledgePage({ params }: PageProps) {
                         Knowledge spaces help organize documentation, guides, and other content for
                         your workspace.
                       </p>
+                      <Button className="mt-4" asChild>
+                        <Link href={`/workspaces/${slug}/knowledge/new`}>
+                          <BookOpen className="h-4 w-4 mr-2" />
+                          Create Knowledge Space
+                        </Link>
+                      </Button>
                     </CardContent>
                   </Card>
                 )}

--- a/orbit-www/src/app/actions/knowledge.ts
+++ b/orbit-www/src/app/actions/knowledge.ts
@@ -3,6 +3,7 @@
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import { revalidatePath } from 'next/cache'
+import { getPayloadUserFromSession } from '@/lib/auth/session'
 
 export async function createKnowledgeSpace(data: {
   name: string
@@ -11,6 +12,11 @@ export async function createKnowledgeSpace(data: {
   visibility: 'private' | 'internal' | 'public'
   workspaceSlug: string
 }) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   // Look up workspace by slug
@@ -18,6 +24,7 @@ export async function createKnowledgeSpace(data: {
     collection: 'workspaces',
     where: { slug: { equals: data.workspaceSlug } },
     limit: 1,
+    overrideAccess: true,
   })
 
   if (workspacesResult.docs.length === 0) {
@@ -41,6 +48,8 @@ export async function createKnowledgeSpace(data: {
       icon: data.icon || undefined,
       visibility: data.visibility,
     },
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   revalidatePath(`/workspaces/${data.workspaceSlug}/knowledge`)
@@ -57,6 +66,11 @@ export async function createKnowledgePage(data: {
   workspaceSlug: string
   spaceSlug: string
 }) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   // Create the page with empty block content
@@ -84,6 +98,8 @@ export async function createKnowledgePage(data: {
       sortOrder: 0,
       tags: [],
     },
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   // Revalidate the space page to show the new page
@@ -98,6 +114,11 @@ export async function renamePage(
   workspaceSlug: string,
   spaceSlug: string
 ) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   await payload.update({
@@ -106,6 +127,8 @@ export async function renamePage(
     data: {
       title: newTitle,
     },
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   revalidatePath(`/workspaces/${workspaceSlug}/knowledge/${spaceSlug}`)
@@ -117,6 +140,11 @@ export async function movePage(
   workspaceSlug: string,
   spaceSlug: string
 ) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   await payload.update({
@@ -125,6 +153,8 @@ export async function movePage(
     data: {
       parentPage: newParentId,
     },
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   revalidatePath(`/workspaces/${workspaceSlug}/knowledge/${spaceSlug}`)
@@ -135,12 +165,18 @@ export async function duplicatePage(
   workspaceSlug: string,
   spaceSlug: string
 ) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   // Get original page
   const original = await payload.findByID({
     collection: 'knowledge-pages',
     id: pageId,
+    overrideAccess: true,
   })
 
   // Create duplicate with unique slug
@@ -158,6 +194,8 @@ export async function duplicatePage(
       sortOrder: (original.sortOrder ?? 0) + 1,
       version: 1,
     },
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   revalidatePath(`/workspaces/${workspaceSlug}/knowledge/${spaceSlug}`)
@@ -169,11 +207,18 @@ export async function deletePage(
   workspaceSlug: string,
   spaceSlug: string
 ) {
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   await payload.delete({
     collection: 'knowledge-pages',
     id: pageId,
+    user: payloadUser,
+    overrideAccess: false,
   })
 
   revalidatePath(`/workspaces/${workspaceSlug}/knowledge/${spaceSlug}`)
@@ -187,17 +232,24 @@ export async function updatePageSortOrder(
 ) {
   'use server'
 
+  const payloadUser = await getPayloadUserFromSession()
+  if (!payloadUser) {
+    throw new Error('Not authenticated')
+  }
+
   const payload = await getPayload({ config })
 
   // Fetch both pages to get their parent
   const activePage = await payload.findByID({
     collection: 'knowledge-pages',
     id: activePageId,
+    overrideAccess: true,
   })
 
   const overPage = await payload.findByID({
     collection: 'knowledge-pages',
     id: overPageId,
+    overrideAccess: true,
   })
 
   // Get parent ID (handle both string and object formats)
@@ -219,6 +271,7 @@ export async function updatePageSortOrder(
     },
     sort: 'sortOrder',
     limit: 1000,
+    overrideAccess: true,
   })
 
   // Reorder: remove active page and insert at over page's position
@@ -240,6 +293,8 @@ export async function updatePageSortOrder(
         collection: 'knowledge-pages',
         id: page.id,
         data: { sortOrder: index },
+        user: payloadUser,
+        overrideAccess: false,
       })
     )
   )

--- a/orbit-www/src/collections/KnowledgeSpaces.ts
+++ b/orbit-www/src/collections/KnowledgeSpaces.ts
@@ -8,82 +8,103 @@ export const KnowledgeSpaces: CollectionConfig = {
     group: 'Knowledge',
   },
   access: {
-    // Read: Workspace members
+    // Read: Platform admins see all, workspace members see their workspaces' spaces
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      
-      // Return query constraint to filter by workspace membership
+      const role = (user as any).role
+      if (role === 'super_admin' || role === 'admin') return true
+
+      const betterAuthId = (user as any).betterAuthId
+      if (!betterAuthId) return false
+
       const memberships = await payload.find({
         collection: 'workspace-members',
         where: {
-          user: { equals: user.id },
+          user: { equals: betterAuthId },
           status: { equals: 'active' },
         },
         limit: 1000,
+        overrideAccess: true,
       })
-      
-      const workspaceIds = memberships.docs.map(m => 
+
+      const workspaceIds = memberships.docs.map(m =>
         typeof m.workspace === 'string' ? m.workspace : m.workspace.id
       )
-      
+
+      if (workspaceIds.length === 0) return false
+
       return {
         workspace: { in: workspaceIds }
       }
     },
-    // Create: Authenticated users (workspace will be validated)
+    // Create: Any authenticated user
     create: ({ req: { user } }) => !!user,
-    // Update: Workspace admins/owners only
+    // Update: Platform admins or workspace admins/owners
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      
+      const role = (user as any).role
+      if (role === 'super_admin' || role === 'admin') return true
+
+      const betterAuthId = (user as any).betterAuthId
+      if (!betterAuthId) return false
+
       const space = await payload.findByID({
         collection: 'knowledge-spaces',
         id,
+        overrideAccess: true,
       })
-      
-      const workspaceId = typeof space.workspace === 'string' 
-        ? space.workspace 
+
+      const workspaceId = typeof space.workspace === 'string'
+        ? space.workspace
         : space.workspace.id
-      
+
       const members = await payload.find({
         collection: 'workspace-members',
         where: {
           and: [
             { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
+            { user: { equals: betterAuthId } },
             { role: { in: ['owner', 'admin'] } },
             { status: { equals: 'active' } },
           ],
         },
+        overrideAccess: true,
       })
-      
+
       return members.docs.length > 0
     },
-    // Delete: Workspace owners only
+    // Delete: Platform admins or workspace owners only
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      
+      const role = (user as any).role
+      if (role === 'super_admin' || role === 'admin') return true
+
+      const betterAuthId = (user as any).betterAuthId
+      if (!betterAuthId) return false
+
       const space = await payload.findByID({
         collection: 'knowledge-spaces',
         id,
+        overrideAccess: true,
       })
-      
+
       const workspaceId = typeof space.workspace === 'string'
         ? space.workspace
         : space.workspace.id
-      
+
       const members = await payload.find({
         collection: 'workspace-members',
         where: {
           and: [
             { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
+            { user: { equals: betterAuthId } },
             { role: { equals: 'owner' } },
             { status: { equals: 'active' } },
           ],
         },
+        overrideAccess: true,
       })
-      
+
       return members.docs.length > 0
     },
   },


### PR DESCRIPTION
## Summary

- Fixes `KnowledgeSpaces` collection access hooks to use `betterAuthId` instead of Payload `user.id` for workspace-members queries (same ID mismatch fix applied to other collections in #36)
- Adds `overrideAccess: true` to all internal queries within access hooks to prevent recursive access control
- Adds platform admin bypass (`super_admin`/`admin`) to all access hooks
- Migrates all 7 knowledge server actions (`createKnowledgeSpace`, `createKnowledgePage`, `renamePage`, `movePage`, `duplicatePage`, `deletePage`, `updatePageSortOrder`) to use `getPayloadUserFromSession()` with `overrideAccess: false`
- Adds "New Space" button in the Knowledge Base page header and "Create Knowledge Space" CTA in the empty state

## Test plan
- [x] Created knowledge space "My Docs" via UI — succeeded
- [x] Created knowledge page "Getting Started Guide" within space — succeeded
- [x] Page shows correct author, date, and breadcrumb navigation
- [x] Knowledge Base empty state now shows Create button
- [x] Verified via agent-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)