### PR TITLE
fix(orbit-www): resolve ESLint errors breaking the production image build

### DIFF
--- a/orbit-www/src/app/(frontend)/platform/llm-providers/new/new-llm-provider-form.tsx
+++ b/orbit-www/src/app/(frontend)/platform/llm-providers/new/new-llm-provider-form.tsx
@@ -156,7 +156,7 @@ export function NewLLMProviderForm({ workspaces }: Props) {
           placeholder="sk-…"
         />
         <p className="text-xs text-muted-foreground">
-          Encrypted at rest. Leave blank for self-hosted backends that don't require a key.
+          Encrypted at rest. Leave blank for self-hosted backends that don&apos;t require a key.
         </p>
       </div>
 

--- a/orbit-www/src/app/(frontend)/platform/llm-providers/page.tsx
+++ b/orbit-www/src/app/(frontend)/platform/llm-providers/page.tsx
@@ -72,7 +72,7 @@ export default async function PlatformLLMProvidersPage() {
               <h1 className="text-2xl font-semibold">LLM Providers</h1>
               <p className="text-sm text-muted-foreground max-w-2xl">
                 Bring-your-own LLM credentials the Infrastructure Agent uses to drive its
-                conversation loop. API keys are encrypted at rest. The agent's runtime worker
+                conversation loop. API keys are encrypted at rest. The agent&apos;s runtime worker
                 fetches the decrypted credential through an internal-only API gated by a shared
                 secret — keys are never exposed to the browser.
               </p>

--- a/orbit-www/src/app/actions/builds.ts
+++ b/orbit-www/src/app/actions/builds.ts
@@ -22,9 +22,10 @@ interface StartBuildInput {
 
 export async function startBuild(input: StartBuildInput) {
   const payloadUser = await getPayloadUserFromSession()
-  if (!payloadUser) {
+  if (!payloadUser?.betterAuthId) {
     return { success: false, error: 'Unauthorized' }
   }
+  const userId = payloadUser.betterAuthId
 
   const payload = await getPayload({ config })
 
@@ -257,7 +258,7 @@ export async function startBuild(input: StartBuildInput) {
     const result = await startBuildWorkflow({
       appId: input.appId,
       workspaceId,
-      userId: payloadUser.betterAuthId,
+      userId,
       repoUrl,
       ref,
       registry: {

--- a/orbit-www/src/app/actions/deployments.ts
+++ b/orbit-www/src/app/actions/deployments.ts
@@ -5,6 +5,9 @@ import config from '@payload-config'
 import { getPayloadUserFromSession } from '@/lib/auth/session'
 import { startDeploymentWorkflow, getDeploymentProgress } from '@/lib/clients/deployment-client'
 import type { JsonObject } from '@bufbuild/protobuf'
+import type { Deployment } from '@/payload-types'
+
+type DeployStrategy = NonNullable<Deployment['deployStrategy']>
 
 interface CreateDeploymentInput {
   appId: string
@@ -19,7 +22,7 @@ interface CreateDeploymentInput {
     hostUrl?: string
   }
   launchId?: string
-  deployStrategy?: string
+  deployStrategy?: DeployStrategy
 }
 
 export async function createDeployment(input: CreateDeploymentInput) {
@@ -64,7 +67,7 @@ export async function createDeployment(input: CreateDeploymentInput) {
   }
 
   // Resolve Launch if provided
-  let launchData: { launch: string; deployStrategy: string; launchOutputs: Record<string, unknown> } | null = null
+  let launchData: { launch: string; deployStrategy: DeployStrategy; launchOutputs: Record<string, unknown> } | null = null
   if (input.launchId) {
     const launch = await payload.findByID({
       collection: 'launches',
@@ -137,9 +140,10 @@ export async function createDeployment(input: CreateDeploymentInput) {
 
 export async function startDeployment(deploymentId: string) {
   const payloadUser = await getPayloadUserFromSession()
-  if (!payloadUser) {
+  if (!payloadUser?.betterAuthId) {
     return { success: false, error: 'Unauthorized' }
   }
+  const userId = payloadUser.betterAuthId
 
   const payload = await getPayload({ config })
 
@@ -219,8 +223,8 @@ export async function startDeployment(deploymentId: string) {
       deploymentId,
       appId,
       workspaceId,
-      userId: payloadUser.betterAuthId,
-      generatorType: deployment.generator,
+      userId,
+      generatorType: deployment.generator ?? '',
       generatorSlug,
       config: deploymentConfig,
       target: deploymentTarget,

--- a/orbit-www/src/app/api/internal/agent-tools/[id]/resolve/route.ts
+++ b/orbit-www/src/app/api/internal/agent-tools/[id]/resolve/route.ts
@@ -78,7 +78,7 @@ export async function POST(
     }
 
     let agentToolVersionId: string | undefined
-    let editedFieldsList: string[] = []
+    const editedFieldsList: string[] = []
 
     // α — capture the agent's original proposal as v1 on every approval
     // so we have an audit baseline. Even runs that don't get edited

--- a/orbit-www/src/components/features/infra-agent/AgentChatThread.tsx
+++ b/orbit-www/src/components/features/infra-agent/AgentChatThread.tsx
@@ -933,7 +933,7 @@ function ApprovalCard({
             </div>
             {approval.reasoning && (
               <details className="text-muted-foreground">
-                <summary className="cursor-pointer">Agent's reasoning</summary>
+                <summary className="cursor-pointer">Agent&apos;s reasoning</summary>
                 <pre className="whitespace-pre-wrap pt-2">{approval.reasoning}</pre>
               </details>
             )}

--- a/orbit-www/src/components/features/infra-agent/CrossWorkspaceAgentRunForm.tsx
+++ b/orbit-www/src/components/features/infra-agent/CrossWorkspaceAgentRunForm.tsx
@@ -149,8 +149,8 @@ export function CrossWorkspaceAgentRunForm({ apps, providers }: Props) {
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-muted-foreground">
           <p>
-            The Infra Agent deploys apps that are registered in a workspace. You're a member of
-            workspaces but none of them have apps yet — add an app from a workspace's Applications
+            The Infra Agent deploys apps that are registered in a workspace. You&apos;re a member of
+            workspaces but none of them have apps yet — add an app from a workspace&apos;s Applications
             page and come back.
           </p>
         </CardContent>


### PR DESCRIPTION
## Problem

The post-merge `Build and Push Images` run on `main` ([27252074328](https://github.com/drewpayment/orbit/actions/runs/27252074328)) failed on the `orbit-www` image: PR #41 introduced six ESLint errors (`react/no-unescaped-entities` ×5, `prefer-const` ×1) that are fatal during the production `next build`. PR checks never exercise the production build, so this only surfaced after merge.

## Fix

- Escape unescaped apostrophes in `new-llm-provider-form.tsx`, `llm-providers/page.tsx`, `AgentChatThread.tsx`, `CrossWorkspaceAgentRunForm.tsx`
- `let` → `const` for `editedFieldsList` in `agent-tools/[id]/resolve/route.ts`
- Fix `betterAuthId` nullability fallout from the #41 `payload-types.ts` regeneration in `builds.ts` / `deployments.ts`: auth guards now require `betterAuthId` (returning Unauthorized otherwise), and `deployStrategy` uses the generated union type instead of `string`

## Verification

- `bun run lint` — exit 0, zero errors (warnings only)
- `DOCKER_BUILD=1 bun run build` (exactly how the Docker image builds) — exit 0

## Heads-up: latent type debt (not fixed here)

The Dockerfile sets `DOCKER_BUILD=1`, and `next.config.mjs` sets `typescript.ignoreBuildErrors` from it — so **CI never typechecks the frontend**. A full `tsc --noEmit` currently reports ~100 errors across ~25 files (mostly `betterAuthId: string | null | undefined` strict-assignment fallout and stale test fixtures). This PR fixes only the files it already touches; the rest deserves a dedicated cleanup, ideally alongside re-enabling typechecking in the image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)