### PR TITLE
fix(ci): build automations-worker image + unbreak orbit-www image build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -34,6 +34,7 @@ jobs:
       kafka-service: ${{ steps.filter.outputs.kafka-service }}
       temporal-worker: ${{ steps.filter.outputs.temporal-worker }}
       launches-worker-azure: ${{ steps.filter.outputs.launches-worker-azure }}
+      automations-worker: ${{ steps.filter.outputs.automations-worker }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -61,6 +62,8 @@ jobs:
               - 'proto/**'
             launches-worker-azure:
               - 'launches-worker-azure/**'
+            automations-worker:
+              - 'orbit-www/services/automation-worker/**'
 
   build:
     needs: changes
@@ -96,6 +99,9 @@ jobs:
           - service: launches-worker-azure
             dockerfile: launches-worker-azure/Dockerfile
             context: launches-worker-azure
+          - service: automations-worker
+            dockerfile: orbit-www/services/automation-worker/Dockerfile
+            context: orbit-www/services/automation-worker
     steps:
       - name: Check if service changed
         id: check

--- a/orbit-www/Dockerfile
+++ b/orbit-www/Dockerfile
@@ -14,6 +14,10 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json bun.lock ./
+# The @orbit/automation-worker workspace package (services/*) must be present for
+# bun to resolve the `workspace:*` dependency under --frozen-lockfile. Copy its
+# manifest before install; its source is brought in by the builder stage's COPY.
+COPY services/automation-worker/package.json ./services/automation-worker/package.json
 RUN bun install --frozen-lockfile
 
 # Rebuild the source code only when needed


### PR DESCRIPTION
Fixes the failing `build-and-push` run on `main` after #53 merged, and ensures the **automations-worker** image is actually published for the cluster.

## Two problems
1. **orbit-www image build broke.** #53 added `@orbit/automation-worker` as a `workspace:*` dependency of `orbit-www`, but the orbit-www Dockerfile's `bun install --frozen-lockfile` can't resolve a workspace package whose manifest isn't in the build context — so the `deps` stage failed with `Workspace dependency "@orbit/automation-worker" not found`.
   → **Fix:** copy `services/automation-worker/package.json` before install (source still arrives via the builder stage's `COPY . .`).
2. **The automations-worker image was never built.** The new worker has a Dockerfile + compose service + k8s manifest, but it wasn't in the CI build matrix, so `ghcr.io/drewpayment/orbit/automations-worker` was never published.
   → **Fix:** add it to the `changes` path filter (`orbit-www/services/automation-worker/**`) and the build matrix (context `orbit-www/services/automation-worker`).

## Why the cluster needs this
[hoytlabs-talos#7](https://github.com/drewpayment/hoytlabs-talos/pull/7) deploys `image: ghcr.io/drewpayment/orbit/automations-worker:latest` — which this PR makes CI produce.

## Verification
- `orbit-www` image builds **end-to-end** locally (deps stage + full `next build`).
- The `automations-worker` image builds from its own context (also proven earlier via `docker compose build`).
- Workflow YAML validated.

## After merge
Trigger the workflow manually with **`build_all: true`** (`gh workflow run build-and-push.yml -f build_all=true`) so `automations-worker:latest` is published immediately (a path-filtered merge wouldn't rebuild the worker since this PR doesn't touch its source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)