### PR TITLE
feat(scorecards): nightly scheduled evaluation via Temporal sweep

### DIFF
--- a/docs/plans/2026-07-01-entity-scores-and-golden-paths.md
+++ b/docs/plans/2026-07-01-entity-scores-and-golden-paths.md
@@ -1,6 +1,6 @@
 # Entity Scores & Golden Paths (Scorecards v2)
 
-**Status:** In progress
+**Status:** Shipped (PR #56)
 **Depends on:** IDP refocus P1 (catalog graph) + P2 (scorecards) — see
 `docs/plans/2026-06-27-idp-refocus-implementation.md`.
 

--- a/docs/plans/2026-07-01-scorecard-reports.md
+++ b/docs/plans/2026-07-01-scorecard-reports.md
@@ -1,6 +1,6 @@
 # Scorecard Reports & Insights
 
-**Status:** In progress
+**Status:** Shipped (PR #59)
 **Depends on:** Entity Scores & Golden Paths (PR #56) — this branch is stacked on
 `feat/entity-scores-golden-paths`. See `2026-07-01-entity-scores-and-golden-paths.md`.
 

--- a/docs/plans/2026-07-02-scheduled-scorecard-evaluation.md
+++ b/docs/plans/2026-07-02-scheduled-scorecard-evaluation.md
@@ -1,0 +1,137 @@
+# Scheduled Scorecard Evaluation
+
+**Date:** 2026-07-02
+**Status:** In progress
+**Roadmap:** `2026-07-02-scorecards-roadmap.md` item 1.
+**Depends on:** P4.2 automation Temporal worker (`docs/plans/2026-06-27-automation-temporal-ts-worker.md`),
+scorecard internal routes (P2 / PR #56 / PR #59).
+
+## Product goal
+
+Scores, golden-path alignment, and report trends must stay fresh **without a human
+clicking "Evaluate now"**. A nightly Temporal-scheduled sweep evaluates every enabled
+scorecard in every workspace, which (via the existing `runScorecardEvaluation`
+pipeline) also recomputes entity scores and appends score snapshots — so the reports
+trend chart accrues history automatically.
+
+## Design
+
+### Shape: one global Temporal Schedule + a sweep workflow on the existing worker
+
+- **No new deployable.** The sweep workflow and its activities live in the existing
+  `orbit-www/services/automation-worker/` package and run on the existing
+  `orbit-automations` task queue. The existing Dockerfile / k8s deployment /CI image
+  pick the code up automatically.
+- **One global Schedule**, id `scorecard-evaluation:global`, cron default `0 5 * * *`
+  (05:00 UTC nightly), overridable via `SCORECARD_EVAL_CRON`. Timezone follows the
+  same convention as automations (`AUTOMATION_SCHEDULE_TZ`, default UTC).
+- **The worker manages its own schedule**: at startup, before polling, the worker
+  idempotently creates-or-converges the Schedule (same converge pattern as
+  `ensureAutomationSchedule` — create, catch `ScheduleAlreadyRunning`, update).
+  Setting `SCORECARD_EVAL_DISABLED=1` converges the Schedule to paused (and pauses
+  an existing one); unset/0 unpauses. This keeps the schedule lifecycle entirely
+  inside the worker — no app-side bootstrap, no manual step.
+  - Requires adding `@temporalio/client` to the worker package (schedule client uses
+    `Connection`, distinct from the worker's `NativeConnection`).
+  - Ensure-failure at startup is FATAL (fail-closed, mirroring the automations
+    invariant): a worker that can't guarantee its schedule exits nonzero and the
+    deployment restarts it.
+
+### Sweep workflow (`ScorecardEvaluationSweepWorkflow`)
+
+Deterministic sandbox rules apply (no Node APIs, type-only activity imports).
+
+1. Activity `listEnabledScorecards()` → GET
+   `${ORBIT_API_URL}/api/internal/scorecards/due` (X-API-Key) → returns
+   `{ scorecards: [{ id, workspaceId }] }`.
+2. For each scorecard, activity `evaluateScorecard({ scorecardId })` → POST the
+   existing `/api/internal/scorecards/evaluate`. Runs with **bounded concurrency
+   (3)** to avoid hammering the app; per-item failures are caught and collected —
+   one bad scorecard must not abort the sweep.
+3. Returns a summary `{ total, succeeded, failed: [{ scorecardId, error }] }` so the
+   Temporal UI shows exactly what happened.
+
+Activity retry/timeout mirrors `dispatchScheduledAutomation`: `startToCloseTimeout`
+generous for evaluate (5m — a big workspace evaluation is slow), 5 attempts, 4xx →
+`ApplicationFailure.nonRetryable`, 5xx/network → retryable Error.
+
+Snapshots & recompute need no extra calls: `runScorecardEvaluation` already invokes
+`recomputeWorkspaceScores` + `captureScoreSnapshots` (30-min throttle collapses
+multiple scorecards per workspace into one snapshot set per sweep).
+
+### New internal route: `GET /api/internal/scorecards/due`
+
+`orbit-www/src/app/api/internal/scorecards/due/route.ts`, X-API-Key
+(`validateInternalApiKey`), mirrors the existing internal scorecards routes.
+Returns every enabled scorecard: `payload.find({ collection: 'scorecards', where:
+{ enabled: { equals: true } }, depth: 0, limit: 0/paginated })` → `{ scorecards:
+[{ id, workspaceId }] }` (workspace normalized to a string id). No request body; no
+tenant filter — this is the machine sweep surface, same trust level as `evaluate`.
+
+### Contract additions (`services/automation-worker/src/shared.ts`)
+
+- `SCORECARD_SWEEP_WORKFLOW = 'ScorecardEvaluationSweepWorkflow'`
+- `SCORECARD_SWEEP_SCHEDULE_ID = 'scorecard-evaluation:global'`
+- `DEFAULT_SCORECARD_EVAL_CRON = '0 5 * * *'`
+- `interface ScorecardSweepResult { total: number; succeeded: number; failed: { scorecardId: string; error: string }[] }`
+- Module stays free of Temporal/Node imports (sandbox-importable invariant).
+
+### Worker wiring
+
+- New `src/workflows/index.ts` barrel re-exporting `AutomationDispatchWorkflow` and
+  `ScorecardEvaluationSweepWorkflow`; `worker.ts` `workflowsPath` points at the
+  barrel (Schedule actions resolve workflows by exported name — existing
+  automation schedules are unaffected).
+- Activities object merges dispatch + scorecard-sweep activities.
+- Startup order: connect → ensure schedule (fatal on failure) → create worker → run.
+
+## Files
+
+| file | change |
+|---|---|
+| `orbit-www/services/automation-worker/src/shared.ts` | add sweep contract consts/types |
+| `orbit-www/services/automation-worker/src/workflows/scorecard-sweep.ts` | NEW — sweep workflow |
+| `orbit-www/services/automation-worker/src/workflows/index.ts` | NEW — barrel for workflowsPath |
+| `orbit-www/services/automation-worker/src/activities/scorecard-sweep.ts` | NEW — list + evaluate activities |
+| `orbit-www/services/automation-worker/src/activities/scorecard-sweep.test.ts` | NEW — activity tests (mirror `dispatch.test.ts`) |
+| `orbit-www/services/automation-worker/src/schedule.ts` | NEW — `ensureScorecardSweepSchedule` (client-side ensure) |
+| `orbit-www/services/automation-worker/src/schedule.test.ts` | NEW — ensure/converge/pause tests |
+| `orbit-www/services/automation-worker/src/worker.ts` | workflowsPath → barrel; register activities; startup ensure |
+| `orbit-www/services/automation-worker/package.json` | add `@temporalio/client` |
+| `orbit-www/src/app/api/internal/scorecards/due/route.ts` | NEW — enabled-scorecards listing |
+| `orbit-www/src/app/api/internal/scorecards/due/route.test.ts` | NEW — route tests (auth, shape, pagination) |
+| `orbit-www/services/automation-worker/README.md` | document sweep + env vars |
+| `infrastructure/k8s/automations-worker/deployment.yaml` | (optional) SCORECARD_EVAL_CRON env passthrough |
+
+## Env
+
+| var | default | meaning |
+|---|---|---|
+| `SCORECARD_EVAL_CRON` | `0 5 * * *` | sweep cadence |
+| `SCORECARD_EVAL_DISABLED` | unset | `1`/`true` ⇒ schedule converged to paused |
+| `ORBIT_API_URL`, `ORBIT_INTERNAL_API_KEY`, `AUTOMATION_SCHEDULE_TZ` | existing | reused |
+
+## User Acceptance Criteria
+
+- **UAC-1:** Worker startup idempotently ensures Schedule `scorecard-evaluation:global`
+  (create → converge-on-exists), honoring cron + disabled env; ensure failure is fatal.
+- **UAC-2:** The sweep workflow lists enabled scorecards via `/due` and POSTs
+  `/evaluate` per scorecard with bounded concurrency (3); a failing scorecard does not
+  abort the sweep; the run result reports `{ total, succeeded, failed[] }`.
+- **UAC-3:** `/api/internal/scorecards/due` rejects missing/bad X-API-Key, returns all
+  enabled scorecards (and only enabled) with string workspace ids, across pagination.
+- **UAC-4:** Activity error semantics match the dispatch activity: 4xx nonretryable,
+  5xx/network retryable; env validated at call time with actionable messages.
+- **UAC-5:** Existing automation dispatch behavior is unchanged (its tests still pass;
+  schedule action workflow names still resolve via the new barrel).
+- **UAC-6:** All new logic is unit-tested (vitest, TDD); `tsc --noEmit` clean for
+  touched files; no UI changes (so no agent-browser pass required).
+
+## Verification
+
+- `cd orbit-www && pnpm exec vitest run services/automation-worker src/app/api/internal`
+  (plus the existing scorecards suites for regression:
+  `pnpm exec vitest run src/lib/scorecards`)
+- `cd orbit-www && pnpm exec tsc --noEmit` (touched files clean; repo has known
+  pre-existing errors elsewhere)
+- QA review pass against UAC-1..6 before merge.

--- a/docs/plans/2026-07-02-scorecards-roadmap.md
+++ b/docs/plans/2026-07-02-scorecards-roadmap.md
@@ -1,0 +1,73 @@
+# Scorecards Capability — Roadmap to Full Delivery
+
+**Date:** 2026-07-02
+**Status:** Active roadmap
+**Context:** Audit of shipped scorecards work (IDP refocus P2 + PRs #56, #59) vs the
+plans in `2026-06-27-idp-refocus-implementation.md`, `2026-07-01-entity-scores-and-golden-paths.md`,
+and `2026-07-01-scorecard-reports.md`.
+
+## Where we are
+
+Authoring and measurement are essentially complete on `main`:
+
+- All five P2 collections (`scorecards`, `scorecard-rules`, `scorecard-rule-results`,
+  `initiatives`, `initiative-action-items`) plus `entity-types`, `entity-scores`,
+  `score-snapshots`.
+- TypeScript evaluation engine (`lib/scorecards/evaluate.ts`) with four rule types
+  (`field-presence`, `relation-check`, `threshold`, `entity-score`), RBAC-gated
+  Rule Builder, level ladders, "Evaluate now".
+- Entity scores + golden-path alignment across the catalog (PR #56).
+- Reports & Insights at `/scorecards/reports` — KPIs, trend, distributions, team/kind
+  breakdowns, rule insights (PR #59).
+- Internal X-API-Key routes: `evaluate`, `recompute-scores`, `capture-snapshots`.
+
+## Gaps, in priority order
+
+### 1. Scheduled evaluation (NOW — see `2026-07-02-scheduled-scorecard-evaluation.md`)
+
+Everything today is on-demand ("Evaluate now", catalog save-time seeding, internal
+routes). Nothing runs nightly, so scores go stale and the reports trend chart only
+accrues history if a human clicks Evaluate. The Temporal automations worker
+(`orbit-www/services/automation-worker/`) and Schedule plumbing already exist from
+P4.2 — wire a scorecard-evaluation sweep into them. This makes everything already
+shipped trustworthy; it ships first.
+
+### 2. Initiatives — data model with no product
+
+`initiatives` + `initiative-action-items` exist and are registered but have **zero
+UI** and no auto-generation of action items for failing entities. This is the
+remediation half of the story (pick scorecard + target level + deadline → action
+items for failing entities → burndown). Also unlocks the "initiative burndown"
+reports section deferred in the reports plan.
+
+### 3. Rule-authoring UX
+
+- **Preview / dry-run** — "which entities would pass this rule?" before saving.
+  Highest-leverage single authoring improvement.
+- **Prebuilt scorecard templates** — production-readiness, security baseline.
+- **Metadata-key discoverability** — suggest `metadata.*` keys seen on real entities.
+- Bulk rule editing.
+
+### 4. Drift → notification delivery
+
+The P4 drift automation works end-to-end but `notify-owner` only records on the
+action run — no email/Slack sink. Failing scorecards don't reach anyone yet.
+
+### 5. Reports follow-ups (explicitly out of scope in the reports plan)
+
+CSV export, scheduled email digests (pairs with #1's scheduling infra),
+per-team drill-down pages.
+
+### 6. Smaller items
+
+- AI-governance rules riding the engine (project `agent-runs` / `pending-approvals`
+  into entity metadata + template rules).
+- RBAC Option B (granular `scorecards:manage`) when the Permissions system activates —
+  switch point is `canManageScorecards`.
+
+## Delivery sequence
+
+1. **Scheduled evaluation** — small, makes shipped value real. ← current
+2. **Initiatives UI + auto action items** — completes measure→improve loop.
+3. **Rule preview + templates** — drives authoring adoption.
+4. Notifications, reports follow-ups, governance rules.

--- a/infrastructure/k8s/automations-worker/deployment.yaml
+++ b/infrastructure/k8s/automations-worker/deployment.yaml
@@ -42,6 +42,12 @@ spec:
                   key: ORBIT_INTERNAL_API_KEY
             - name: AUTOMATION_SCHEDULE_TZ
               value: UTC
+            # Nightly scorecard-evaluation sweep cadence (default matches the
+            # worker's built-in default; override to change the schedule).
+            - name: SCORECARD_EVAL_CRON
+              value: "0 5 * * *"
+            # SCORECARD_EVAL_DISABLED: unset by default (sweep schedule enabled).
+            # Set to "1" to converge the schedule to paused.
           resources:
             requests:
               memory: 256Mi

--- a/orbit-www/bun.lock
+++ b/orbit-www/bun.lock
@@ -123,6 +123,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@temporalio/activity": "^1.13.0",
+        "@temporalio/client": "^1.13.0",
         "@temporalio/worker": "^1.13.0",
         "@temporalio/workflow": "^1.13.0",
         "tsx": "^4.19.2",
@@ -3226,6 +3227,8 @@
 
     "@lexical/react/react-error-boundary": ["react-error-boundary@3.1.4", "", { "dependencies": { "@babel/runtime": "7.28.4" }, "peerDependencies": { "react": "19.1.0" } }, "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA=="],
 
+    "@orbit/automation-worker/@temporalio/client": ["@temporalio/client@1.18.1", "", { "dependencies": { "@grpc/grpc-js": "^1.12.4", "@temporalio/common": "1.18.1", "@temporalio/proto": "1.18.1", "abort-controller": "^3.0.0", "long": "^5.2.3", "nexus-rpc": "^0.0.2", "uuid": "^11.1.0" } }, "sha512-ToYL+qTCO8AE7IBsk1kmCZYh2Nu6e2W8QB+H5cKp2l8VUYWljNKXfb1aguGVN1gnCsBhbcu3s7dJmltLvlOcSw=="],
+
     "@payloadcms/graphql/tsx": ["tsx@4.19.2", "", { "dependencies": { "esbuild": "0.23.1", "get-tsconfig": "4.10.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g=="],
 
     "@payloadcms/next/@dnd-kit/core": ["@dnd-kit/core@6.0.8", "", { "dependencies": { "@dnd-kit/accessibility": "3.1.1", "@dnd-kit/utilities": "3.2.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "19.1.0", "react-dom": "19.1.0" } }, "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA=="],
@@ -3564,6 +3567,12 @@
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
+    "@orbit/automation-worker/@temporalio/client/@temporalio/common": ["@temporalio/common@1.18.1", "", { "dependencies": { "@temporalio/proto": "1.18.1", "long": "^5.2.3", "ms": "3.0.0-canary.1", "nexus-rpc": "^0.0.2", "proto3-json-serializer": "^2.0.0" } }, "sha512-2hYWRKmY8WLt/8Nkrx2tziGAoNcbHDWbQR8AGvJ2xcap5E3hTIQPiNDARUm0tyCEK9umnCQztndbDxzLcxUZeA=="],
+
+    "@orbit/automation-worker/@temporalio/client/@temporalio/proto": ["@temporalio/proto@1.18.1", "", { "dependencies": { "long": "^5.2.3", "protobufjs": "7.5.8" } }, "sha512-pLa1JkmVwGdoFPCmb9DJ4P0z2mk3Zyu1VW6pXvJiYjt6W52Vm7YYi0caqfcSs/Wb/ZamdMbGqMcezftzVdzkYg=="],
+
+    "@orbit/automation-worker/@temporalio/client/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
     "@payloadcms/graphql/tsx/esbuild": ["esbuild@0.23.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.23.1", "@esbuild/android-arm": "0.23.1", "@esbuild/android-arm64": "0.23.1", "@esbuild/android-x64": "0.23.1", "@esbuild/darwin-arm64": "0.23.1", "@esbuild/darwin-x64": "0.23.1", "@esbuild/freebsd-arm64": "0.23.1", "@esbuild/freebsd-x64": "0.23.1", "@esbuild/linux-arm": "0.23.1", "@esbuild/linux-arm64": "0.23.1", "@esbuild/linux-ia32": "0.23.1", "@esbuild/linux-loong64": "0.23.1", "@esbuild/linux-mips64el": "0.23.1", "@esbuild/linux-ppc64": "0.23.1", "@esbuild/linux-riscv64": "0.23.1", "@esbuild/linux-s390x": "0.23.1", "@esbuild/linux-x64": "0.23.1", "@esbuild/netbsd-x64": "0.23.1", "@esbuild/openbsd-arm64": "0.23.1", "@esbuild/openbsd-x64": "0.23.1", "@esbuild/sunos-x64": "0.23.1", "@esbuild/win32-arm64": "0.23.1", "@esbuild/win32-ia32": "0.23.1", "@esbuild/win32-x64": "0.23.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg=="],
 
     "@payloadcms/graphql/tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -3750,6 +3759,10 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
+    "@orbit/automation-worker/@temporalio/client/@temporalio/common/ms": ["ms@3.0.0-canary.1", "", {}, "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="],
+
+    "@orbit/automation-worker/@temporalio/client/@temporalio/proto/protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
+
     "@payloadcms/graphql/tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.23.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ=="],
 
     "@payloadcms/graphql/tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.23.1", "", { "os": "android", "cpu": "arm" }, "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ=="],
@@ -3819,6 +3832,10 @@
     "@vue/compiler-core/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@vue/compiler-sfc/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@orbit/automation-worker/@temporalio/client/@temporalio/proto/protobufjs/@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@orbit/automation-worker/@temporalio/client/@temporalio/proto/protobufjs/@types/node": ["@types/node@22.19.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w=="],
 
     "@temporalio/activity/@temporalio/client/@temporalio/proto/protobufjs/@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
 

--- a/orbit-www/services/automation-worker/README.md
+++ b/orbit-www/services/automation-worker/README.md
@@ -1,12 +1,21 @@
 # @orbit/automation-worker
 
-Temporal worker that fires **`schedule`-type Orbit automations** (P4.2).
+Temporal worker that runs two things on the dedicated `orbit-automations` task
+queue:
+
+1. **`schedule`-type Orbit automations** (P4.2) — the original purpose.
+2. **The nightly scheduled scorecard evaluation sweep** (scorecards roadmap
+   item 1) — see [Scorecard evaluation sweep](#scorecard-evaluation-sweep) below.
+
+Both workflows are bundled from `src/workflows/index.ts`; each Temporal Schedule
+action resolves its workflow by exported name.
+
+## Automations dispatch
 
 Each schedule automation owns a Temporal Schedule (created by the Next.js app via
 `@temporalio/client`). When a schedule is due, Temporal starts the thin
-`AutomationDispatchWorkflow` on the dedicated `orbit-automations` task queue. The
-workflow's single activity, `dispatchScheduledAutomation`, POSTs to orbit-www's
-existing internal route:
+`AutomationDispatchWorkflow`. The workflow's single activity,
+`dispatchScheduledAutomation`, POSTs to orbit-www's existing internal route:
 
 ```
 POST ${ORBIT_API_URL}/api/internal/automations/dispatch
@@ -20,18 +29,56 @@ Payload/Mongo/`server-only` code.
 
 See `docs/plans/2026-06-27-automation-temporal-ts-worker.md` for the full design.
 
+## Scorecard evaluation sweep
+
+A single **global** nightly Temporal Schedule (`scorecard-evaluation:global`)
+keeps scores, golden-path alignment, and report trends fresh without anyone
+clicking "Evaluate now". When due, Temporal starts `ScorecardEvaluationSweepWorkflow`,
+which:
+
+1. Lists every enabled scorecard (across all workspaces) via the
+   `listEnabledScorecards` activity → `GET ${ORBIT_API_URL}/api/internal/scorecards/due`.
+2. Evaluates each scorecard via the `evaluateScorecard` activity →
+   `POST ${ORBIT_API_URL}/api/internal/scorecards/evaluate` with body
+   `{ "scorecardId": "<id>" }`, at **bounded concurrency (3)** to avoid hammering
+   the app. Per-scorecard failures are caught and collected — one bad scorecard
+   never aborts the sweep.
+3. Returns `{ total, succeeded, failed: [{ scorecardId, error }] }` so the
+   Temporal UI shows exactly what happened.
+
+Score snapshots and entity-score recompute need no extra calls: the `/evaluate`
+route's `runScorecardEvaluation` already recomputes workspace scores and captures
+snapshots (a 30-min throttle collapses multiple scorecards per workspace into one
+snapshot set per sweep).
+
+**The worker self-manages this Schedule.** At startup, BEFORE it begins polling,
+it idempotently creates-or-converges `scorecard-evaluation:global` (create, catch
+`ScheduleAlreadyRunning`, update) honoring the cron + disabled env. This ensure is
+**fatal on failure** (fail-closed): a worker that can't guarantee its Schedule
+exits nonzero and the deployment restarts it. There is no app-side bootstrap and
+no manual step.
+
+Activity error semantics mirror the dispatch activity: a 4xx is terminal
+(non-retryable `ApplicationFailure` — Temporal stops), any other non-2xx
+(5xx/network) is retryable, and env is validated at call time with actionable
+messages.
+
+See `docs/plans/2026-07-02-scheduled-scorecard-evaluation.md` for the full design.
+
 ## Environment variables
 
 | Var | Default | Read in | Purpose |
 |---|---|---|---|
 | `TEMPORAL_ADDRESS` | `localhost:7233` | worker | Temporal frontend `host:port`. |
 | `TEMPORAL_NAMESPACE` | `default` | worker | Temporal namespace to poll. |
-| `ORBIT_API_URL` | — (**required**) | activity | Base URL of the Next.js app, e.g. `http://localhost:3000`. |
-| `ORBIT_INTERNAL_API_KEY` | — (**required**) | activity | Key for the internal dispatch route (`X-API-Key`). |
-| `AUTOMATION_SCHEDULE_TZ` | `UTC` | Next.js (schedule lifecycle) | Schedule timezone. Not read by this worker; listed for completeness. |
+| `ORBIT_API_URL` | — (**required**) | activities | Base URL of the Next.js app, e.g. `http://localhost:3000`. |
+| `ORBIT_INTERNAL_API_KEY` | — (**required**) | activities | Key for the internal routes (`X-API-Key`). |
+| `SCORECARD_EVAL_CRON` | `0 5 * * *` | worker (schedule ensure) | Sweep cadence (05:00 UTC nightly by default). |
+| `SCORECARD_EVAL_DISABLED` | unset | worker (schedule ensure) | `1`/`true` ⇒ the sweep Schedule is converged to **paused** (also pauses an existing one); unset/`0` ⇒ unpaused. |
+| `AUTOMATION_SCHEDULE_TZ` | `UTC` | worker (schedule ensure) | Timezone for the sweep cron. Shared with the automations convention. |
 
-The activity throws a clear error if `ORBIT_API_URL` or `ORBIT_INTERNAL_API_KEY`
-is missing, and throws on any non-2xx dispatch response so Temporal retries
+The activities throw a clear error if `ORBIT_API_URL` or `ORBIT_INTERNAL_API_KEY`
+is missing, and throw on any non-2xx response so Temporal retries
 (`maximumAttempts: 5`).
 
 ## Running (Phase 1, local)
@@ -50,8 +97,10 @@ cd orbit-www && bun run dev
 cd orbit-www && bun run worker:automations
 ```
 
-A clean startup logs the task queue, namespace, and Temporal address. The worker
-drains in-flight work on `SIGINT`/`SIGTERM` and exits non-zero on a fatal error.
+A clean startup logs the sweep-schedule ensure (id + cron + paused state), then
+the task queue, namespace, and Temporal address. The worker drains in-flight work
+on `SIGINT`/`SIGTERM` and exits non-zero on a fatal error (including a
+schedule-ensure failure at startup).
 
 ## Typecheck
 

--- a/orbit-www/services/automation-worker/package.json
+++ b/orbit-www/services/automation-worker/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@temporalio/activity": "^1.13.0",
+    "@temporalio/client": "^1.13.0",
     "@temporalio/worker": "^1.13.0",
     "@temporalio/workflow": "^1.13.0",
     "tsx": "^4.19.2"

--- a/orbit-www/services/automation-worker/src/activities/scorecard-sweep.test.ts
+++ b/orbit-www/services/automation-worker/src/activities/scorecard-sweep.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ApplicationFailure } from '@temporalio/activity'
+import { listEnabledScorecards, evaluateScorecard } from './scorecard-sweep'
+
+/**
+ * Scorecard-sweep activity tests. Mirrors the dispatch activity tests: a global
+ * `fetch` stub + env save/restore, asserting the request shape and the error
+ * semantics that Temporal's retry policy depends on — a TERMINAL failure (4xx)
+ * surfaces as a non-retryable {@link ApplicationFailure} so Temporal STOPS, while
+ * a transient failure (5xx/network) stays a plain retryable Error.
+ */
+
+function mockFetch(impl: () => Promise<Response> | Response) {
+  const fn = vi.fn(impl)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  process.env.ORBIT_API_URL = 'http://orbit.test'
+  process.env.ORBIT_INTERNAL_API_KEY = 'secret'
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('listEnabledScorecards', () => {
+  it('GETs the /due route with the API key and parses the scorecards array', async () => {
+    const fetchFn = mockFetch(() =>
+      jsonResponse(200, {
+        scorecards: [
+          { id: 's1', workspaceId: 'ws1' },
+          { id: 's2', workspaceId: 'ws2' },
+        ],
+      }),
+    )
+
+    const result = await listEnabledScorecards()
+
+    expect(result).toEqual([
+      { id: 's1', workspaceId: 'ws1' },
+      { id: 's2', workspaceId: 'ws2' },
+    ])
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('http://orbit.test/api/internal/scorecards/due')
+    expect(init.method).toBe('GET')
+    expect((init.headers as Record<string, string>)['X-API-Key']).toBe('secret')
+  })
+
+  it('returns an empty list when the route reports no scorecards', async () => {
+    mockFetch(() => jsonResponse(200, { scorecards: [] }))
+    await expect(listEnabledScorecards()).resolves.toEqual([])
+  })
+
+  it('tolerates a missing scorecards field by returning an empty list', async () => {
+    mockFetch(() => jsonResponse(200, {}))
+    await expect(listEnabledScorecards()).resolves.toEqual([])
+  })
+
+  it('throws a NON-retryable ApplicationFailure on a 4xx response', async () => {
+    mockFetch(() => jsonResponse(403, { error: 'forbidden' }))
+    const err = await listEnabledScorecards().catch((e) => e)
+    expect(err).toBeInstanceOf(ApplicationFailure)
+    expect((err as ApplicationFailure).nonRetryable).toBe(true)
+    expect((err as Error).message).toContain('403')
+  })
+
+  it('throws a plain (retryable) Error on a 5xx response', async () => {
+    mockFetch(() => jsonResponse(500, { error: 'kaboom' }))
+    const err = await listEnabledScorecards().catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('500')
+  })
+
+  it('throws a retryable Error naming ORBIT_API_URL when it is missing', async () => {
+    delete process.env.ORBIT_API_URL
+    const fetchFn = mockFetch(() => jsonResponse(200, { scorecards: [] }))
+    const err = await listEnabledScorecards().catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('ORBIT_API_URL')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('throws a retryable Error naming ORBIT_INTERNAL_API_KEY when it is missing', async () => {
+    delete process.env.ORBIT_INTERNAL_API_KEY
+    const fetchFn = mockFetch(() => jsonResponse(200, { scorecards: [] }))
+    const err = await listEnabledScorecards().catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('ORBIT_INTERNAL_API_KEY')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})
+
+describe('evaluateScorecard', () => {
+  it('POSTs the /evaluate route with the API key and a JSON body', async () => {
+    const fetchFn = mockFetch(() => jsonResponse(200, { ok: true }))
+
+    await expect(evaluateScorecard({ scorecardId: 's1' })).resolves.toBeUndefined()
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('http://orbit.test/api/internal/scorecards/evaluate')
+    expect(init.method).toBe('POST')
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-API-Key']).toBe('secret')
+    expect(headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual({ scorecardId: 's1' })
+  })
+
+  it('throws a NON-retryable ApplicationFailure on a 4xx response', async () => {
+    mockFetch(() => jsonResponse(422, { error: 'bad scorecard' }))
+    const err = await evaluateScorecard({ scorecardId: 's1' }).catch((e) => e)
+    expect(err).toBeInstanceOf(ApplicationFailure)
+    expect((err as ApplicationFailure).nonRetryable).toBe(true)
+    expect((err as Error).message).toContain('422')
+    expect((err as Error).message).toContain('s1')
+  })
+
+  it('throws a plain (retryable) Error on a 5xx response', async () => {
+    mockFetch(() => jsonResponse(503, { error: 'unavailable' }))
+    const err = await evaluateScorecard({ scorecardId: 's1' }).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('503')
+  })
+
+  it('throws a retryable Error naming ORBIT_API_URL when it is missing', async () => {
+    delete process.env.ORBIT_API_URL
+    const fetchFn = mockFetch(() => jsonResponse(200, {}))
+    const err = await evaluateScorecard({ scorecardId: 's1' }).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('ORBIT_API_URL')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('throws a retryable Error naming ORBIT_INTERNAL_API_KEY when it is missing', async () => {
+    delete process.env.ORBIT_INTERNAL_API_KEY
+    const fetchFn = mockFetch(() => jsonResponse(200, {}))
+    const err = await evaluateScorecard({ scorecardId: 's1' }).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).not.toBeInstanceOf(ApplicationFailure)
+    expect((err as Error).message).toContain('ORBIT_INTERNAL_API_KEY')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/orbit-www/services/automation-worker/src/activities/scorecard-sweep.ts
+++ b/orbit-www/services/automation-worker/src/activities/scorecard-sweep.ts
@@ -1,0 +1,111 @@
+/**
+ * Activities for the scheduled scorecard evaluation sweep (scorecards roadmap
+ * item 1).
+ *
+ * These run in plain Node (NOT the workflow sandbox), so they are free to read
+ * the environment and use global `fetch`. Like the automation dispatch activity,
+ * they stay deliberately thin: all real work (listing enabled scorecards,
+ * running `runScorecardEvaluation`, recomputing entity scores, capturing
+ * snapshots) lives behind the internal scorecard routes in orbit-www. The
+ * activities' only job is to call those routes and to fail loudly so Temporal
+ * retries.
+ *
+ * See docs/plans/2026-07-02-scheduled-scorecard-evaluation.md.
+ */
+
+import { ApplicationFailure } from '@temporalio/activity'
+
+import type { DueScorecard } from '../shared'
+
+/**
+ * Read the two required internal-API env vars at CALL time (not module scope) so
+ * the worker picks up config without a restart-order dependency and so missing
+ * config produces a clear, actionable error rather than a silent `undefined` in
+ * the URL.
+ *
+ * @throws a plain (retryable) Error naming the first missing var.
+ */
+function readInternalApiConfig(activity: string): { apiUrl: string; apiKey: string } {
+  const apiUrl = process.env.ORBIT_API_URL
+  if (!apiUrl) {
+    throw new Error(`${activity}: missing required env var ORBIT_API_URL`)
+  }
+  const apiKey = process.env.ORBIT_INTERNAL_API_KEY
+  if (!apiKey) {
+    throw new Error(`${activity}: missing required env var ORBIT_INTERNAL_API_KEY`)
+  }
+  return { apiUrl, apiKey }
+}
+
+/**
+ * Classify a non-2xx response the same way the dispatch activity does: a 4xx is
+ * TERMINAL (the request itself is wrong and will never succeed on retry) → a
+ * non-retryable {@link ApplicationFailure} so Temporal stops the retry storm; any
+ * other non-2xx (5xx/network) is transient → a plain Error that Temporal retries
+ * per the workflow policy.
+ */
+async function throwForResponse(activity: string, response: Response, context: string): Promise<never> {
+  const body = await response.text().catch(() => '<unreadable response body>')
+  const message = `${activity}: ${context} returned ${response.status} ${response.statusText}: ${body}`
+  if (response.status >= 400 && response.status < 500) {
+    throw ApplicationFailure.nonRetryable(message, 'ScorecardSweepTerminal')
+  }
+  throw new Error(message)
+}
+
+/**
+ * List every enabled scorecard (across all workspaces) that is due for the
+ * nightly sweep, via GET `${ORBIT_API_URL}/api/internal/scorecards/due`.
+ *
+ * @throws if env is missing, or if the route responds non-2xx (4xx →
+ *   non-retryable, else retryable).
+ */
+export async function listEnabledScorecards(): Promise<DueScorecard[]> {
+  const { apiUrl, apiKey } = readInternalApiConfig('listEnabledScorecards')
+
+  const url = `${apiUrl}/api/internal/scorecards/due`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey,
+    },
+  })
+
+  if (!response.ok) {
+    await throwForResponse('listEnabledScorecards', response, 'due route')
+  }
+
+  const data = (await response.json()) as { scorecards?: DueScorecard[] }
+  return data.scorecards ?? []
+}
+
+/**
+ * Trigger evaluation of a single scorecard via POST
+ * `${ORBIT_API_URL}/api/internal/scorecards/evaluate`. The route re-runs the
+ * scorecard pipeline (which also recomputes entity scores and captures score
+ * snapshots), so the sweep needs no extra calls for trend history.
+ *
+ * @throws if env is missing, or if the route responds non-2xx (4xx →
+ *   non-retryable, else retryable).
+ */
+export async function evaluateScorecard(input: { scorecardId: string }): Promise<void> {
+  const { apiUrl, apiKey } = readInternalApiConfig('evaluateScorecard')
+
+  const url = `${apiUrl}/api/internal/scorecards/evaluate`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': apiKey,
+    },
+    body: JSON.stringify({ scorecardId: input.scorecardId }),
+  })
+
+  if (!response.ok) {
+    await throwForResponse(
+      'evaluateScorecard',
+      response,
+      `evaluate route for scorecard ${input.scorecardId}`,
+    )
+  }
+}

--- a/orbit-www/services/automation-worker/src/schedule.test.ts
+++ b/orbit-www/services/automation-worker/src/schedule.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * Sweep-schedule ensure tests. A fake Temporal client (passed directly to the
+ * ensure fn) lets us assert the spec/action/state mapping and the fail-closed
+ * converge/propagate behavior without a real Temporal. `@temporalio/client` is
+ * mocked so the helper's `ScheduleAlreadyRunning instanceof` check switches on
+ * the same class the tests throw.
+ */
+
+vi.mock('@temporalio/client', () => ({
+  ScheduleAlreadyRunning: class ScheduleAlreadyRunning extends Error {
+    readonly scheduleId: string
+    constructor(message: string, scheduleId: string) {
+      super(message)
+      this.name = 'ScheduleAlreadyRunning'
+      this.scheduleId = scheduleId
+    }
+  },
+}))
+
+import { ScheduleAlreadyRunning } from '@temporalio/client'
+import { ensureScorecardSweepSchedule } from './schedule'
+
+function makeClient() {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const create = vi.fn(async (..._args: any[]): Promise<any> => undefined)
+  const update = vi.fn(async (..._args: any[]): Promise<any> => undefined)
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  const getHandle = vi.fn(() => ({ update }))
+  const client = { schedule: { create, getHandle } }
+  return { client, create, update, getHandle }
+}
+
+const ENV_KEYS = ['SCORECARD_EVAL_CRON', 'SCORECARD_EVAL_DISABLED', 'AUTOMATION_SCHEDULE_TZ'] as const
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+  vi.restoreAllMocks()
+})
+
+describe('ensureScorecardSweepSchedule', () => {
+  it('creates the global schedule with default cron/tz and state.paused=false', async () => {
+    const { client, create } = makeClient()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureScorecardSweepSchedule(client as any)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = create.mock.calls[0][0] as Record<string, any>
+    expect(opts.scheduleId).toBe('scorecard-evaluation:global')
+    expect(opts.spec.cronExpressions).toEqual(['0 5 * * *'])
+    expect(opts.spec.timezone).toBe('UTC')
+    expect(opts.action.type).toBe('startWorkflow')
+    expect(opts.action.workflowType).toBe('ScorecardEvaluationSweepWorkflow')
+    expect(opts.action.taskQueue).toBe('orbit-automations')
+    expect(opts.action.args ?? []).toEqual([])
+    expect(opts.state.paused).toBe(false)
+  })
+
+  it('honors SCORECARD_EVAL_CRON and AUTOMATION_SCHEDULE_TZ overrides', async () => {
+    process.env.SCORECARD_EVAL_CRON = '0 */6 * * *'
+    process.env.AUTOMATION_SCHEDULE_TZ = 'America/New_York'
+    const { client, create } = makeClient()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureScorecardSweepSchedule(client as any)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = create.mock.calls[0][0] as Record<string, any>
+    expect(opts.spec.cronExpressions).toEqual(['0 */6 * * *'])
+    expect(opts.spec.timezone).toBe('America/New_York')
+  })
+
+  it('creates paused when SCORECARD_EVAL_DISABLED=1', async () => {
+    process.env.SCORECARD_EVAL_DISABLED = '1'
+    const { client, create } = makeClient()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureScorecardSweepSchedule(client as any)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((create.mock.calls[0][0] as any).state.paused).toBe(true)
+  })
+
+  it('creates paused when SCORECARD_EVAL_DISABLED=true', async () => {
+    process.env.SCORECARD_EVAL_DISABLED = 'true'
+    const { client, create } = makeClient()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureScorecardSweepSchedule(client as any)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((create.mock.calls[0][0] as any).state.paused).toBe(true)
+  })
+
+  it('converges on ScheduleAlreadyRunning, merging spec/action/paused over prev', async () => {
+    process.env.SCORECARD_EVAL_DISABLED = '1'
+    const { client, create, getHandle, update } = makeClient()
+    create.mockRejectedValueOnce(new ScheduleAlreadyRunning('exists', 'scorecard-evaluation:global'))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureScorecardSweepSchedule(client as any)
+
+    expect(getHandle).toHaveBeenCalledWith('scorecard-evaluation:global')
+    expect(update).toHaveBeenCalledTimes(1)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateFn = update.mock.calls[0][0] as (prev: any) => any
+    const next = updateFn({
+      spec: { cronExpressions: ['stale'], timezone: 'UTC' },
+      action: { workflowType: 'Stale' },
+      state: { paused: false, note: 'keep me' },
+      policies: {},
+    })
+    expect(next.spec.cronExpressions).toEqual(['0 5 * * *'])
+    expect(next.action.workflowType).toBe('ScorecardEvaluationSweepWorkflow')
+    expect(next.state.paused).toBe(true)
+    expect(next.state.note).toBe('keep me')
+  })
+
+  it('propagates a non-already-exists create failure (fail-closed)', async () => {
+    const { client, create } = makeClient()
+    create.mockRejectedValueOnce(new Error('connection refused'))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(ensureScorecardSweepSchedule(client as any)).rejects.toThrow('connection refused')
+  })
+})

--- a/orbit-www/services/automation-worker/src/schedule.ts
+++ b/orbit-www/services/automation-worker/src/schedule.ts
@@ -1,0 +1,122 @@
+/**
+ * Temporal Schedule lifecycle for the GLOBAL scorecard evaluation sweep
+ * (scorecards roadmap item 1).
+ *
+ * Unlike automations (one Schedule per record, managed by the Next.js app), the
+ * sweep is a single global nightly Schedule that the WORKER self-manages at
+ * startup — there is no app-side bootstrap. The pattern mirrors
+ * `ensureAutomationSchedule` in `orbit-www/src/lib/temporal/automation-schedules.ts`:
+ * create, catch `ScheduleAlreadyRunning`, converge via `getHandle().update()`.
+ *
+ * FAIL-CLOSED: this PROPAGATES every non-already-exists error. The worker treats
+ * an ensure failure at startup as fatal (exits nonzero, the deployment restarts
+ * it) so we never poll a task queue whose sweep Schedule we could not guarantee.
+ *
+ * The schedule client uses `Connection` (distinct from the worker's
+ * `NativeConnection`), so this module imports `@temporalio/client` and therefore
+ * must NOT be imported by the workflow sandbox — only `worker.ts` imports it.
+ *
+ * See docs/plans/2026-07-02-scheduled-scorecard-evaluation.md.
+ */
+
+import { Client, Connection, ScheduleAlreadyRunning } from '@temporalio/client'
+
+import {
+  AUTOMATION_TASK_QUEUE,
+  DEFAULT_AUTOMATION_SCHEDULE_TZ,
+  DEFAULT_SCORECARD_EVAL_CRON,
+  SCORECARD_SWEEP_SCHEDULE_ID,
+  SCORECARD_SWEEP_WORKFLOW,
+} from './shared'
+
+/** Sweep cadence — a single global cron, overridable via env. */
+function sweepCron(): string {
+  return process.env.SCORECARD_EVAL_CRON || DEFAULT_SCORECARD_EVAL_CRON
+}
+
+/** Cron timezone — reuses the automations convention/env. */
+function sweepTimezone(): string {
+  return process.env.AUTOMATION_SCHEDULE_TZ || DEFAULT_AUTOMATION_SCHEDULE_TZ
+}
+
+/** The sweep is paused when explicitly disabled via env (`1`/`true`). */
+export function isSweepDisabled(): boolean {
+  const v = process.env.SCORECARD_EVAL_DISABLED
+  return v === '1' || v === 'true'
+}
+
+/**
+ * Create-or-converge the single global sweep Schedule on the given client.
+ * Idempotent on `SCORECARD_SWEEP_SCHEDULE_ID`: a create that races an existing
+ * Schedule falls back to an update converging spec/action/paused. The Schedule is
+ * paused when `SCORECARD_EVAL_DISABLED` is set. Throws on any real Temporal
+ * failure (fail-closed).
+ *
+ * Accepts the client as a param so it is unit-testable with a fake client; use
+ * {@link connectAndEnsureSchedule} for the connect-then-ensure convenience the
+ * worker entry point wants.
+ */
+export async function ensureScorecardSweepSchedule(client: Client): Promise<void> {
+  const paused = isSweepDisabled()
+
+  const spec = {
+    cronExpressions: [sweepCron()],
+    // NOTE: @temporalio/client@^1.13.0 spells this `timezone` (lower-case z),
+    // not `timeZone` — matching ensureAutomationSchedule.
+    timezone: sweepTimezone(),
+  }
+  const action = {
+    type: 'startWorkflow' as const,
+    workflowType: SCORECARD_SWEEP_WORKFLOW,
+    taskQueue: AUTOMATION_TASK_QUEUE,
+    // The sweep discovers its own work via the `/due` activity — no args.
+    args: [] as const,
+  }
+
+  try {
+    // No explicit overlap policy: Temporal's default is Skip, so if a sweep is
+    // still running when the next cron tick fires, that tick is skipped rather
+    // than started concurrently — exactly what we want (no pile-up of overlapping
+    // full-catalog sweeps).
+    await client.schedule.create({
+      scheduleId: SCORECARD_SWEEP_SCHEDULE_ID,
+      spec,
+      action,
+      state: { paused },
+    })
+  } catch (err) {
+    // A Schedule with this id already exists — converge it to the current spec.
+    if (err instanceof ScheduleAlreadyRunning) {
+      const handle = client.schedule.getHandle(SCORECARD_SWEEP_SCHEDULE_ID)
+      await handle.update((prev) => ({
+        ...prev,
+        spec,
+        action,
+        state: { ...prev.state, paused },
+      }))
+      return
+    }
+    throw err
+  }
+}
+
+/**
+ * Connect a schedule {@link Client} (via `Connection`, distinct from the worker's
+ * `NativeConnection`) and ensure the sweep Schedule. Returns the connection so
+ * the caller can close it after the ensure. Convenience for the worker entry
+ * point; the ensure itself is tested via {@link ensureScorecardSweepSchedule}.
+ */
+export async function connectAndEnsureSchedule(
+  address: string,
+  namespace: string,
+): Promise<Connection> {
+  const connection = await Connection.connect({ address })
+  try {
+    const client = new Client({ connection, namespace })
+    await ensureScorecardSweepSchedule(client)
+    return connection
+  } catch (err) {
+    await connection.close().catch(() => undefined)
+    throw err
+  }
+}

--- a/orbit-www/services/automation-worker/src/shared.ts
+++ b/orbit-www/services/automation-worker/src/shared.ts
@@ -1,10 +1,11 @@
 /**
- * Client-safe contract for the automation Temporal worker (P4.2).
+ * Client-safe contract for the automation Temporal worker (P4.2) and the
+ * scheduled scorecard evaluation sweep (scorecards roadmap item 1).
  *
  * Imported by BOTH the Next.js app (schedule lifecycle helpers + server actions)
  * and the worker runtime (workflow + activity + worker entry). It is the single
- * source of truth for the workflow name, task queue, schedule id, and the input
- * shape passed from a Temporal Schedule action to the dispatch workflow.
+ * source of truth for the workflow names, task queue, schedule ids, and the input
+ * shapes passed from a Temporal Schedule action to a workflow.
  *
  * INVARIANT — this module MUST stay free of:
  *   - any `@temporalio/worker | @temporalio/workflow | @temporalio/activity` import,
@@ -20,7 +21,8 @@ export const AUTOMATION_DISPATCH_WORKFLOW = 'AutomationDispatchWorkflow' as cons
 
 /**
  * Dedicated task queue for automation schedules. Isolated from the Go worker's
- * `orbit-workflows` queue so the two never poll each other's tasks.
+ * `orbit-workflows` queue so the two never poll each other's tasks. The scorecard
+ * evaluation sweep reuses this queue — it runs on the same worker process.
  */
 export const AUTOMATION_TASK_QUEUE = 'orbit-automations' as const
 
@@ -46,4 +48,44 @@ export interface AutomationDispatchInput {
  */
 export function scheduleId(automationId: string): string {
   return `automation:${automationId}`
+}
+
+// ---------------------------------------------------------------------------
+// Scheduled scorecard evaluation sweep (scorecards roadmap item 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Registered name of the scorecard evaluation sweep workflow — must match the
+ * worker's registration and the Schedule action's `workflowType`.
+ */
+export const SCORECARD_SWEEP_WORKFLOW = 'ScorecardEvaluationSweepWorkflow' as const
+
+/**
+ * Deterministic id of the single GLOBAL sweep Schedule. Unlike automations (one
+ * Schedule per record), there is exactly one nightly sweep across all workspaces,
+ * so its id is a constant rather than a function of some record id.
+ */
+export const SCORECARD_SWEEP_SCHEDULE_ID = 'scorecard-evaluation:global' as const
+
+/**
+ * Default sweep cadence: 05:00 UTC nightly. Overridable via `SCORECARD_EVAL_CRON`
+ * (read at the call site, NOT here — keeps this module sandbox-importable).
+ */
+export const DEFAULT_SCORECARD_EVAL_CRON = '0 5 * * *' as const
+
+/** One enabled scorecard due for evaluation, as returned by the `/due` route. */
+export interface DueScorecard {
+  id: string
+  workspaceId: string
+}
+
+/**
+ * Summary returned by the sweep workflow so the Temporal UI shows exactly what
+ * happened: how many scorecards were evaluated, how many succeeded, and the
+ * per-scorecard error for each that failed (a failure never aborts the sweep).
+ */
+export interface ScorecardSweepResult {
+  total: number
+  succeeded: number
+  failed: { scorecardId: string; error: string }[]
 }

--- a/orbit-www/services/automation-worker/src/worker.ts
+++ b/orbit-www/services/automation-worker/src/worker.ts
@@ -1,10 +1,16 @@
 /**
- * Long-running entry point for the automation Temporal worker (P4.2).
+ * Long-running entry point for the automation Temporal worker (P4.2) and the
+ * scheduled scorecard evaluation sweep (scorecards roadmap item 1).
  *
  * Runs as a SEPARATE Node process alongside the Next.js app — a Temporal Worker
  * is always its own process. It polls the dedicated `orbit-automations` task
- * queue, runs the dispatch workflow in the V8 sandbox, and executes the dispatch
- * activity in plain Node. All env is read here at startup.
+ * queue, runs both the automation dispatch workflow and the scorecard sweep
+ * workflow in the V8 sandbox, and executes their activities in plain Node. All
+ * env is read here at startup.
+ *
+ * Startup order: connect → ensure the global sweep Schedule (FATAL on failure —
+ * fail-closed, so a worker that can't guarantee its schedule exits nonzero and
+ * the deployment restarts it) → create the worker → run.
  *
  * ESM note: orbit-www is `type: module`, so the workflows path is resolved via
  * `import.meta.url` (NOT `require.resolve`).
@@ -14,16 +20,30 @@ import { fileURLToPath } from 'node:url'
 
 import { NativeConnection, Worker } from '@temporalio/worker'
 
-import * as activities from './activities/dispatch'
-import { AUTOMATION_TASK_QUEUE } from './shared'
+import * as dispatchActivities from './activities/dispatch'
+import * as scorecardSweepActivities from './activities/scorecard-sweep'
+import { connectAndEnsureSchedule, isSweepDisabled } from './schedule'
+import { AUTOMATION_TASK_QUEUE, DEFAULT_SCORECARD_EVAL_CRON, SCORECARD_SWEEP_SCHEDULE_ID } from './shared'
 
 async function run(): Promise<void> {
   const address = process.env.TEMPORAL_ADDRESS || 'localhost:7233'
   const namespace = process.env.TEMPORAL_NAMESPACE || 'default'
 
   // Temporal's workflow bundler needs the on-disk path to the workflows module,
-  // resolved relative to this file rather than the CWD.
-  const workflowsPath = fileURLToPath(new URL('./workflows/automation-dispatch.ts', import.meta.url))
+  // resolved relative to this file rather than the CWD. The barrel re-exports
+  // BOTH workflows so each Schedule action resolves its workflow by name.
+  const workflowsPath = fileURLToPath(new URL('./workflows/index.ts', import.meta.url))
+
+  // FATAL if this rejects: we refuse to poll a task queue whose sweep Schedule we
+  // could not guarantee. The Connection is closed after the ensure — the worker
+  // uses its own NativeConnection to poll.
+  const scheduleConnection = await connectAndEnsureSchedule(address, namespace)
+  await scheduleConnection.close()
+  console.log(
+    `[automation-worker] sweep schedule ensured — id "${SCORECARD_SWEEP_SCHEDULE_ID}", cron "${
+      process.env.SCORECARD_EVAL_CRON || DEFAULT_SCORECARD_EVAL_CRON
+    }", paused ${isSweepDisabled()}`,
+  )
 
   const connection = await NativeConnection.connect({ address })
 
@@ -32,7 +52,7 @@ async function run(): Promise<void> {
     namespace,
     taskQueue: AUTOMATION_TASK_QUEUE,
     workflowsPath,
-    activities,
+    activities: { ...dispatchActivities, ...scorecardSweepActivities },
   })
 
   console.log(
@@ -40,7 +60,7 @@ async function run(): Promise<void> {
   )
 
   // Drain in-flight work cleanly on termination so a redeploy doesn't drop a
-  // due dispatch mid-flight.
+  // due dispatch or a running sweep mid-flight.
   const shutdown = (signal: string): void => {
     console.log(`[automation-worker] received ${signal}, shutting down…`)
     worker.shutdown()

--- a/orbit-www/services/automation-worker/src/workflows/concurrency.test.ts
+++ b/orbit-www/services/automation-worker/src/workflows/concurrency.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { runWithConcurrency } from './concurrency'
+
+/**
+ * Unit tests for the sandbox-safe bounded-concurrency helper used by the
+ * scorecard sweep. The helper is pure JS (no Temporal/Node imports) so it is
+ * safe to import from a workflow module; these tests exercise it directly.
+ *
+ * The three invariants: results come back in INPUT order regardless of
+ * completion order; no more than `limit` tasks run concurrently; and an error
+ * from any task rejects the whole call.
+ */
+
+/** A controllable async task: resolves when `release()` is called. */
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('runWithConcurrency', () => {
+  it('returns results in input order even when tasks finish out of order', async () => {
+    const items = [10, 20, 30, 40]
+    // Finish in reverse order but expect input-order results.
+    const result = await runWithConcurrency(items, 2, async (n) => {
+      await new Promise((r) => setTimeout(r, (50 - n) / 5))
+      return n * 2
+    })
+    expect(result).toEqual([20, 40, 60, 80])
+  })
+
+  it('never runs more than `limit` tasks concurrently', async () => {
+    const items = [0, 1, 2, 3, 4, 5]
+    let inFlight = 0
+    let maxInFlight = 0
+    const gates = items.map(() => deferred<void>())
+
+    const promise = runWithConcurrency(items, 3, async (i) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await gates[i].promise
+      inFlight--
+      return i
+    })
+
+    // Let the scheduler start the first wave.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(maxInFlight).toBe(3)
+
+    // Release everything and let it drain.
+    gates.forEach((g) => g.resolve())
+    const result = await promise
+    expect(result).toEqual(items)
+    expect(maxInFlight).toBe(3)
+  })
+
+  it('propagates a task error to the caller', async () => {
+    const items = [1, 2, 3]
+    await expect(
+      runWithConcurrency(items, 2, async (n) => {
+        if (n === 2) throw new Error('boom')
+        return n
+      }),
+    ).rejects.toThrow('boom')
+  })
+
+  it('handles an empty input list', async () => {
+    const result = await runWithConcurrency([], 3, async (n) => n)
+    expect(result).toEqual([])
+  })
+
+  it('handles a limit larger than the number of items', async () => {
+    const result = await runWithConcurrency([1, 2], 10, async (n) => n * 10)
+    expect(result).toEqual([10, 20])
+  })
+})
+
+/**
+ * Tests for `errorDetail` — the helper that pulls the useful message out of a
+ * rejected activity. After retry exhaustion `proxyActivities` rejects with an
+ * ActivityFailure whose `.message` is framework-generic ("Activity task failed")
+ * and whose real "…returned 500: <body>" detail is in `.cause`, so we prefer the
+ * cause's message when present.
+ */
+import { errorDetail } from './concurrency'
+
+describe('errorDetail', () => {
+  it('returns the message of a plain Error', () => {
+    expect(errorDetail(new Error('boom'))).toBe('boom')
+  })
+
+  it('prefers the cause message when an Error has an Error cause', () => {
+    const cause = new Error('evaluateScorecard: evaluate route returned 500: kaboom')
+    const err = new Error('Activity task failed', { cause })
+    expect(errorDetail(err)).toBe('evaluateScorecard: evaluate route returned 500: kaboom')
+  })
+
+  it('falls back to the outer message when the cause is not an Error', () => {
+    const err = new Error('outer', { cause: 'a string cause' })
+    expect(errorDetail(err)).toBe('outer')
+  })
+
+  it('stringifies a non-Error value', () => {
+    expect(errorDetail('just a string')).toBe('just a string')
+    expect(errorDetail(42)).toBe('42')
+  })
+})

--- a/orbit-www/services/automation-worker/src/workflows/concurrency.ts
+++ b/orbit-www/services/automation-worker/src/workflows/concurrency.ts
@@ -1,0 +1,65 @@
+/**
+ * Bounded-concurrency runner + error-detail extraction — pure JS, sandbox-safe.
+ *
+ * INVARIANT: this module imports NOTHING (no Temporal, no Node), so it is safe to
+ * import from a Temporal workflow module that runs in the deterministic V8
+ * sandbox. It uses only `Promise` and array primitives — no timers, no
+ * `Date.now()`, no `Math.random()`.
+ */
+
+/**
+ * Run `fn` over `items` with at most `limit` invocations in flight at once, and
+ * return the results in INPUT order (index-stable) regardless of the order in
+ * which the individual tasks settle. Any task rejection rejects the whole call
+ * (first error wins); callers that need per-item error isolation should have `fn`
+ * catch internally and return a result sentinel — which is exactly what the
+ * scorecard sweep does so one bad scorecard never aborts the sweep.
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  // Shared cursor: each worker atomically (single-threaded event loop) claims
+  // the next index, so exactly `min(limit, items.length)` workers race through
+  // the list without ever exceeding the limit.
+  let next = 0
+
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await fn(items[index], index)
+    }
+  }
+
+  const workerCount = Math.max(0, Math.min(limit, items.length))
+  const workers: Promise<void>[] = []
+  for (let i = 0; i < workerCount; i++) {
+    workers.push(worker())
+  }
+  await Promise.all(workers)
+
+  return results
+}
+
+/**
+ * Extract the human-useful detail from a rejected value.
+ *
+ * A `proxyActivities` call that exhausts its retries rejects with an
+ * ActivityFailure whose own `.message` is framework-generic ("Activity task
+ * failed") — the real "…returned 500: <body>" detail lives in `.cause`. So when
+ * `err` is an Error whose `cause` is also an Error, prefer the cause's message;
+ * otherwise fall back to the Error's own message, and finally to `String(err)`
+ * for non-Error rejections. Kept sandbox-safe (no imports) so the workflow can
+ * use it directly.
+ */
+export function errorDetail(err: unknown): string {
+  if (err instanceof Error) {
+    if (err.cause instanceof Error) {
+      return err.cause.message
+    }
+    return err.message
+  }
+  return String(err)
+}

--- a/orbit-www/services/automation-worker/src/workflows/index.ts
+++ b/orbit-www/services/automation-worker/src/workflows/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Workflows barrel — the single module `worker.ts` points `workflowsPath` at.
+ *
+ * Temporal resolves a Schedule action's workflow by its EXPORTED NAME from the
+ * bundled workflows module, so every workflow that a Schedule can start MUST be
+ * re-exported here. Keeping both workflows in one barrel is what lets the
+ * automation schedules and the scorecard sweep schedule share one worker/task
+ * queue without either one's action failing to resolve.
+ */
+
+export { AutomationDispatchWorkflow } from './automation-dispatch'
+export { ScorecardEvaluationSweepWorkflow } from './scorecard-sweep'

--- a/orbit-www/services/automation-worker/src/workflows/scorecard-sweep.ts
+++ b/orbit-www/services/automation-worker/src/workflows/scorecard-sweep.ts
@@ -1,0 +1,67 @@
+/**
+ * The scorecard evaluation sweep workflow — thin, but with fan-out.
+ *
+ * Runs in Temporal's deterministic V8 sandbox: NO Node APIs, NO `Date.now()` /
+ * `Math.random()`, NO Payload/Mongo imports. Activity imports are TYPE-only so
+ * the sandbox never loads the activities' Node code; `proxyActivities` resolves
+ * them on the worker side at run time. The `runWithConcurrency` / `errorDetail`
+ * helpers are pure JS (import nothing) so they are safe to import here.
+ *
+ * The exported function name MUST equal SCORECARD_SWEEP_WORKFLOW
+ * ('ScorecardEvaluationSweepWorkflow') — the Temporal Schedule action starts the
+ * workflow by that name.
+ *
+ * Flow: list every enabled scorecard, then evaluate each with bounded
+ * concurrency (3) to avoid hammering the app. Per-item failures are CAUGHT and
+ * collected — one bad scorecard must never abort the sweep — and reported in the
+ * result so the Temporal UI shows exactly what happened.
+ *
+ * See docs/plans/2026-07-02-scheduled-scorecard-evaluation.md.
+ */
+
+import { proxyActivities } from '@temporalio/workflow'
+
+import type * as activities from '../activities/scorecard-sweep'
+import type { ScorecardSweepResult } from '../shared'
+import { errorDetail, runWithConcurrency } from './concurrency'
+
+/** How many scorecard evaluations run at once. Keeps app load bounded. */
+const EVALUATION_CONCURRENCY = 3
+
+const { listEnabledScorecards } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1m',
+  retry: { maximumAttempts: 5 },
+})
+
+const { evaluateScorecard } = proxyActivities<typeof activities>({
+  // A big-workspace evaluation is slow — give it a generous window.
+  startToCloseTimeout: '5m',
+  retry: { maximumAttempts: 5 },
+})
+
+export async function ScorecardEvaluationSweepWorkflow(): Promise<ScorecardSweepResult> {
+  const scorecards = await listEnabledScorecards()
+
+  // Per-item errors are captured (never thrown) so a single failing scorecard
+  // cannot abort the sweep; `runWithConcurrency` only rejects on a thrown error,
+  // so we always resolve to a sentinel. `errorDetail` digs the real HTTP detail
+  // out of the retry-exhausted ActivityFailure's `.cause`.
+  const outcomes = await runWithConcurrency(scorecards, EVALUATION_CONCURRENCY, async (scorecard) => {
+    try {
+      await evaluateScorecard({ scorecardId: scorecard.id })
+      return { ok: true as const }
+    } catch (err) {
+      return { ok: false as const, scorecardId: scorecard.id, error: errorDetail(err) }
+    }
+  })
+
+  const failed = outcomes
+    .filter((o): o is { ok: false; scorecardId: string; error: string } => !o.ok)
+    .map(({ scorecardId, error }) => ({ scorecardId, error }))
+
+  return {
+    total: scorecards.length,
+    succeeded: scorecards.length - failed.length,
+    failed,
+  }
+}

--- a/orbit-www/src/app/api/internal/scorecards/due/route.test.ts
+++ b/orbit-www/src/app/api/internal/scorecards/due/route.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+vi.stubEnv('ORBIT_INTERNAL_API_KEY', 'test-api-key')
+
+// Import after mocking env
+import { getPayload } from 'payload'
+const { GET } = await import('./route')
+
+function req(apiKey?: string | null) {
+  const headers: Record<string, string> = {}
+  if (apiKey) headers['X-API-Key'] = apiKey
+  return new Request('http://localhost/api/internal/scorecards/due', {
+    method: 'GET',
+    headers,
+  })
+}
+
+describe('GET /api/internal/scorecards/due', () => {
+  const mockPayload = {
+    find: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(getPayload as any).mockResolvedValue(mockPayload)
+  })
+
+  it('returns 401 without an API key', async () => {
+    const response = await GET(req(null) as any)
+    expect(response.status).toBe(401)
+    expect(mockPayload.find).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 with the wrong API key', async () => {
+    const response = await GET(req('wrong-key') as any)
+    expect(response.status).toBe(401)
+    expect(mockPayload.find).not.toHaveBeenCalled()
+  })
+
+  it('returns only enabled scorecards with workspace normalized to a string id', async () => {
+    mockPayload.find.mockResolvedValueOnce({
+      docs: [
+        { id: 'sc-1', workspace: 'ws-1' },
+        { id: 'sc-2', workspace: { id: 'ws-2', slug: 'ws-two' } },
+      ],
+      hasNextPage: false,
+    })
+
+    const response = await GET(req('test-api-key') as any)
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data).toEqual({
+      scorecards: [
+        { id: 'sc-1', workspaceId: 'ws-1' },
+        { id: 'sc-2', workspaceId: 'ws-2' },
+      ],
+    })
+
+    expect(mockPayload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'scorecards',
+        where: { enabled: { equals: true } },
+      }),
+    )
+  })
+
+  it('skips rows with a missing workspace', async () => {
+    mockPayload.find.mockResolvedValueOnce({
+      docs: [
+        { id: 'sc-1', workspace: 'ws-1' },
+        { id: 'sc-2', workspace: null },
+        { id: 'sc-3' },
+      ],
+      hasNextPage: false,
+    })
+
+    const response = await GET(req('test-api-key') as any)
+    const data = await response.json()
+    expect(data.scorecards).toEqual([{ id: 'sc-1', workspaceId: 'ws-1' }])
+  })
+
+  it('paginates across multiple pages', async () => {
+    mockPayload.find
+      .mockResolvedValueOnce({
+        docs: [{ id: 'sc-1', workspace: 'ws-1' }],
+        hasNextPage: true,
+      })
+      .mockResolvedValueOnce({
+        docs: [{ id: 'sc-2', workspace: 'ws-2' }],
+        hasNextPage: false,
+      })
+
+    const response = await GET(req('test-api-key') as any)
+    const data = await response.json()
+    expect(data.scorecards).toEqual([
+      { id: 'sc-1', workspaceId: 'ws-1' },
+      { id: 'sc-2', workspaceId: 'ws-2' },
+    ])
+    expect(mockPayload.find).toHaveBeenCalledTimes(2)
+    expect(mockPayload.find).toHaveBeenNthCalledWith(1, expect.objectContaining({ page: 1 }))
+    expect(mockPayload.find).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }))
+  })
+
+  it('returns 500 when payload throws', async () => {
+    mockPayload.find.mockRejectedValueOnce(new Error('db exploded'))
+
+    const response = await GET(req('test-api-key') as any)
+    expect(response.status).toBe(500)
+    const data = await response.json()
+    expect(data.error).toBe('db exploded')
+  })
+})

--- a/orbit-www/src/app/api/internal/scorecards/due/route.ts
+++ b/orbit-www/src/app/api/internal/scorecards/due/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { validateInternalApiKey } from '@/lib/auth/internal-api-auth'
+
+const PAGE_SIZE = 100
+
+/**
+ * GET /api/internal/scorecards/due
+ *
+ * Lists every enabled scorecard across every workspace. This is the machine
+ * sweep surface the Temporal `ScorecardEvaluationSweepWorkflow` polls
+ * nightly to decide what to POST to `/api/internal/scorecards/evaluate` —
+ * there is no tenant filter, same trust level as `evaluate`.
+ *
+ * Auth: X-API-Key validated against ORBIT_INTERNAL_API_KEY (constant-time).
+ *
+ * Response: { scorecards: [{ id, workspaceId }] }
+ */
+export async function GET(request: NextRequest) {
+  const authError = validateInternalApiKey(request.headers.get('X-API-Key'))
+  if (authError) return authError
+
+  try {
+    const payload = await getPayload({ config: configPromise })
+    const scorecards: { id: string; workspaceId: string }[] = []
+
+    for (let page = 1; ; page++) {
+      const res = await payload.find({
+        collection: 'scorecards',
+        where: { enabled: { equals: true } },
+        limit: PAGE_SIZE,
+        page,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      for (const doc of res.docs as { id: string; workspace?: unknown }[]) {
+        const workspaceId =
+          typeof doc.workspace === 'string'
+            ? doc.workspace
+            : (doc.workspace as { id?: string } | null | undefined)?.id
+
+        if (!workspaceId) continue
+        scorecards.push({ id: doc.id, workspaceId })
+      }
+
+      if (!res.hasNextPage) break
+    }
+
+    return NextResponse.json({ scorecards })
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

Delivers item 1 of the scorecards roadmap (`docs/plans/2026-07-02-scorecards-roadmap.md`): scores, golden-path alignment, and report trends now stay fresh **without anyone clicking "Evaluate now"**.

- **Self-managing global Temporal Schedule** `scorecard-evaluation:global` (default `0 5 * * *` UTC, override `SCORECARD_EVAL_CRON`, pause with `SCORECARD_EVAL_DISABLED=1`) — idempotently created/converged by the automation worker at startup, fail-closed (ensure failure exits nonzero).
- **`ScorecardEvaluationSweepWorkflow`** on the existing `orbit-automations` queue/worker (no new deployable): lists enabled scorecards via the new internal route, evaluates each via the existing `/api/internal/scorecards/evaluate` with bounded concurrency (3); per-item failures are isolated and reported in the run result `{ total, succeeded, failed[] }` with real HTTP error detail (ActivityFailure cause unwrapped).
- **New internal route** `GET /api/internal/scorecards/due` (X-API-Key, fail-closed 401): all enabled scorecards across workspaces, paginated per repo convention.
- Snapshots/recompute need no extra calls — `runScorecardEvaluation` already chains them, and the 30-min snapshot throttle collapses each sweep into one snapshot set per workspace.
- Also: scorecards roadmap doc, scheduled-evaluation plan doc, and marks the shipped 2026-07-01 plans (PRs #56, #59) accordingly.

## Design
`docs/plans/2026-07-02-scheduled-scorecard-evaluation.md` — mirrors the P4.2 automation-schedule patterns (create→converge, 4xx nonretryable / 5xx retryable activities, sandbox-safe contract module).

## Verification
- `bunx vitest run services/automation-worker src/app/api/internal/scorecards/due src/lib/scorecards src/lib/automations src/lib/temporal` → **271 tests, all green** (33 new worker tests incl. bounded-concurrency determinism + schedule converge/pause; 6 new route tests; pre-existing dispatch/automation suites unchanged).
- `tsc --noEmit` clean for all touched files.
- Expert QA audit: **all 6 UACs PASS**, no blockers; the one MINOR + 2 nits found were fixed pre-PR (error-cause unwrapping, shared cron const in startup log, documented Skip overlap policy).
- No UI changes (headless backend feature), so no browser QA pass required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpEs7C3mrTpjCysuRGQZh