### PR TITLE
feat(scorecards): Initiatives UI + auto-generated action items

### DIFF
--- a/docs/plans/2026-07-02-initiatives-ui.md
+++ b/docs/plans/2026-07-02-initiatives-ui.md
@@ -1,0 +1,152 @@
+# Initiatives UI + Auto-Generated Action Items
+
+**Date:** 2026-07-02
+**Status:** In progress
+**Roadmap:** `2026-07-02-scorecards-roadmap.md` item 2.
+**Depends on:** P2 collections (`initiatives`, `initiative-action-items` — already
+registered, no schema changes), scorecard evaluation pipeline
+(`lib/scorecards/evaluate.ts`), nightly sweep (PR #60) which will keep initiatives
+fresh once merged.
+
+## Product goal
+
+Close the measure→improve loop (the Cortex Initiatives model). An engineering
+leader picks a scorecard + target level + deadline; Orbit generates one action
+item per (failing entity × failing rule at/below the target level), teams work
+the items, and progress is visible at a glance. Re-evaluation keeps items in
+sync automatically: fixed things complete themselves, regressions reopen.
+
+## Design
+
+### Sync semantics (`orbit-www/src/lib/scorecards/initiatives.ts`)
+
+Definitions, given an initiative `(scorecard, targetLevel)`:
+- **Target rank** = rank of `targetLevel` in the scorecard's `levels` ladder.
+- **In-scope rules** = the scorecard's rules whose `level` name has rank ≤ target
+  rank; rules with NO level are in scope at every target (they gate every rung —
+  match `computeEntityLevel`'s existing interpretation; read it and stay
+  consistent).
+- **Failing pair** = (entity, in-scope rule) whose LATEST `scorecard-rule-results`
+  row has `passed: false`.
+
+`syncInitiativeActionItems(payload, initiativeId)` diffs failing pairs against
+existing items:
+- Pair failing, no item → **create** (`status: open`).
+- Item exists (any status), pair failing → leave untouched (user state wins).
+- Item `open`/`in-progress`, pair now passing (or rule/entity no longer in
+  scope) → **auto-complete** (`status: done`, append a note "auto-completed:
+  rule now passing").
+- Item `done`, pair failing again → **reopen** (`status: open`, append note).
+- Item `waived` → NEVER touched by sync, in either direction.
+
+The diff itself is a pure, unit-tested function
+`diffActionItems(existingItems, failingPairs)` → `{ toCreate, toComplete,
+toReopen }`; the payload-touching wrapper stays thin (mirror the
+`evaluate.ts` style: paginated reads via the page-loop convention).
+
+**Progress** = pure `computeInitiativeProgress(items)` → `{ total, open,
+inProgress, done, waived, pctComplete }` where `pctComplete = round(100 × (done
++ waived) / total)`, 100 when total = 0.
+
+**Evaluation hook-in:** at the end of `runScorecardEvaluation`, fire-and-forget
+(same pattern as `captureScoreSnapshots`): sync every `active` initiative of the
+evaluated scorecard. A sync failure must never fail an evaluation. With PR #60's
+nightly sweep this keeps every active initiative current daily.
+
+### Server actions (`orbit-www/src/app/(frontend)/scorecards/initiatives/actions.ts`)
+
+Tenancy identical to `scorecards/actions.ts` (`getMemberWorkspaceIds`, session
+user server-side). Contract (exact — UI codes against this):
+
+- `listInitiatives(): Promise<InitiativeSummary[]>` — workspace-scoped, each with
+  scorecard name, targetLevel, owner name, deadline, status, progress.
+- `getInitiativeDetail(id: string): Promise<InitiativeDetail | null>` — initiative
+  + progress + items enriched with entity name/kind (link target id), rule
+  title/level, assignee name.
+- `createInitiative(input: { name: string; description?: string; scorecardId:
+  string; targetLevel: string; deadline?: string }): Promise<{ id: string }>` —
+  validates scorecard is in a caller-managed workspace and targetLevel is one of
+  its level names; creates with `status: active`, `owner` = current user,
+  workspace = scorecard's workspace; then runs the initial sync inline.
+- `updateInitiativeStatus(id: string, status: 'active'|'completed'|'cancelled'):
+  Promise<void>`
+- `syncInitiative(id: string): Promise<{ created: number; completed: number;
+  reopened: number }>`
+- `updateActionItem(id: string, patch: { status?: ItemStatus; assigneeId?:
+  string | null; notes?: string }): Promise<void>`
+- `listScorecardOptions(): Promise<{ id; name; levels: { name; rank }[] }[]>` —
+  for the create form (enabled scorecards with ≥1 level).
+
+**RBAC:** initiative lifecycle (create / status / sync) requires
+`canManageScorecards` (workspace owner/admin — same gate as scorecard
+authoring). Action-item updates (status/assignee/notes) are open to any
+workspace member (assignees work their items). Enforced in the server actions.
+
+### UI
+
+Routes (mirror the scorecards pages' server-component + client-island style):
+- `/scorecards/initiatives/page.tsx` — list: cards with name, scorecard,
+  target-level chip, status badge, deadline (overdue highlighted), progress bar
+  (done+waived / total), owner. Empty state + "New initiative" (gated).
+- `/scorecards/initiatives/new/page.tsx` — form: name, description, scorecard
+  select → targetLevel select populated from that scorecard's levels, deadline
+  date picker. Create → redirect to detail.
+- `/scorecards/initiatives/[id]/page.tsx` — header (status badge, deadline,
+  owner, scorecard link, progress bar + counts), actions (Sync now,
+  Complete/Cancel/Reactivate — gated), items table.
+
+Components in `orbit-www/src/components/features/scorecards/initiatives/`:
+`InitiativeCard`, `InitiativeForm`, `InitiativeHeader`, `ActionItemsTable`
+(columns: entity (link to `/catalog/[id]`), rule, status select (inline update,
+member-editable), assignee, notes (popover/inline edit), updated), plus a small
+`ProgressBar` reusing existing Progress styling patterns. Pure presentational
+helpers (status→badge tone, overdue check, progress math already in lib) go in
+`initiative-ui.ts` with unit tests, mirroring `scorecard-ui.ts`.
+
+Navigation: "Initiatives" link in the `/scorecards` page header (next to
+Reports), and an "Initiatives" count/link on the scorecard detail page if cheap.
+
+Out of scope (follow-ups): reports burndown section, email/Slack nudges,
+per-item comments/history, bulk assignment.
+
+## User Acceptance Criteria
+
+- **UAC-1 (Create):** owner/admin can create an initiative from a scorecard +
+  target level (+ optional deadline); creation generates action items for every
+  failing (entity × in-scope rule) immediately; members cannot create (gated in
+  UI and server action).
+- **UAC-2 (List):** `/scorecards/initiatives` shows workspace-scoped initiatives
+  with status, deadline (overdue visually flagged), and accurate progress;
+  linked from the `/scorecards` header; empty state renders without errors.
+- **UAC-3 (Detail):** detail page shows progress counts and all items with
+  entity links, rule titles, editable status/assignee/notes; a member (non-admin)
+  can update item fields; lifecycle buttons are hidden from members.
+- **UAC-4 (Sync):** re-running evaluation (or Sync now) auto-completes items
+  whose rule now passes, reopens `done` items that regressed, never touches
+  `waived` items, and reports `{created, completed, reopened}`.
+- **UAC-5 (Evaluation hook):** `runScorecardEvaluation` fire-and-forget syncs
+  active initiatives of that scorecard; a sync failure does not fail evaluation
+  (unit-tested); completed/cancelled initiatives are not synced.
+- **UAC-6 (Tenancy/RBAC):** every action is bounded to caller's workspace
+  memberships; lifecycle actions reject non-managers server-side (not just
+  hidden UI).
+- **UAC-7 (Quality):** diff/progress/UI-helper logic is pure + vitest-covered;
+  all scorecards suites pass; `tsc --noEmit` clean for touched files.
+- **UAC-8 (Browser QA):** live agent-browser pass validates UAC-1..4 end-to-end
+  against the dev server (seeded login, real scorecard with failing entities),
+  including the item status round-trip and a Sync-now after flipping a rule
+  result.
+
+## Work packages
+
+| WP | Owner | Scope |
+|---|---|---|
+| WP1 (lib+actions) | opus agent | `lib/scorecards/initiatives.ts` (+`initiatives.test.ts`), `evaluate.ts` hook-in (+test), `app/(frontend)/scorecards/initiatives/actions.ts` |
+| WP2 (UI) | opus agent | pages under `app/(frontend)/scorecards/initiatives/`, components under `components/features/scorecards/initiatives/`, `initiative-ui.ts` (+test), header links |
+| QA | opus agent | UAC audit: suites + tsc + live agent-browser pass |
+
+## Verification
+
+- `cd orbit-www && bunx vitest run src/lib/scorecards src/components/features/scorecards src/app/api/internal/scorecards`
+- `cd orbit-www && bunx tsc --noEmit` (touched files clean)
+- agent-browser QA per UAC-8 (pre/post-flight pgrep hygiene per CLAUDE.md).

--- a/orbit-www/src/app/(frontend)/scorecards/initiatives/[id]/page.tsx
+++ b/orbit-www/src/app/(frontend)/scorecards/initiatives/[id]/page.tsx
@@ -1,0 +1,51 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { InitiativeHeader } from '@/components/features/scorecards/initiatives/InitiativeHeader'
+import { ActionItemsTable } from '@/components/features/scorecards/initiatives/ActionItemsTable'
+import { getInitiativeDetail } from '../actions'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * Initiative detail: the header (status, deadline, owner, scorecard link,
+ * progress) with gated lifecycle controls, plus the action-items table where
+ * members work their items. Tenancy + RBAC are enforced in getInitiativeDetail
+ * (which also computes `canManage`); an out-of-scope or missing id 404s.
+ */
+export default async function InitiativeDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const detail = await getInitiativeDetail(id)
+  if (!detail) notFound()
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex-1 space-y-6 p-8 pt-6">
+          <div>
+            <Link
+              href="/scorecards/initiatives"
+              className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Initiatives
+            </Link>
+            <InitiativeHeader initiative={detail} canManage={detail.canManage} />
+          </div>
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold">Action items ({detail.items.length})</h2>
+            <ActionItemsTable items={detail.items} />
+          </section>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/orbit-www/src/app/(frontend)/scorecards/initiatives/actions.ts
+++ b/orbit-www/src/app/(frontend)/scorecards/initiatives/actions.ts
@@ -1,0 +1,441 @@
+'use server'
+
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { revalidatePath } from 'next/cache'
+import { getCurrentUser } from '@/lib/auth/session'
+import type {
+  CatalogEntity,
+  Initiative,
+  InitiativeActionItem,
+  Scorecard,
+  ScorecardRule,
+} from '@/payload-types'
+import { canManageScorecards } from '@/lib/scorecards/authz'
+import {
+  syncInitiativeActionItems,
+  assertAssigneeInWorkspace,
+  computeInitiativeProgress,
+  toActionItemLite,
+  userDisplayName,
+  type InitiativeStatus,
+  type InitiativeSummary,
+  type InitiativeDetail,
+  type InitiativeDetailItem,
+  type ItemStatus,
+  type ScorecardOption,
+} from '@/lib/scorecards/initiatives'
+
+type Payload = Awaited<ReturnType<typeof getPayload>>
+
+/** Extract a relationship's id whether it arrived as a string or a populated doc. */
+function relId(value: unknown): string | null {
+  if (!value) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && 'id' in (value as Record<string, unknown>)) {
+    return String((value as { id: unknown }).id)
+  }
+  return null
+}
+
+/**
+ * Workspace IDs the user actively belongs to — the tenant boundary for every
+ * query here. Mirrors `scorecards/actions.ts`'s `getMemberWorkspaceIds`.
+ */
+async function getMemberWorkspaceIds(payload: Payload, userId: string): Promise<string[]> {
+  const memberships = await payload.find({
+    collection: 'workspace-members',
+    where: { user: { equals: userId }, status: { equals: 'active' } },
+    limit: 1000,
+    depth: 0,
+    overrideAccess: true,
+  })
+  return memberships.docs.map((m) => (typeof m.workspace === 'string' ? m.workspace : m.workspace.id))
+}
+
+/** Resolve + assert the session user; throws when unauthenticated. */
+async function requireUserId(): Promise<string> {
+  const uid = (await getCurrentUser())?.id
+  if (!uid) throw new Error('Not authenticated')
+  return uid
+}
+
+/** Throw unless the user may manage initiatives (owner/admin) in `workspaceId`. */
+async function assertCanManage(
+  payload: Payload,
+  userId: string,
+  workspaceId: string | null,
+): Promise<void> {
+  if (!workspaceId || !(await canManageScorecards(payload, userId, workspaceId))) {
+    throw new Error('You do not have permission to manage initiatives in this workspace.')
+  }
+}
+
+function scorecardNameOf(sc: unknown): string {
+  if (sc && typeof sc === 'object' && 'name' in (sc as Record<string, unknown>)) {
+    return String((sc as { name: unknown }).name)
+  }
+  return ''
+}
+
+function revalidateInitiatives(id?: string): void {
+  revalidatePath('/scorecards/initiatives')
+  if (id) revalidatePath(`/scorecards/initiatives/${id}`)
+}
+
+// ---------------------------------------------------------------------------
+// listInitiatives — workspace-scoped cards with progress
+// ---------------------------------------------------------------------------
+
+export async function listInitiatives(): Promise<InitiativeSummary[]> {
+  const payload = await getPayload({ config })
+  const uid = (await getCurrentUser())?.id
+  if (!uid) return []
+
+  const workspaceIds = await getMemberWorkspaceIds(payload, uid)
+  if (workspaceIds.length === 0) return []
+
+  const res = await payload.find({
+    collection: 'initiatives',
+    where: { workspace: { in: workspaceIds } },
+    sort: '-createdAt',
+    limit: 500,
+    depth: 1, // populate scorecard (name) + owner (name)
+    overrideAccess: true,
+  })
+  const initiatives = res.docs as Initiative[]
+  if (initiatives.length === 0) return []
+
+  // Batch every initiative's action items for progress, then group by initiative.
+  const ids = initiatives.map((i) => i.id)
+  const itemsRes = await payload.find({
+    collection: 'initiative-action-items',
+    where: { initiative: { in: ids } },
+    limit: 20000,
+    depth: 0,
+    overrideAccess: true,
+  })
+  const itemsByInitiative = new Map<string, InitiativeActionItem[]>()
+  for (const item of itemsRes.docs as InitiativeActionItem[]) {
+    const iniId = relId(item.initiative)
+    if (!iniId) continue
+    const list = itemsByInitiative.get(iniId) ?? []
+    list.push(item)
+    itemsByInitiative.set(iniId, list)
+  }
+
+  return initiatives.map((ini) => {
+    const items = itemsByInitiative.get(ini.id) ?? []
+    const progress = computeInitiativeProgress(items.map(toActionItemLite))
+    return {
+      id: ini.id,
+      name: ini.name,
+      description: ini.description,
+      scorecardId: relId(ini.scorecard) ?? '',
+      scorecardName: scorecardNameOf(ini.scorecard),
+      targetLevel: ini.targetLevel,
+      ownerId: relId(ini.owner),
+      ownerName: userDisplayName(ini.owner),
+      deadline: ini.deadline,
+      status: (ini.status ?? 'active') as InitiativeStatus,
+      progress,
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// getInitiativeDetail — initiative + progress + enriched items
+// ---------------------------------------------------------------------------
+
+export async function getInitiativeDetail(id: string): Promise<InitiativeDetail | null> {
+  const payload = await getPayload({ config })
+  const uid = (await getCurrentUser())?.id
+  if (!uid || !id) return null
+
+  const workspaceIds = await getMemberWorkspaceIds(payload, uid)
+  if (workspaceIds.length === 0) return null
+
+  let initiative: Initiative
+  try {
+    initiative = (await payload.findByID({
+      collection: 'initiatives',
+      id,
+      depth: 1, // populate scorecard + owner
+      overrideAccess: true,
+    })) as Initiative
+  } catch {
+    return null
+  }
+  const workspaceId = relId(initiative.workspace)
+  if (!initiative || !workspaceId || !workspaceIds.includes(workspaceId)) return null
+
+  const itemsRes = await payload.find({
+    collection: 'initiative-action-items',
+    where: { initiative: { equals: id } },
+    sort: '-updatedAt',
+    limit: 20000,
+    depth: 1, // populate entity (name/kind), rule (title/level), assignee (name)
+    overrideAccess: true,
+  })
+  const itemRows = itemsRes.docs as InitiativeActionItem[]
+
+  const items: InitiativeDetailItem[] = itemRows.map((row) => {
+    const entity = row.entity as CatalogEntity | string
+    const rule = row.rule as ScorecardRule | string | null | undefined
+    const entityIsDoc = entity && typeof entity === 'object'
+    const ruleIsDoc = rule && typeof rule === 'object'
+    return {
+      id: row.id,
+      entityId: relId(row.entity) ?? '',
+      entityName: entityIsDoc ? (entity as CatalogEntity).name : (relId(row.entity) ?? ''),
+      entityKind: entityIsDoc ? (entity as CatalogEntity).kind : null,
+      ruleId: relId(row.rule),
+      ruleTitle: ruleIsDoc ? (rule as ScorecardRule).title : null,
+      ruleLevel: ruleIsDoc ? (rule as ScorecardRule).level : null,
+      status: (row.status ?? 'open') as ItemStatus,
+      assigneeId: relId(row.assignee),
+      assigneeName: userDisplayName(row.assignee),
+      notes: row.notes ?? null,
+      updatedAt: row.updatedAt,
+    }
+  })
+
+  const progress = computeInitiativeProgress(itemRows.map(toActionItemLite))
+  const canManage = await canManageScorecards(payload, uid, workspaceId)
+
+  return {
+    id: initiative.id,
+    name: initiative.name,
+    description: initiative.description,
+    scorecardId: relId(initiative.scorecard) ?? '',
+    scorecardName: scorecardNameOf(initiative.scorecard),
+    targetLevel: initiative.targetLevel,
+    ownerId: relId(initiative.owner),
+    ownerName: userDisplayName(initiative.owner),
+    deadline: initiative.deadline,
+    status: (initiative.status ?? 'active') as InitiativeStatus,
+    canManage,
+    progress,
+    items,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createInitiative — lifecycle (owner/admin), then initial sync inline
+// ---------------------------------------------------------------------------
+
+export interface CreateInitiativeInput {
+  name: string
+  description?: string
+  scorecardId: string
+  targetLevel: string
+  deadline?: string
+}
+
+export async function createInitiative(input: CreateInitiativeInput): Promise<{ id: string }> {
+  const payload = await getPayload({ config })
+  const uid = await requireUserId()
+
+  if (!input.name?.trim()) throw new Error('An initiative name is required.')
+  if (!input.scorecardId) throw new Error('A scorecard is required.')
+
+  // The parent scorecard determines the workspace; the caller must manage it.
+  let scorecard: Scorecard
+  try {
+    scorecard = (await payload.findByID({
+      collection: 'scorecards',
+      id: input.scorecardId,
+      depth: 0,
+      overrideAccess: true,
+    })) as Scorecard
+  } catch {
+    throw new Error('Scorecard not found')
+  }
+  const workspaceId = relId(scorecard.workspace)
+  await assertCanManage(payload, uid, workspaceId)
+
+  const levelNames = (scorecard.levels ?? []).map((l) => l.name)
+  if (!input.targetLevel || !levelNames.includes(input.targetLevel)) {
+    throw new Error('The target level must be one of the scorecard levels.')
+  }
+
+  const created = await payload.create({
+    collection: 'initiatives',
+    data: {
+      name: input.name.trim(),
+      description: input.description?.trim() || undefined,
+      workspace: workspaceId as string,
+      scorecard: input.scorecardId,
+      targetLevel: input.targetLevel,
+      owner: uid,
+      deadline: input.deadline || undefined,
+      status: 'active',
+    },
+    overrideAccess: true,
+  })
+
+  // Populate action items immediately so the detail page lands populated.
+  await syncInitiativeActionItems(payload, created.id)
+
+  revalidateInitiatives(created.id)
+  return { id: created.id }
+}
+
+// ---------------------------------------------------------------------------
+// updateInitiativeStatus — lifecycle (owner/admin)
+// ---------------------------------------------------------------------------
+
+export async function updateInitiativeStatus(
+  id: string,
+  status: InitiativeStatus,
+): Promise<void> {
+  const payload = await getPayload({ config })
+  const uid = await requireUserId()
+
+  let initiative: Initiative
+  try {
+    initiative = (await payload.findByID({
+      collection: 'initiatives',
+      id,
+      depth: 0,
+      overrideAccess: true,
+    })) as Initiative
+  } catch {
+    throw new Error('Initiative not found')
+  }
+  await assertCanManage(payload, uid, relId(initiative.workspace))
+
+  if (!['active', 'completed', 'cancelled'].includes(status)) {
+    throw new Error('Invalid initiative status.')
+  }
+
+  await payload.update({
+    collection: 'initiatives',
+    id,
+    data: { status },
+    overrideAccess: true,
+  })
+
+  revalidateInitiatives(id)
+}
+
+// ---------------------------------------------------------------------------
+// syncInitiative — lifecycle (owner/admin), on-demand reconcile
+// ---------------------------------------------------------------------------
+
+export async function syncInitiative(
+  id: string,
+): Promise<{ created: number; completed: number; reopened: number }> {
+  const payload = await getPayload({ config })
+  const uid = await requireUserId()
+
+  let initiative: Initiative
+  try {
+    initiative = (await payload.findByID({
+      collection: 'initiatives',
+      id,
+      depth: 0,
+      overrideAccess: true,
+    })) as Initiative
+  } catch {
+    throw new Error('Initiative not found')
+  }
+  await assertCanManage(payload, uid, relId(initiative.workspace))
+
+  const result = await syncInitiativeActionItems(payload, id)
+  revalidateInitiatives(id)
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// updateActionItem — any workspace member may work their items
+// ---------------------------------------------------------------------------
+
+export interface UpdateActionItemPatch {
+  status?: ItemStatus
+  assigneeId?: string | null
+  notes?: string
+}
+
+export async function updateActionItem(id: string, patch: UpdateActionItemPatch): Promise<void> {
+  const payload = await getPayload({ config })
+  const uid = await requireUserId()
+
+  let item: InitiativeActionItem
+  try {
+    item = (await payload.findByID({
+      collection: 'initiative-action-items',
+      id,
+      depth: 0,
+      overrideAccess: true,
+    })) as InitiativeActionItem
+  } catch {
+    throw new Error('Action item not found')
+  }
+
+  // Any active member of the item's workspace may update it (assignees work
+  // their items) — no owner/admin gate here, unlike lifecycle actions.
+  const workspaceId = relId(item.workspace)
+  const workspaceIds = await getMemberWorkspaceIds(payload, uid)
+  if (!workspaceId || !workspaceIds.includes(workspaceId)) {
+    throw new Error('You do not have access to this action item.')
+  }
+
+  // A concrete assignee must be an active member of the item's workspace —
+  // block pinning an arbitrary/foreign user (their name/email would leak via
+  // the detail page's depth-1 populate). Clearing the assignee always passes.
+  if (patch.assigneeId !== undefined) {
+    await assertAssigneeInWorkspace(payload, patch.assigneeId, workspaceId)
+  }
+
+  const data: Record<string, unknown> = {}
+  if (patch.status !== undefined) {
+    if (!['open', 'in-progress', 'done', 'waived'].includes(patch.status)) {
+      throw new Error('Invalid action item status.')
+    }
+    data.status = patch.status
+  }
+  if (patch.assigneeId !== undefined) data.assignee = patch.assigneeId || null
+  if (patch.notes !== undefined) data.notes = patch.notes?.trim() ? patch.notes : null
+
+  await payload.update({
+    collection: 'initiative-action-items',
+    id,
+    data,
+    overrideAccess: true,
+  })
+
+  revalidateInitiatives(relId(item.initiative) ?? undefined)
+}
+
+// ---------------------------------------------------------------------------
+// listScorecardOptions — create-form source (enabled scorecards with ≥1 level)
+// ---------------------------------------------------------------------------
+
+export async function listScorecardOptions(): Promise<ScorecardOption[]> {
+  const payload = await getPayload({ config })
+  const uid = (await getCurrentUser())?.id
+  if (!uid) return []
+
+  const workspaceIds = await getMemberWorkspaceIds(payload, uid)
+  if (workspaceIds.length === 0) return []
+
+  const res = await payload.find({
+    collection: 'scorecards',
+    where: { and: [{ workspace: { in: workspaceIds } }, { enabled: { equals: true } }] },
+    sort: 'name',
+    limit: 500,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  return (res.docs as Scorecard[])
+    .map((sc) => ({
+      id: sc.id,
+      name: sc.name,
+      levels: (sc.levels ?? [])
+        .map((l) => ({ name: l.name, rank: l.rank }))
+        .sort((a, b) => a.rank - b.rank),
+    }))
+    .filter((opt) => opt.levels.length > 0)
+}

--- a/orbit-www/src/app/(frontend)/scorecards/initiatives/new/page.tsx
+++ b/orbit-www/src/app/(frontend)/scorecards/initiatives/new/page.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import { ArrowLeft, ShieldAlert } from 'lucide-react'
+import { getCurrentUser } from '@/lib/auth/session'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { InitiativeForm } from '@/components/features/scorecards/initiatives/InitiativeForm'
+import { getManageableWorkspaces } from '../../actions'
+import { listScorecardOptions } from '../actions'
+
+/**
+ * New-initiative flow. Resolves the caller's manageable workspaces (owner/admin)
+ * as a defense-in-depth gate on top of the RBAC-enforced createInitiative action,
+ * and the scorecards they can target. Empty states cover both "can't author" and
+ * "no scorecards to target yet".
+ */
+export default async function NewInitiativePage() {
+  const user = await getCurrentUser()
+  const [workspaces, scorecards] = await Promise.all([
+    getManageableWorkspaces(user?.id),
+    listScorecardOptions(),
+  ])
+
+  const canManage = workspaces.length > 0
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex-1 space-y-6 p-8 pt-6">
+          <div>
+            <Link
+              href="/scorecards/initiatives"
+              className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Initiatives
+            </Link>
+            <h1 className="text-3xl font-bold">New initiative</h1>
+            <p className="mt-2 text-muted-foreground">
+              Target a scorecard level by a deadline. Orbit generates an action item for every
+              failing rule at or below that level.
+            </p>
+          </div>
+
+          {!canManage ? (
+            <NotPermitted />
+          ) : scorecards.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+              <ShieldAlert className="mb-4 h-12 w-12 text-muted-foreground" />
+              <h3 className="text-lg font-semibold">No scorecards to target</h3>
+              <p className="mt-1 max-w-md text-sm text-muted-foreground">
+                Create a scorecard with a maturity ladder first, then come back to launch an
+                initiative against it.
+              </p>
+            </div>
+          ) : (
+            <Card className="max-w-2xl">
+              <CardHeader>
+                <CardTitle className="text-base">Details</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <InitiativeForm scorecards={scorecards} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}
+
+function NotPermitted() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+      <ShieldAlert className="mb-4 h-12 w-12 text-muted-foreground" />
+      <h3 className="text-lg font-semibold">You can&rsquo;t create initiatives</h3>
+      <p className="mt-1 max-w-md text-sm text-muted-foreground">
+        Launching an initiative requires being an owner or admin of a workspace. Ask a workspace
+        owner for access.
+      </p>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/scorecards/initiatives/page.tsx
+++ b/orbit-www/src/app/(frontend)/scorecards/initiatives/page.tsx
@@ -1,0 +1,106 @@
+import { Suspense } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Loader2, Plus, Target } from 'lucide-react'
+import { getCurrentUser } from '@/lib/auth/session'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { Button } from '@/components/ui/button'
+import { InitiativeCard } from '@/components/features/scorecards/initiatives/InitiativeCard'
+import { getManageableWorkspaces } from '../actions'
+import { listInitiatives } from './actions'
+
+/**
+ * Initiatives landing (Initiatives UI, docs/plans/2026-07-02-initiatives-ui.md).
+ *
+ * Lists the workspace's initiatives as cards — each carrying its scorecard,
+ * target level, status, deadline (overdue flagged) and live progress — so an
+ * engineering leader can see every improvement campaign at a glance. Linked from
+ * the `/scorecards` header. Cards deep-link to `/scorecards/initiatives/{id}`.
+ */
+async function InitiativesContent() {
+  const initiatives = await listInitiatives()
+
+  if (initiatives.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+        <Target className="mb-4 h-12 w-12 text-muted-foreground" />
+        <h3 className="text-lg font-semibold">No initiatives yet</h3>
+        <p className="mt-1 max-w-md text-sm text-muted-foreground">
+          Initiatives drive entities up a scorecard ladder by a deadline. Pick a scorecard and
+          target level and Orbit generates an action item for every failing rule, then keeps them in
+          sync as you re-evaluate.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {initiatives.map((initiative) => (
+        <InitiativeCard key={initiative.id} initiative={initiative} />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * "New initiative" CTA — rendered only for owners/admins of at least one
+ * workspace (matches the createInitiative RBAC gate). Streams in its own
+ * Suspense boundary so resolving the manageable workspaces never blocks the
+ * page header.
+ */
+async function NewInitiativeButton() {
+  const user = await getCurrentUser()
+  const workspaces = await getManageableWorkspaces(user?.id)
+  if (workspaces.length === 0) return null
+  return (
+    <Button asChild size="sm">
+      <Link href="/scorecards/initiatives/new">
+        <Plus className="h-4 w-4" />
+        New initiative
+      </Link>
+    </Button>
+  )
+}
+
+export default function InitiativesPage() {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex-1 space-y-4 p-8 pt-6">
+          <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <Link
+                href="/scorecards"
+                className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Scorecards
+              </Link>
+              <h1 className="text-3xl font-bold">Initiatives</h1>
+              <p className="mt-2 text-muted-foreground">
+                Time-boxed campaigns to raise scorecard compliance — measure, then improve.
+              </p>
+            </div>
+            <Suspense fallback={null}>
+              <NewInitiativeButton />
+            </Suspense>
+          </div>
+
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            }
+          >
+            <InitiativesContent />
+          </Suspense>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/orbit-www/src/app/(frontend)/scorecards/page.tsx
+++ b/orbit-www/src/app/(frontend)/scorecards/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import Link from 'next/link'
-import { BarChart3, Loader2, Plus, ShieldCheck } from 'lucide-react'
+import { BarChart3, Loader2, Plus, ShieldCheck, Target } from 'lucide-react'
 import { getCurrentUser } from '@/lib/auth/session'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
@@ -79,6 +79,12 @@ export default function ScorecardsPage() {
               </p>
             </div>
             <div className="flex items-center gap-2">
+              <Button asChild variant="outline" size="sm">
+                <Link href="/scorecards/initiatives">
+                  <Target className="h-4 w-4" />
+                  Initiatives
+                </Link>
+              </Button>
               <Button asChild variant="outline" size="sm">
                 <Link href="/scorecards/reports">
                   <BarChart3 className="h-4 w-4" />

--- a/orbit-www/src/components/features/scorecards/initiatives/ActionItemsTable.tsx
+++ b/orbit-www/src/components/features/scorecards/initiatives/ActionItemsTable.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Loader2, StickyNote } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { updateActionItem } from '@/app/(frontend)/scorecards/initiatives/actions'
+import {
+  formatDeadline,
+  ITEM_STATUS_OPTIONS,
+  itemStatusPresentation,
+  type ActionItemView,
+  type ItemStatus,
+} from './initiative-ui'
+
+/**
+ * The action-items table for an initiative detail page. Each row links its
+ * entity into the catalog, shows the failing rule (+ level), and lets any
+ * workspace member update the item's status inline and edit its notes in a
+ * popover. Assignee is display-only in v1 (no user-picker convention yet).
+ *
+ * Mutations call the member-editable updateActionItem action and refresh the
+ * route so the server-recomputed progress + updatedAt re-render.
+ */
+export function ActionItemsTable({ items }: { items: ActionItemView[] }) {
+  const router = useRouter()
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  async function mutate(id: string, patch: Parameters<typeof updateActionItem>[1]) {
+    setPendingId(id)
+    try {
+      await updateActionItem(id, patch)
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update item')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed py-10 text-center text-sm text-muted-foreground">
+        No action items yet. Items are generated from the scorecard&rsquo;s failing rules when the
+        initiative is created or synced.
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="min-w-[180px]">Entity</TableHead>
+            <TableHead className="min-w-[200px]">Rule</TableHead>
+            <TableHead className="min-w-[150px]">Status</TableHead>
+            <TableHead className="min-w-[120px]">Assignee</TableHead>
+            <TableHead className="min-w-[80px]">Notes</TableHead>
+            <TableHead className="min-w-[110px]">Updated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell className="font-medium">
+                <Link href={`/catalog/${item.entityId}`} className="hover:underline">
+                  {item.entityName}
+                </Link>
+                {item.entityKind && (
+                  <span className="ml-1.5 text-xs capitalize text-muted-foreground">
+                    {item.entityKind}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell>
+                <div className="flex flex-col gap-0.5">
+                  <span>{item.ruleTitle ?? '—'}</span>
+                  {item.ruleLevel && (
+                    <Badge variant="outline" className="w-fit font-normal">
+                      {item.ruleLevel}
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                <StatusCell
+                  value={item.status}
+                  pending={pendingId === item.id}
+                  onChange={(status) => mutate(item.id, { status })}
+                />
+              </TableCell>
+              <TableCell className="text-sm">
+                {item.assigneeName ? (
+                  item.assigneeName
+                ) : (
+                  <span className="text-muted-foreground">Unassigned</span>
+                )}
+              </TableCell>
+              <TableCell>
+                <NotesCell
+                  notes={item.notes}
+                  pending={pendingId === item.id}
+                  onSave={(notes) => mutate(item.id, { notes })}
+                />
+              </TableCell>
+              <TableCell className="text-xs text-muted-foreground">
+                {item.updatedAt ? formatDeadline(item.updatedAt) : '—'}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function StatusCell({
+  value,
+  pending,
+  onChange,
+}: {
+  value: string
+  pending: boolean
+  onChange: (status: ItemStatus) => void
+}) {
+  const p = itemStatusPresentation(value)
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={value} onValueChange={(v) => onChange(v as ItemStatus)} disabled={pending}>
+        <SelectTrigger className="h-8 w-[140px]">
+          <SelectValue>
+            <Badge variant={p.variant} className={cn('font-normal', p.className)}>
+              {p.label}
+            </Badge>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {ITEM_STATUS_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {pending && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+    </div>
+  )
+}
+
+function NotesCell({
+  notes,
+  pending,
+  onSave,
+}: {
+  notes?: string | null
+  pending: boolean
+  onSave: (notes: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState(notes ?? '')
+  const hasNotes = !!notes?.trim()
+
+  function handleOpenChange(next: boolean) {
+    if (next) setDraft(notes ?? '')
+    setOpen(next)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn('h-8 gap-1 px-2', hasNotes ? 'text-foreground' : 'text-muted-foreground')}
+          title={hasNotes ? notes ?? undefined : 'Add a note'}
+        >
+          <StickyNote className="h-4 w-4" />
+          {hasNotes ? 'View' : 'Add'}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 space-y-2" align="start">
+        <Textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Add remediation notes…"
+          className="min-h-24"
+        />
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={() => setOpen(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => {
+              onSave(draft.trim())
+              setOpen(false)
+            }}
+            disabled={pending}
+          >
+            {pending && <Loader2 className="h-4 w-4 animate-spin" />}
+            Save
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/orbit-www/src/components/features/scorecards/initiatives/InitiativeCard.tsx
+++ b/orbit-www/src/components/features/scorecards/initiatives/InitiativeCard.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link'
+import { CalendarClock, ShieldCheck, User } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { InitiativeProgressBar } from './InitiativeProgress'
+import {
+  formatDeadline,
+  initiativeStatusPresentation,
+  isOverdue,
+  targetLevelLabel,
+  type InitiativeSummaryView,
+} from './initiative-ui'
+
+/**
+ * An initiative rendered as a clickable list card: name, scorecard, target-level
+ * chip, status badge, deadline (overdue flagged), progress bar + counts, owner.
+ * Links to `/scorecards/initiatives/{id}`.
+ */
+export function InitiativeCard({ initiative }: { initiative: InitiativeSummaryView }) {
+  const status = initiativeStatusPresentation(initiative.status)
+  const overdue = initiative.status === 'active' && isOverdue(initiative.deadline, new Date())
+
+  return (
+    <Link
+      href={`/scorecards/initiatives/${initiative.id}`}
+      className="block focus:outline-none"
+    >
+      <Card className="h-full transition-colors hover:border-primary/50 hover:bg-accent/40">
+        <CardHeader className="space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="truncate text-base" title={initiative.name}>
+              {initiative.name}
+            </CardTitle>
+            <Badge variant={status.variant} className={cn('shrink-0 font-normal', status.className)}>
+              {status.label}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant="secondary" className="gap-1 font-normal">
+              <ShieldCheck className="h-3 w-3" />
+              {initiative.scorecardName}
+            </Badge>
+            <Badge variant="outline" className="font-normal">
+              {targetLevelLabel(initiative.targetLevel)}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <InitiativeProgressBar progress={initiative.progress} />
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span
+              className={cn('inline-flex items-center gap-1', overdue && 'font-medium text-red-600')}
+            >
+              <CalendarClock className="h-3 w-3" />
+              {formatDeadline(initiative.deadline)}
+              {overdue && ' · overdue'}
+            </span>
+            {initiative.ownerName && (
+              <span className="inline-flex items-center gap-1">
+                <User className="h-3 w-3" />
+                {initiative.ownerName}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/orbit-www/src/components/features/scorecards/initiatives/InitiativeForm.tsx
+++ b/orbit-www/src/components/features/scorecards/initiatives/InitiativeForm.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { createInitiative } from '@/app/(frontend)/scorecards/initiatives/actions'
+import type { ScorecardOption } from './initiative-ui'
+
+/**
+ * Create form for an initiative (IDP refocus P2). Picks a scorecard, then a
+ * target level populated from that scorecard's ladder, plus an optional
+ * deadline. On success redirects to the new initiative's detail page.
+ *
+ * Authoring is RBAC-enforced server-side in createInitiative; the page only
+ * renders this form for owners/admins.
+ */
+export function InitiativeForm({ scorecards }: { scorecards: ScorecardOption[] }) {
+  const router = useRouter()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [scorecardId, setScorecardId] = useState(scorecards[0]?.id ?? '')
+  const [deadline, setDeadline] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Ladder for the currently-selected scorecard, lowest rung first.
+  const levels = useMemo(() => {
+    const sc = scorecards.find((s) => s.id === scorecardId)
+    return [...(sc?.levels ?? [])].sort((a, b) => a.rank - b.rank)
+  }, [scorecards, scorecardId])
+
+  const [targetLevel, setTargetLevel] = useState(scorecards[0]?.levels?.[0]?.name ?? '')
+
+  function handleScorecardChange(id: string) {
+    setScorecardId(id)
+    const sc = scorecards.find((s) => s.id === id)
+    const ladder = [...(sc?.levels ?? [])].sort((a, b) => a.rank - b.rank)
+    setTargetLevel(ladder[0]?.name ?? '')
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) {
+      toast.error('An initiative name is required.')
+      return
+    }
+    if (!scorecardId) {
+      toast.error('Select a scorecard.')
+      return
+    }
+    if (!targetLevel) {
+      toast.error('Select a target level.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const { id } = await createInitiative({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        scorecardId,
+        targetLevel,
+        deadline: deadline || undefined,
+      })
+      toast.success('Initiative created')
+      router.push(`/scorecards/initiatives/${id}`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create initiative')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="init-name">Name</Label>
+        <Input
+          id="init-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Reach Silver on Production readiness"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="init-description">Description</Label>
+        <Textarea
+          id="init-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Why this campaign matters and what &ldquo;done&rdquo; looks like."
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="init-scorecard">Scorecard</Label>
+        <Select value={scorecardId} onValueChange={handleScorecardChange}>
+          <SelectTrigger id="init-scorecard">
+            <SelectValue placeholder="Select a scorecard" />
+          </SelectTrigger>
+          <SelectContent>
+            {scorecards.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                {s.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="init-target">Target level</Label>
+        <Select value={targetLevel} onValueChange={setTargetLevel} disabled={levels.length === 0}>
+          <SelectTrigger id="init-target">
+            <SelectValue placeholder="Select a target level" />
+          </SelectTrigger>
+          <SelectContent>
+            {levels.map((l) => (
+              <SelectItem key={l.name} value={l.name}>
+                {l.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Action items are generated for every failing rule at or below this level.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="init-deadline">Deadline</Label>
+        <Input
+          id="init-deadline"
+          type="date"
+          value={deadline}
+          onChange={(e) => setDeadline(e.target.value)}
+          className="w-fit"
+        />
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+          Create initiative
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/orbit-www/src/components/features/scorecards/initiatives/InitiativeHeader.tsx
+++ b/orbit-www/src/components/features/scorecards/initiatives/InitiativeHeader.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { CalendarClock, CheckCircle2, Loader2, RefreshCw, ShieldCheck, User, XCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+import { syncInitiative, updateInitiativeStatus } from '@/app/(frontend)/scorecards/initiatives/actions'
+import { InitiativeProgressBar } from './InitiativeProgress'
+import {
+  formatDeadline,
+  initiativeStatusPresentation,
+  isOverdue,
+  targetLevelLabel,
+  type InitiativeDetailView,
+} from './initiative-ui'
+
+/**
+ * Detail-page header for an initiative: title, status badge, target level,
+ * scorecard link, deadline (overdue flagged), owner, and the progress bar with
+ * counts. Owner/admins additionally get the lifecycle controls (Sync now +
+ * Complete/Cancel/Reactivate); those actions are RBAC-enforced server-side and
+ * only surface when `canManage` is true.
+ */
+export function InitiativeHeader({
+  initiative,
+  canManage,
+}: {
+  initiative: InitiativeDetailView
+  canManage: boolean
+}) {
+  const router = useRouter()
+  const [busy, setBusy] = useState<null | 'sync' | 'status'>(null)
+  const [confirm, setConfirm] = useState<null | 'completed' | 'cancelled'>(null)
+
+  const status = initiativeStatusPresentation(initiative.status)
+  const overdue = initiative.status === 'active' && isOverdue(initiative.deadline, new Date())
+  const isActive = initiative.status === 'active'
+
+  async function handleSync() {
+    setBusy('sync')
+    try {
+      const r = await syncInitiative(initiative.id)
+      toast.success(
+        `Synced: ${r.created} created, ${r.completed} auto-completed, ${r.reopened} reopened.`,
+      )
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Sync failed')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function handleStatus(next: 'active' | 'completed' | 'cancelled') {
+    setBusy('status')
+    try {
+      await updateInitiativeStatus(initiative.id, next)
+      toast.success(
+        next === 'active'
+          ? 'Initiative reactivated'
+          : next === 'completed'
+            ? 'Initiative completed'
+            : 'Initiative cancelled',
+      )
+      setConfirm(null)
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update initiative')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-3xl font-bold">{initiative.name}</h1>
+            <Badge variant={status.variant} className={cn('font-normal', status.className)}>
+              {status.label}
+            </Badge>
+          </div>
+          {initiative.description && (
+            <p className="max-w-2xl text-muted-foreground">{initiative.description}</p>
+          )}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+            <Link
+              href={`/scorecards/${initiative.scorecardId}`}
+              className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+            >
+              <ShieldCheck className="h-4 w-4" />
+              {initiative.scorecardName}
+            </Link>
+            <Badge variant="outline" className="font-normal">
+              {targetLevelLabel(initiative.targetLevel)}
+            </Badge>
+            <span className={cn('inline-flex items-center gap-1', overdue && 'font-medium text-red-600')}>
+              <CalendarClock className="h-4 w-4" />
+              {formatDeadline(initiative.deadline)}
+              {overdue && ' · overdue'}
+            </span>
+            {initiative.ownerName && (
+              <span className="inline-flex items-center gap-1">
+                <User className="h-4 w-4" />
+                {initiative.ownerName}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {canManage && (
+          <div className="flex flex-wrap items-center gap-2">
+            {isActive && (
+              <Button size="sm" variant="outline" onClick={handleSync} disabled={busy !== null}>
+                {busy === 'sync' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                Sync now
+              </Button>
+            )}
+            {isActive ? (
+              <>
+                <Button
+                  size="sm"
+                  onClick={() => setConfirm('completed')}
+                  disabled={busy !== null}
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                  Complete
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirm('cancelled')}
+                  disabled={busy !== null}
+                >
+                  <XCircle className="h-4 w-4" />
+                  Cancel
+                </Button>
+              </>
+            ) : (
+              <Button size="sm" variant="outline" onClick={() => handleStatus('active')} disabled={busy !== null}>
+                {busy === 'status' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                Reactivate
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="max-w-md">
+        <InitiativeProgressBar progress={initiative.progress} />
+      </div>
+
+      <AlertDialog open={confirm !== null} onOpenChange={(o) => !o && setConfirm(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirm === 'completed' ? 'Complete this initiative?' : 'Cancel this initiative?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirm === 'completed'
+                ? 'Marking it completed stops automatic syncing. You can reactivate it later.'
+                : 'Cancelling stops automatic syncing and archives the campaign. You can reactivate it later.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy !== null}>Keep active</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                if (confirm) handleStatus(confirm)
+              }}
+              disabled={busy !== null}
+            >
+              {busy === 'status' && <Loader2 className="h-4 w-4 animate-spin" />}
+              {confirm === 'completed' ? 'Complete' : 'Cancel initiative'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/orbit-www/src/components/features/scorecards/initiatives/InitiativeProgress.tsx
+++ b/orbit-www/src/components/features/scorecards/initiatives/InitiativeProgress.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+import { Progress } from '@/components/ui/progress'
+import { progressTone, type InitiativeProgressView } from './initiative-ui'
+
+/**
+ * Completion bar for an initiative: the done+waived / total percentage plus a
+ * "x of y done" caption, toned by completion. Reuses the shared <Progress>
+ * primitive so it reads identically to the scorecard rollups.
+ */
+export function InitiativeProgressBar({
+  progress,
+  className,
+  showCounts = true,
+}: {
+  progress: InitiativeProgressView
+  className?: string
+  showCounts?: boolean
+}) {
+  const { pctComplete, done, waived, total } = progress
+  const resolved = done + waived
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      {showCounts && (
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">
+            {resolved} of {total} done
+          </span>
+          <span className={cn('font-semibold tabular-nums', progressTone(pctComplete))}>
+            {pctComplete}%
+          </span>
+        </div>
+      )}
+      <Progress value={pctComplete} className="h-1.5" />
+    </div>
+  )
+}

--- a/orbit-www/src/components/features/scorecards/initiatives/initiative-ui.test.ts
+++ b/orbit-www/src/components/features/scorecards/initiatives/initiative-ui.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatDeadline,
+  initiativeStatusPresentation,
+  isOverdue,
+  itemStatusPresentation,
+  progressTone,
+  targetLevelLabel,
+} from './initiative-ui'
+
+describe('initiativeStatusPresentation', () => {
+  it('maps each lifecycle status to a distinct label + variant', () => {
+    expect(initiativeStatusPresentation('active').label).toBe('Active')
+    expect(initiativeStatusPresentation('completed').label).toBe('Completed')
+    expect(initiativeStatusPresentation('cancelled').label).toBe('Cancelled')
+    expect(initiativeStatusPresentation('completed').variant).toBe('default')
+    expect(initiativeStatusPresentation('cancelled').variant).toBe('outline')
+  })
+
+  it('falls back to a neutral outline chip for an unknown status', () => {
+    const p = initiativeStatusPresentation('mystery')
+    expect(p.variant).toBe('outline')
+    expect(p.label).toBe('mystery')
+  })
+})
+
+describe('itemStatusPresentation', () => {
+  it('labels the four item statuses', () => {
+    expect(itemStatusPresentation('open').label).toBe('Open')
+    expect(itemStatusPresentation('in-progress').label).toBe('In progress')
+    expect(itemStatusPresentation('done').label).toBe('Done')
+    expect(itemStatusPresentation('waived').label).toBe('Waived')
+  })
+})
+
+describe('isOverdue', () => {
+  const now = new Date('2026-07-02T12:00:00.000Z')
+
+  it('is true when the deadline is strictly in the past', () => {
+    expect(isOverdue('2026-07-01T00:00:00.000Z', now)).toBe(true)
+  })
+
+  it('is false for a future deadline', () => {
+    expect(isOverdue('2026-07-03T00:00:00.000Z', now)).toBe(false)
+  })
+
+  it('is false when no deadline is set', () => {
+    expect(isOverdue(null, now)).toBe(false)
+    expect(isOverdue(undefined, now)).toBe(false)
+  })
+})
+
+describe('formatDeadline', () => {
+  it('renders a short UTC date', () => {
+    expect(formatDeadline('2026-07-02T00:00:00.000Z')).toBe('Jul 2, 2026')
+  })
+
+  it('renders a placeholder when unset', () => {
+    expect(formatDeadline(null)).toBe('No deadline')
+    expect(formatDeadline(undefined)).toBe('No deadline')
+  })
+})
+
+describe('progressTone', () => {
+  it('greens a fully complete initiative and reds an untouched one', () => {
+    expect(progressTone(100)).toBe('text-emerald-600')
+    expect(progressTone(70)).toBe('text-amber-600')
+    expect(progressTone(10)).toBe('text-red-600')
+  })
+})
+
+describe('targetLevelLabel', () => {
+  it('prefixes a target level', () => {
+    expect(targetLevelLabel('Gold')).toBe('Target: Gold')
+  })
+
+  it('handles a missing target', () => {
+    expect(targetLevelLabel(null)).toBe('No target level')
+  })
+})

--- a/orbit-www/src/components/features/scorecards/initiatives/initiative-ui.ts
+++ b/orbit-www/src/components/features/scorecards/initiatives/initiative-ui.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure presentation helpers for the Initiatives UI (IDP refocus P2 — the Cortex
+ * Initiatives model).
+ *
+ * Framework-light on purpose (mirrors ../scorecard-ui.ts): no 'use server', no
+ * React, no Payload imports — so both server actions and client components can
+ * import these. Keep every export side-effect free and unit-testable (see
+ * initiative-ui.test.ts).
+ */
+
+import { passRatioTone } from '../scorecard-ui'
+
+/** Initiative lifecycle states (mirrors Initiatives.status). */
+export type InitiativeStatus = 'active' | 'completed' | 'cancelled'
+
+/** Action-item states (mirrors InitiativeActionItems.status). */
+export type ItemStatus = 'open' | 'in-progress' | 'done' | 'waived'
+
+type DateInput = string | number | Date | null | undefined
+
+/** Badge presentation: a shadcn <Badge> variant plus optional extra classes. */
+export interface BadgePresentation {
+  label: string
+  variant: 'default' | 'secondary' | 'destructive' | 'outline'
+  className?: string
+}
+
+const INITIATIVE_STATUS: Record<InitiativeStatus, BadgePresentation> = {
+  active: { label: 'Active', variant: 'default' },
+  completed: {
+    label: 'Completed',
+    variant: 'default',
+    className: 'border-transparent bg-emerald-600 text-white hover:bg-emerald-600/90',
+  },
+  cancelled: { label: 'Cancelled', variant: 'outline', className: 'text-muted-foreground' },
+}
+
+/** Map an initiative status to a badge; unknown values render as a neutral chip. */
+export function initiativeStatusPresentation(status: string): BadgePresentation {
+  return INITIATIVE_STATUS[status as InitiativeStatus] ?? { label: status, variant: 'outline' }
+}
+
+const ITEM_STATUS: Record<ItemStatus, BadgePresentation> = {
+  open: { label: 'Open', variant: 'outline', className: 'text-muted-foreground' },
+  'in-progress': {
+    label: 'In progress',
+    variant: 'secondary',
+    className: 'border-transparent bg-amber-100 text-amber-800',
+  },
+  done: {
+    label: 'Done',
+    variant: 'secondary',
+    className: 'border-transparent bg-emerald-100 text-emerald-800',
+  },
+  waived: { label: 'Waived', variant: 'outline', className: 'text-muted-foreground line-through' },
+}
+
+/** Map an action-item status to a badge; unknown values render as a neutral chip. */
+export function itemStatusPresentation(status: string): BadgePresentation {
+  return ITEM_STATUS[status as ItemStatus] ?? { label: status, variant: 'outline' }
+}
+
+/** Human labels for the item-status <Select> (value → label), ladder order. */
+export const ITEM_STATUS_OPTIONS: { value: ItemStatus; label: string }[] = [
+  { value: 'open', label: 'Open' },
+  { value: 'in-progress', label: 'In progress' },
+  { value: 'done', label: 'Done' },
+  { value: 'waived', label: 'Waived' },
+]
+
+/**
+ * True when `deadline` is strictly earlier than `now`. Pure past-check — callers
+ * apply it only to *active* initiatives (a completed/cancelled campaign is never
+ * flagged overdue). Returns false when no deadline is set.
+ */
+export function isOverdue(deadline: DateInput, now: Date): boolean {
+  if (deadline == null) return false
+  const t = new Date(deadline).getTime()
+  if (Number.isNaN(t)) return false
+  return t < now.getTime()
+}
+
+const DEADLINE_FMT = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+/** Short, TZ-stable deadline label ("Jul 2, 2026"), or "No deadline" when unset. */
+export function formatDeadline(deadline: DateInput): string {
+  if (deadline == null) return 'No deadline'
+  const d = new Date(deadline)
+  if (Number.isNaN(d.getTime())) return 'No deadline'
+  return DEADLINE_FMT.format(d)
+}
+
+/**
+ * Tailwind text tone for a completion percentage (0..100). Reuses the scorecard
+ * pass-ratio thresholds so progress reads consistently across the two features.
+ */
+export function progressTone(pct: number): string {
+  return passRatioTone(pct / 100)
+}
+
+/** Chip/label text for an initiative's target ladder level. */
+export function targetLevelLabel(targetLevel?: string | null): string {
+  const t = typeof targetLevel === 'string' ? targetLevel.trim() : ''
+  return t ? `Target: ${t}` : 'No target level'
+}
+
+// ---------------------------------------------------------------------------
+// View models
+//
+// The presentational contract the initiative components render against. Kept
+// here (framework-light) so the components stay decoupled from the server
+// actions; the pages import the real action return types (from
+// lib/scorecards/initiatives.ts + the actions module) and pass them in. These
+// mirror that contract structurally — any drift surfaces as a page tsc error.
+// ---------------------------------------------------------------------------
+
+/** Progress rollup for one initiative (mirrors computeInitiativeProgress). */
+export interface InitiativeProgressView {
+  total: number
+  open: number
+  inProgress: number
+  done: number
+  waived: number
+  pctComplete: number
+}
+
+/** One initiative as rendered on the list page. */
+export interface InitiativeSummaryView {
+  id: string
+  name: string
+  scorecardName: string
+  targetLevel?: string | null
+  status: string
+  deadline?: string | null
+  ownerName?: string | null
+  progress: InitiativeProgressView
+}
+
+/** One action item, enriched for the detail table. */
+export interface ActionItemView {
+  id: string
+  entityId: string
+  entityName: string
+  entityKind?: string | null
+  ruleId?: string | null
+  ruleTitle?: string | null
+  ruleLevel?: string | null
+  status: string
+  assigneeId?: string | null
+  assigneeName?: string | null
+  notes?: string | null
+  updatedAt?: string | null
+}
+
+/** Full initiative detail: header fields, progress + enriched items. */
+export interface InitiativeDetailView {
+  id: string
+  name: string
+  description?: string | null
+  scorecardId: string
+  scorecardName: string
+  targetLevel?: string | null
+  status: string
+  deadline?: string | null
+  ownerName?: string | null
+  progress: InitiativeProgressView
+  items: ActionItemView[]
+}
+
+/** A scorecard option for the create form's picker (mirrors listScorecardOptions). */
+export interface ScorecardOption {
+  id: string
+  name: string
+  levels: { name: string; rank: number }[]
+}

--- a/orbit-www/src/lib/scorecards/evaluate.ts
+++ b/orbit-www/src/lib/scorecards/evaluate.ts
@@ -1032,5 +1032,32 @@ export async function runScorecardEvaluation(
     }
   })()
 
+  // Fire-and-forget: reconcile every ACTIVE initiative on this scorecard with
+  // the fresh results (auto-complete fixed items, reopen regressions) — the
+  // Initiatives auto-sync (docs/plans/2026-07-02-initiatives-ui.md). Mirrors
+  // the snapshot capture above: a per-initiative sync failure must NEVER fail
+  // an evaluation, and the dynamic import keeps the module boundary loose.
+  ;(async () => {
+    try {
+      const { syncInitiativeActionItems } = await import('./initiatives')
+      const initiativesRes = await payload.find({
+        collection: 'initiatives',
+        where: { and: [{ scorecard: { equals: scorecardId } }, { status: { equals: 'active' } }] },
+        limit: 1000,
+        depth: 0,
+        overrideAccess: true,
+      })
+      for (const initiative of initiativesRes.docs as { id: string }[]) {
+        try {
+          await syncInitiativeActionItems(payload, initiative.id)
+        } catch (err) {
+          console.error(`[runScorecardEvaluation] initiative sync failed for ${initiative.id}:`, err)
+        }
+      }
+    } catch (err) {
+      console.error('[runScorecardEvaluation] initiative sync failed:', err)
+    }
+  })()
+
   return { scorecardId, entitiesEvaluated, rulesEvaluated, resultsWritten }
 }

--- a/orbit-www/src/lib/scorecards/initiatives.test.ts
+++ b/orbit-www/src/lib/scorecards/initiatives.test.ts
@@ -1,0 +1,613 @@
+import { describe, it, expect } from 'vitest'
+import type { Payload } from 'payload'
+import type { InitiativeActionItem, ScorecardRuleResult } from '@/payload-types'
+import type { LevelDef } from '@/components/features/scorecards/scorecard-ui'
+import { runScorecardEvaluation } from './evaluate'
+import {
+  computeTargetRank,
+  selectInScopeRules,
+  computeFailingPairs,
+  diffActionItems,
+  computeInitiativeProgress,
+  latestRuleResults,
+  appendNote,
+  toActionItemLite,
+  syncInitiativeActionItems,
+  isActiveWorkspaceMember,
+  assertAssigneeInWorkspace,
+  AUTO_COMPLETE_NOTE,
+  REOPEN_NOTE,
+  type ActionItemLite,
+  type FailingPair,
+  type RuleLite,
+} from './initiatives'
+
+const LEVELS: LevelDef[] = [
+  { name: 'Bronze', rank: 1 },
+  { name: 'Silver', rank: 2 },
+  { name: 'Gold', rank: 3 },
+]
+
+// --- computeTargetRank -------------------------------------------------------
+
+describe('computeTargetRank', () => {
+  it('returns the rank of a known level name', () => {
+    expect(computeTargetRank(LEVELS, 'Silver')).toBe(2)
+  })
+  it('returns null for an unknown level name', () => {
+    expect(computeTargetRank(LEVELS, 'Platinum')).toBeNull()
+  })
+  it('returns null when the target is absent', () => {
+    expect(computeTargetRank(LEVELS, null)).toBeNull()
+    expect(computeTargetRank(LEVELS, undefined)).toBeNull()
+    expect(computeTargetRank(LEVELS, '')).toBeNull()
+  })
+})
+
+// --- selectInScopeRules ------------------------------------------------------
+
+describe('selectInScopeRules', () => {
+  const rules: RuleLite[] = [
+    { id: 'base', level: null }, // level-less base rule
+    { id: 'bronze', level: 'Bronze' },
+    { id: 'silver', level: 'Silver' },
+    { id: 'gold', level: 'Gold' },
+    { id: 'ghost', level: 'Platinum' }, // off-ladder level
+  ]
+
+  it('includes level-less rules plus leveled rules with rank <= target rank', () => {
+    const ids = selectInScopeRules(rules, LEVELS, 'Silver').map((r) => r.id)
+    expect(ids.sort()).toEqual(['base', 'bronze', 'silver'])
+  })
+
+  it('at the top target, includes every on-ladder leveled rule plus base', () => {
+    const ids = selectInScopeRules(rules, LEVELS, 'Gold').map((r) => r.id)
+    expect(ids.sort()).toEqual(['base', 'bronze', 'gold', 'silver'])
+  })
+
+  it('excludes rules tagged with a level not on the ladder (gates no rung)', () => {
+    const ids = selectInScopeRules(rules, LEVELS, 'Gold').map((r) => r.id)
+    expect(ids).not.toContain('ghost')
+  })
+
+  it('with a null/unknown target rank, only level-less base rules are in scope', () => {
+    expect(selectInScopeRules(rules, LEVELS, 'Platinum').map((r) => r.id)).toEqual(['base'])
+    expect(selectInScopeRules(rules, LEVELS, null).map((r) => r.id)).toEqual(['base'])
+  })
+})
+
+// --- computeFailingPairs -----------------------------------------------------
+
+describe('computeFailingPairs', () => {
+  const rules: RuleLite[] = [
+    { id: 'base', level: null },
+    { id: 'bronze', level: 'Bronze' },
+    { id: 'gold', level: 'Gold' },
+  ]
+
+  it('emits a pair for every failing latest result on an in-scope rule', () => {
+    const results = [
+      { ruleId: 'base', entityId: 'e1', passed: false },
+      { ruleId: 'bronze', entityId: 'e1', passed: false },
+      { ruleId: 'base', entityId: 'e2', passed: true }, // passing → excluded
+    ]
+    const pairs = computeFailingPairs(rules, results, LEVELS, 'Bronze')
+    expect(pairs).toEqual([
+      { entityId: 'e1', ruleId: 'base' },
+      { entityId: 'e1', ruleId: 'bronze' },
+    ])
+  })
+
+  it('excludes failing results for out-of-scope (above-target) rules', () => {
+    const results = [
+      { ruleId: 'bronze', entityId: 'e1', passed: false },
+      { ruleId: 'gold', entityId: 'e1', passed: false }, // above Bronze target
+    ]
+    const pairs = computeFailingPairs(rules, results, LEVELS, 'Bronze')
+    expect(pairs).toEqual([{ entityId: 'e1', ruleId: 'bronze' }])
+  })
+})
+
+// --- diffActionItems ---------------------------------------------------------
+
+function item(partial: Partial<ActionItemLite> & { id: string }): ActionItemLite {
+  return {
+    entityId: partial.entityId ?? 'e1',
+    ruleId: partial.ruleId ?? 'r1',
+    status: partial.status ?? 'open',
+    notes: partial.notes ?? null,
+    ...partial,
+  }
+}
+
+describe('diffActionItems', () => {
+  it('creates an item for a failing pair with no existing item', () => {
+    const failing: FailingPair[] = [{ entityId: 'e1', ruleId: 'r1' }]
+    const diff = diffActionItems([], failing)
+    expect(diff.toCreate).toEqual(failing)
+    expect(diff.toComplete).toEqual([])
+    expect(diff.toReopen).toEqual([])
+  })
+
+  it('leaves an open item whose pair is still failing untouched', () => {
+    const existing = [item({ id: 'a', status: 'open' })]
+    const diff = diffActionItems(existing, [{ entityId: 'e1', ruleId: 'r1' }])
+    expect(diff).toEqual({ toCreate: [], toComplete: [], toReopen: [] })
+  })
+
+  it('auto-completes an open item whose pair now passes (not in failing set)', () => {
+    const existing = [item({ id: 'a', status: 'open' })]
+    const diff = diffActionItems(existing, [])
+    expect(diff.toComplete.map((i) => i.id)).toEqual(['a'])
+    expect(diff.toCreate).toEqual([])
+    expect(diff.toReopen).toEqual([])
+  })
+
+  it('auto-completes an in-progress item whose pair left scope', () => {
+    const existing = [item({ id: 'a', status: 'in-progress' })]
+    const diff = diffActionItems(existing, [])
+    expect(diff.toComplete.map((i) => i.id)).toEqual(['a'])
+  })
+
+  it('reopens a done item whose pair fails again', () => {
+    const existing = [item({ id: 'a', status: 'done' })]
+    const diff = diffActionItems(existing, [{ entityId: 'e1', ruleId: 'r1' }])
+    expect(diff.toReopen.map((i) => i.id)).toEqual(['a'])
+    expect(diff.toComplete).toEqual([])
+    expect(diff.toCreate).toEqual([])
+  })
+
+  it('leaves a done item whose pair still passes untouched', () => {
+    const existing = [item({ id: 'a', status: 'done' })]
+    const diff = diffActionItems(existing, [])
+    expect(diff).toEqual({ toCreate: [], toComplete: [], toReopen: [] })
+  })
+
+  it('never touches a waived item — pair passing', () => {
+    const existing = [item({ id: 'a', status: 'waived' })]
+    const diff = diffActionItems(existing, [])
+    expect(diff).toEqual({ toCreate: [], toComplete: [], toReopen: [] })
+  })
+
+  it('never touches a waived item — pair failing (no reopen, no duplicate create)', () => {
+    const existing = [item({ id: 'a', status: 'waived' })]
+    const diff = diffActionItems(existing, [{ entityId: 'e1', ruleId: 'r1' }])
+    // waived counts as an existing item for this pair → no create, no reopen.
+    expect(diff).toEqual({ toCreate: [], toComplete: [], toReopen: [] })
+  })
+
+  it('ignores items with no rule id (manual, not sync-managed)', () => {
+    const existing = [item({ id: 'a', ruleId: null, status: 'open' })]
+    const diff = diffActionItems(existing, [])
+    expect(diff).toEqual({ toCreate: [], toComplete: [], toReopen: [] })
+  })
+
+  it('dedupes repeated failing pairs into a single create', () => {
+    const failing: FailingPair[] = [
+      { entityId: 'e1', ruleId: 'r1' },
+      { entityId: 'e1', ruleId: 'r1' },
+    ]
+    const diff = diffActionItems([], failing)
+    expect(diff.toCreate).toEqual([{ entityId: 'e1', ruleId: 'r1' }])
+  })
+
+  it('handles a mixed batch across entities and rules', () => {
+    const existing = [
+      item({ id: 'keep', entityId: 'e1', ruleId: 'r1', status: 'open' }), // still failing
+      item({ id: 'complete', entityId: 'e1', ruleId: 'r2', status: 'in-progress' }), // now passing
+      item({ id: 'reopen', entityId: 'e2', ruleId: 'r1', status: 'done' }), // fails again
+      item({ id: 'waived', entityId: 'e2', ruleId: 'r2', status: 'waived' }), // immune
+    ]
+    const failing: FailingPair[] = [
+      { entityId: 'e1', ruleId: 'r1' }, // keep
+      { entityId: 'e2', ruleId: 'r1' }, // reopen
+      { entityId: 'e3', ruleId: 'r1' }, // new create
+    ]
+    const diff = diffActionItems(existing, failing)
+    expect(diff.toCreate).toEqual([{ entityId: 'e3', ruleId: 'r1' }])
+    expect(diff.toComplete.map((i) => i.id)).toEqual(['complete'])
+    expect(diff.toReopen.map((i) => i.id)).toEqual(['reopen'])
+  })
+})
+
+// --- computeInitiativeProgress ----------------------------------------------
+
+describe('computeInitiativeProgress', () => {
+  it('is 100% complete for an empty item list', () => {
+    expect(computeInitiativeProgress([])).toEqual({
+      total: 0,
+      open: 0,
+      inProgress: 0,
+      done: 0,
+      waived: 0,
+      pctComplete: 100,
+    })
+  })
+
+  it('counts each status and computes (done + waived) / total', () => {
+    const progress = computeInitiativeProgress([
+      { status: 'open' },
+      { status: 'in-progress' },
+      { status: 'done' },
+      { status: 'waived' },
+    ])
+    expect(progress).toEqual({
+      total: 4,
+      open: 1,
+      inProgress: 1,
+      done: 1,
+      waived: 1,
+      pctComplete: 50,
+    })
+  })
+
+  it('treats waived as counting toward completion (all waived → 100%)', () => {
+    expect(computeInitiativeProgress([{ status: 'waived' }, { status: 'waived' }]).pctComplete).toBe(100)
+  })
+
+  it('rounds the percentage', () => {
+    // 1 of 3 complete → round(33.33) = 33
+    expect(computeInitiativeProgress([{ status: 'done' }, { status: 'open' }, { status: 'open' }]).pctComplete).toBe(33)
+    // 2 of 3 complete → round(66.67) = 67
+    expect(computeInitiativeProgress([{ status: 'done' }, { status: 'done' }, { status: 'open' }]).pctComplete).toBe(67)
+  })
+})
+
+// --- latestRuleResults / appendNote / toActionItemLite ----------------------
+
+describe('latestRuleResults', () => {
+  it('reduces to one lite result per (rule, entity), newest evaluatedAt wins', () => {
+    const rows = [
+      { rule: 'r1', entity: 'e1', passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' },
+      { rule: 'r1', entity: 'e1', passed: true, evaluatedAt: '2026-07-02T00:00:00.000Z' },
+      { rule: 'r2', entity: 'e1', passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' },
+    ] as unknown as ScorecardRuleResult[]
+    const latest = latestRuleResults(rows)
+    expect(latest).toContainEqual({ ruleId: 'r1', entityId: 'e1', passed: true })
+    expect(latest).toContainEqual({ ruleId: 'r2', entityId: 'e1', passed: false })
+    expect(latest).toHaveLength(2)
+  })
+
+  it('normalises populated relationship ends to their ids', () => {
+    const rows = [
+      { rule: { id: 'r1' }, entity: { id: 'e1' }, passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' },
+    ] as unknown as ScorecardRuleResult[]
+    expect(latestRuleResults(rows)).toEqual([{ ruleId: 'r1', entityId: 'e1', passed: false }])
+  })
+})
+
+describe('appendNote', () => {
+  it('returns the line alone when there are no existing notes', () => {
+    expect(appendNote(null, 'hello')).toBe('hello')
+    expect(appendNote('', 'hello')).toBe('hello')
+    expect(appendNote('   ', 'hello')).toBe('hello')
+  })
+  it('appends on a fresh line, preserving prior content', () => {
+    expect(appendNote('first', 'second')).toBe('first\nsecond')
+  })
+})
+
+describe('toActionItemLite', () => {
+  it('maps a persisted row to the lite shape, defaulting status to open', () => {
+    const row = {
+      id: 'a',
+      entity: { id: 'e1' },
+      rule: 'r1',
+      status: null,
+      notes: 'x',
+    } as unknown as InitiativeActionItem
+    expect(toActionItemLite(row)).toEqual({ id: 'a', entityId: 'e1', ruleId: 'r1', status: 'open', notes: 'x' })
+  })
+})
+
+// --- FakePayload (sync wrapper + evaluation-hook integration) ----------------
+//
+// Mirrors evaluate.test.ts's in-memory Payload stand-in, extended with the
+// initiatives / initiative-action-items collections this module reads/writes.
+
+type Doc = Record<string, unknown> & { id: string }
+
+class FakePayload {
+  collections: Record<string, Doc[]> = {
+    'catalog-entities': [],
+    'catalog-relations': [],
+    scorecards: [],
+    'scorecard-rules': [],
+    'scorecard-rule-results': [],
+    'entity-scores': [],
+    'entity-types': [],
+    initiatives: [],
+    'initiative-action-items': [],
+    'score-snapshots': [],
+    'workspace-members': [],
+  }
+  private counter = 1
+  /** Collections whose writes should throw (to exercise failure paths). */
+  throwOnWrite = new Set<string>()
+
+  private nextId(collection: string): string {
+    return `${collection}-${this.counter++}`
+  }
+
+  async find({
+    collection,
+    where,
+    limit = 100,
+    page = 1,
+    depth = 0,
+  }: {
+    collection: string
+    where?: unknown
+    limit?: number
+    page?: number
+    depth?: number
+  }) {
+    const all = (this.collections[collection] ?? []).filter((d) => matchesWhere(d, where))
+    const start = (page - 1) * limit
+    let docs = all.slice(start, start + limit)
+    const hasNextPage = start + limit < all.length
+    if (depth >= 1 && collection === 'catalog-relations') {
+      docs = docs.map((d) => ({ ...d, from: this.populate(d.from), to: this.populate(d.to) }))
+    }
+    return { docs, hasNextPage }
+  }
+
+  private populate(idOrDoc: unknown): unknown {
+    if (typeof idOrDoc !== 'string') return idOrDoc
+    return this.collections['catalog-entities'].find((e) => e.id === idOrDoc) ?? idOrDoc
+  }
+
+  async findByID({ collection, id }: { collection: string; id: string }) {
+    const doc = (this.collections[collection] ?? []).find((d) => d.id === id)
+    if (!doc) throw new Error(`${collection}/${id} not found`)
+    return doc
+  }
+
+  async create({ collection, data }: { collection: string; data: Record<string, unknown> }) {
+    if (this.throwOnWrite.has(collection)) throw new Error(`create ${collection} blew up`)
+    const doc = { id: this.nextId(collection), ...data } as Doc
+    this.collections[collection] = this.collections[collection] ?? []
+    this.collections[collection].push(doc)
+    return doc
+  }
+
+  async update({ collection, id, data }: { collection: string; id: string; data: Record<string, unknown> }) {
+    if (this.throwOnWrite.has(collection)) throw new Error(`update ${collection} blew up`)
+    const list = this.collections[collection] ?? []
+    const idx = list.findIndex((d) => d.id === id)
+    if (idx === -1) throw new Error(`${collection}/${id} not found`)
+    list[idx] = { ...list[idx], ...data }
+    return list[idx]
+  }
+}
+
+function matchesWhere(doc: Doc, where: unknown): boolean {
+  if (!where || typeof where !== 'object') return true
+  const w = where as Record<string, unknown>
+  if (Array.isArray(w.and)) return (w.and as unknown[]).every((clause) => matchesWhere(doc, clause))
+  if (Array.isArray(w.or)) return (w.or as unknown[]).some((clause) => matchesWhere(doc, clause))
+  for (const [field, condRaw] of Object.entries(w)) {
+    const cond = condRaw as Record<string, unknown>
+    const raw = doc[field]
+    const actualId = raw && typeof raw === 'object' ? (raw as Doc).id : raw
+    if ('equals' in cond) {
+      if (actualId !== cond.equals) return false
+    } else if ('in' in cond) {
+      if (!(cond.in as unknown[]).includes(actualId)) return false
+    } else if ('exists' in cond) {
+      const exists = raw !== undefined && raw !== null
+      if (exists !== cond.exists) return false
+    }
+  }
+  return true
+}
+
+/** Let all fire-and-forget microtasks/timeouts settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 30; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+// --- syncInitiativeActionItems ----------------------------------------------
+
+describe('syncInitiativeActionItems', () => {
+  function seed(): FakePayload {
+    const fp = new FakePayload()
+    fp.collections['scorecards'] = [
+      { id: 'sc1', workspace: 'ws1', levels: [{ name: 'Bronze', rank: 1 }, { name: 'Gold', rank: 3 }] },
+    ]
+    fp.collections['scorecard-rules'] = [
+      { id: 'base', scorecard: 'sc1', workspace: 'ws1', level: null },
+      { id: 'bronze', scorecard: 'sc1', workspace: 'ws1', level: 'Bronze' },
+      { id: 'gold', scorecard: 'sc1', workspace: 'ws1', level: 'Gold' },
+    ]
+    fp.collections['initiatives'] = [
+      { id: 'ini1', workspace: 'ws1', scorecard: 'sc1', targetLevel: 'Bronze', status: 'active' },
+    ]
+    return fp
+  }
+
+  it('creates open items for failing in-scope pairs, ignoring out-of-scope failures', async () => {
+    const fp = seed()
+    fp.collections['scorecard-rule-results'] = [
+      { id: 'rr1', scorecard: 'sc1', rule: 'base', entity: 'e1', passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' },
+      { id: 'rr2', scorecard: 'sc1', rule: 'bronze', entity: 'e1', passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' },
+      { id: 'rr3', scorecard: 'sc1', rule: 'gold', entity: 'e1', passed: false, evaluatedAt: '2026-07-01T00:00:00.000Z' }, // out of scope for Bronze
+    ]
+
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'ini1')
+
+    expect(result).toEqual({ created: 2, completed: 0, reopened: 0 })
+    const items = fp.collections['initiative-action-items']
+    expect(items).toHaveLength(2)
+    expect(items.every((i) => i.status === 'open' && i.initiative === 'ini1' && i.workspace === 'ws1')).toBe(true)
+    expect(items.map((i) => i.rule).sort()).toEqual(['base', 'bronze'])
+  })
+
+  it('auto-completes an open item whose rule now passes, appending a note', async () => {
+    const fp = seed()
+    fp.collections['scorecard-rule-results'] = [
+      { id: 'rr1', scorecard: 'sc1', rule: 'base', entity: 'e1', passed: true, evaluatedAt: '2026-07-02T00:00:00.000Z' },
+    ]
+    fp.collections['initiative-action-items'] = [
+      { id: 'ai1', workspace: 'ws1', initiative: 'ini1', entity: 'e1', rule: 'base', status: 'open', notes: 'looking into it' },
+    ]
+
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'ini1')
+
+    expect(result).toEqual({ created: 0, completed: 1, reopened: 0 })
+    const item = fp.collections['initiative-action-items'][0]
+    expect(item.status).toBe('done')
+    expect(item.notes).toBe(`looking into it\n${AUTO_COMPLETE_NOTE}`)
+  })
+
+  it('reopens a done item whose rule fails again, appending a note', async () => {
+    const fp = seed()
+    fp.collections['scorecard-rule-results'] = [
+      { id: 'rr1', scorecard: 'sc1', rule: 'base', entity: 'e1', passed: false, evaluatedAt: '2026-07-02T00:00:00.000Z' },
+    ]
+    fp.collections['initiative-action-items'] = [
+      { id: 'ai1', workspace: 'ws1', initiative: 'ini1', entity: 'e1', rule: 'base', status: 'done', notes: null },
+    ]
+
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'ini1')
+
+    expect(result).toEqual({ created: 0, completed: 0, reopened: 1 })
+    const item = fp.collections['initiative-action-items'][0]
+    expect(item.status).toBe('open')
+    expect(item.notes).toBe(REOPEN_NOTE)
+  })
+
+  it('never touches a waived item and returns zeros for a settled initiative', async () => {
+    const fp = seed()
+    fp.collections['scorecard-rule-results'] = [
+      { id: 'rr1', scorecard: 'sc1', rule: 'base', entity: 'e1', passed: false, evaluatedAt: '2026-07-02T00:00:00.000Z' },
+    ]
+    fp.collections['initiative-action-items'] = [
+      { id: 'ai1', workspace: 'ws1', initiative: 'ini1', entity: 'e1', rule: 'base', status: 'waived', notes: 'accepted' },
+    ]
+
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'ini1')
+
+    expect(result).toEqual({ created: 0, completed: 0, reopened: 0 })
+    expect(fp.collections['initiative-action-items'][0]).toMatchObject({ status: 'waived', notes: 'accepted' })
+  })
+
+  it('is a no-op returning zeros for a non-active initiative', async () => {
+    const fp = seed()
+    fp.collections['initiatives'][0].status = 'completed'
+    fp.collections['scorecard-rule-results'] = [
+      { id: 'rr1', scorecard: 'sc1', rule: 'base', entity: 'e1', passed: false, evaluatedAt: '2026-07-02T00:00:00.000Z' },
+    ]
+
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'ini1')
+
+    expect(result).toEqual({ created: 0, completed: 0, reopened: 0 })
+    expect(fp.collections['initiative-action-items']).toHaveLength(0)
+  })
+
+  it('returns zeros when the initiative does not exist', async () => {
+    const fp = seed()
+    const result = await syncInitiativeActionItems(fp as unknown as Payload, 'missing')
+    expect(result).toEqual({ created: 0, completed: 0, reopened: 0 })
+  })
+})
+
+// --- runScorecardEvaluation hook-in -----------------------------------------
+
+describe('runScorecardEvaluation → initiative sync hook', () => {
+  function seedEval(): FakePayload {
+    const fp = new FakePayload()
+    fp.collections['catalog-entities'] = [{ id: 'e1', kind: 'service', workspace: 'ws1' }]
+    fp.collections['scorecards'] = [{ id: 'sc1', workspace: 'ws1', levels: [{ name: 'Bronze', rank: 1 }] }]
+    // A rule that fails for e1 (owner is not set) so the initiative has work to do.
+    fp.collections['scorecard-rules'] = [
+      { id: 'base', scorecard: 'sc1', workspace: 'ws1', level: null, type: 'field-presence', weight: 1, expression: { path: 'owner', op: 'exists' } },
+    ]
+    fp.collections['initiatives'] = [
+      { id: 'ini1', workspace: 'ws1', scorecard: 'sc1', targetLevel: 'Bronze', status: 'active' },
+    ]
+    return fp
+  }
+
+  it('resolves with the evaluation summary and syncs active initiatives (fire-and-forget)', async () => {
+    const fp = seedEval()
+
+    const summary = await runScorecardEvaluation(fp as unknown as Payload, 'sc1')
+    expect(summary.entitiesEvaluated).toBe(1)
+    expect(summary.rulesEvaluated).toBe(1)
+
+    await flush()
+
+    const items = fp.collections['initiative-action-items']
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ initiative: 'ini1', entity: 'e1', rule: 'base', status: 'open' })
+  })
+
+  it('does not sync completed/cancelled initiatives', async () => {
+    const fp = seedEval()
+    fp.collections['initiatives'][0].status = 'completed'
+
+    await runScorecardEvaluation(fp as unknown as Payload, 'sc1')
+    await flush()
+
+    expect(fp.collections['initiative-action-items']).toHaveLength(0)
+  })
+
+  it('a sync failure never fails the evaluation', async () => {
+    const fp = seedEval()
+    fp.throwOnWrite.add('initiative-action-items') // any sync write throws
+
+    // Must resolve (not reject) despite the sync error swallowed by the hook.
+    const summary = await runScorecardEvaluation(fp as unknown as Payload, 'sc1')
+    expect(summary.entitiesEvaluated).toBe(1)
+
+    await flush()
+    // The throwing write left no items behind, but evaluation still succeeded.
+    expect(fp.collections['initiative-action-items']).toHaveLength(0)
+  })
+})
+
+// --- assignee workspace validation ------------------------------------------
+
+describe('isActiveWorkspaceMember / assertAssigneeInWorkspace', () => {
+  function seed(): FakePayload {
+    const fp = new FakePayload()
+    fp.collections['workspace-members'] = [
+      { id: 'm1', user: 'u-member', workspace: 'ws1', status: 'active' },
+      { id: 'm2', user: 'u-inactive', workspace: 'ws1', status: 'invited' },
+      { id: 'm3', user: 'u-other-ws', workspace: 'ws2', status: 'active' },
+    ]
+    return fp
+  }
+
+  it('isActiveWorkspaceMember is true only for an active member of the workspace', async () => {
+    const fp = seed()
+    expect(await isActiveWorkspaceMember(fp as unknown as Payload, 'u-member', 'ws1')).toBe(true)
+    expect(await isActiveWorkspaceMember(fp as unknown as Payload, 'u-inactive', 'ws1')).toBe(false)
+    expect(await isActiveWorkspaceMember(fp as unknown as Payload, 'u-other-ws', 'ws1')).toBe(false)
+    expect(await isActiveWorkspaceMember(fp as unknown as Payload, 'u-nobody', 'ws1')).toBe(false)
+  })
+
+  it('assertAssigneeInWorkspace accepts an active member of the workspace', async () => {
+    const fp = seed()
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, 'u-member', 'ws1')).resolves.toBeUndefined()
+  })
+
+  it('assertAssigneeInWorkspace rejects a foreign/non-member user', async () => {
+    const fp = seed()
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, 'u-other-ws', 'ws1')).rejects.toThrow(
+      /active member/i,
+    )
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, 'u-nobody', 'ws1')).rejects.toThrow()
+  })
+
+  it('assertAssigneeInWorkspace passes through when clearing the assignee (null/undefined/empty), issuing no query', async () => {
+    const fp = seed()
+    // No workspace-members rows at all → would reject any concrete id, but
+    // clearing must still pass without touching the collection.
+    fp.collections['workspace-members'] = []
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, null, 'ws1')).resolves.toBeUndefined()
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, undefined, 'ws1')).resolves.toBeUndefined()
+    await expect(assertAssigneeInWorkspace(fp as unknown as Payload, '', 'ws1')).resolves.toBeUndefined()
+  })
+})

--- a/orbit-www/src/lib/scorecards/initiatives.ts
+++ b/orbit-www/src/lib/scorecards/initiatives.ts
@@ -1,0 +1,501 @@
+import type { Payload } from 'payload'
+import type {
+  CatalogEntity,
+  Initiative,
+  InitiativeActionItem,
+  Scorecard,
+  ScorecardRule,
+  ScorecardRuleResult,
+  User,
+} from '@/payload-types'
+import type { LevelDef } from '@/components/features/scorecards/scorecard-ui'
+
+/**
+ * Initiatives sync engine (Initiatives UI + auto-generated action items,
+ * docs/plans/2026-07-02-initiatives-ui.md, WP1).
+ *
+ * Closes the measure→improve loop (the Cortex Initiatives model): an initiative
+ * targets a scorecard level by a deadline, and Orbit keeps one action item per
+ * (failing entity × in-scope failing rule) in sync with the latest evaluation —
+ * fixed things auto-complete, regressions reopen, waived items are sacrosanct.
+ *
+ * The diff/progress/scope logic is pure and unit-tested; the Payload-touching
+ * wrapper (`syncInitiativeActionItems`) stays thin and mirrors `evaluate.ts`'s
+ * page-loop reads + `overrideAccess` writes.
+ */
+
+// --- shared plain-data types (no Payload types leak past this module) --------
+
+export type ItemStatus = 'open' | 'in-progress' | 'done' | 'waived'
+export type InitiativeStatus = 'active' | 'completed' | 'cancelled'
+
+/** Minimal rule shape needed to attribute a rule to a ladder rung. */
+export interface RuleLite {
+  id: string
+  level?: string | null
+}
+
+/** A (entity, in-scope rule) pair whose latest result is failing. */
+export interface FailingPair {
+  entityId: string
+  ruleId: string
+}
+
+/** The single latest scorecard-rule-results row for a (rule, entity) pair. */
+export interface RuleResultLite {
+  ruleId: string
+  entityId: string
+  passed: boolean
+}
+
+/** Minimal action-item shape the diff/progress functions operate on. */
+export interface ActionItemLite {
+  id: string
+  entityId: string
+  /** Null for a manually-created item with no rule — such items are never
+   *  touched by sync (they are not sync-managed). */
+  ruleId: string | null
+  status: ItemStatus
+  notes?: string | null
+}
+
+export interface InitiativeProgress {
+  total: number
+  open: number
+  inProgress: number
+  done: number
+  waived: number
+  /** round(100 × (done + waived) / total); 100 when total === 0. */
+  pctComplete: number
+}
+
+export interface ActionItemDiff {
+  toCreate: FailingPair[]
+  toComplete: ActionItemLite[]
+  toReopen: ActionItemLite[]
+}
+
+export interface SyncResult {
+  created: number
+  completed: number
+  reopened: number
+}
+
+// --- view-model types (server-action contract; UI codes against these) ------
+
+export interface InitiativeSummary {
+  id: string
+  name: string
+  description?: string | null
+  scorecardId: string
+  scorecardName: string
+  targetLevel?: string | null
+  ownerId?: string | null
+  ownerName?: string | null
+  deadline?: string | null
+  status: InitiativeStatus
+  progress: InitiativeProgress
+}
+
+export interface InitiativeDetailItem {
+  id: string
+  entityId: string
+  entityName: string
+  entityKind?: string | null
+  ruleId?: string | null
+  ruleTitle?: string | null
+  ruleLevel?: string | null
+  status: ItemStatus
+  assigneeId?: string | null
+  assigneeName?: string | null
+  notes?: string | null
+  updatedAt: string
+}
+
+export interface InitiativeDetail {
+  id: string
+  name: string
+  description?: string | null
+  scorecardId: string
+  scorecardName: string
+  targetLevel?: string | null
+  ownerId?: string | null
+  ownerName?: string | null
+  deadline?: string | null
+  status: InitiativeStatus
+  canManage: boolean
+  progress: InitiativeProgress
+  items: InitiativeDetailItem[]
+}
+
+export interface ScorecardOption {
+  id: string
+  name: string
+  levels: { name: string; rank: number }[]
+}
+
+// --- notes appended by sync -------------------------------------------------
+
+export const AUTO_COMPLETE_NOTE = 'auto-completed: rule now passing'
+export const REOPEN_NOTE = 'reopened: rule is failing again'
+
+// --- pure functions ---------------------------------------------------------
+
+/** Normalise a relationship end (id string or populated doc) to its id, or null. */
+function relId(v: unknown): string | null {
+  if (v == null) return null
+  if (typeof v === 'string') return v
+  if (typeof v === 'object' && 'id' in (v as Record<string, unknown>)) {
+    return String((v as { id: unknown }).id)
+  }
+  return null
+}
+
+/**
+ * Rank of `targetLevel` within the scorecard's ladder, or `null` when the name
+ * isn't on the ladder (or is absent). A null rank means "no leveled rule can be
+ * placed relative to the target", so `selectInScopeRules` keeps only the
+ * always-gating level-less rules in scope.
+ */
+export function computeTargetRank(
+  levels: LevelDef[],
+  targetLevel: string | null | undefined,
+): number | null {
+  if (!targetLevel) return null
+  const match = levels.find((l) => l.name === targetLevel)
+  return match ? match.rank : null
+}
+
+/**
+ * The rules in scope for an initiative targeting `targetLevel`.
+ *
+ * Mirrors `computeEntityLevel` (evaluate.ts): level-less rules are the "base"
+ * rung that gates EVERY level, so they are ALWAYS in scope regardless of the
+ * target. A rule tagged with a ladder level is in scope when that level's rank
+ * ≤ the target rank. A rule tagged with a level that is NOT on the ladder gates
+ * no rung (computeEntityLevel simply never evaluates it against any level), so
+ * it is treated as OUT of scope here. When the target rank is null (targetLevel
+ * absent or off-ladder), only the level-less base rules remain in scope.
+ */
+export function selectInScopeRules(
+  rules: RuleLite[],
+  levels: LevelDef[],
+  targetLevel: string | null | undefined,
+): RuleLite[] {
+  const targetRank = computeTargetRank(levels, targetLevel)
+  const rankByName = new Map(levels.map((l) => [l.name, l.rank]))
+
+  return rules.filter((rule) => {
+    if (!rule.level) return true // base rule — gates every rung
+    const rank = rankByName.get(rule.level)
+    if (rank === undefined) return false // off-ladder level — gates no rung
+    if (targetRank === null) return false // nothing to compare against
+    return rank <= targetRank
+  })
+}
+
+/**
+ * The failing (entity × in-scope rule) pairs for an initiative: every latest
+ * rule result that is (a) for an in-scope rule and (b) `passed === false`.
+ */
+export function computeFailingPairs(
+  rules: RuleLite[],
+  latestResults: RuleResultLite[],
+  levels: LevelDef[],
+  targetLevel: string | null | undefined,
+): FailingPair[] {
+  const inScope = new Set(selectInScopeRules(rules, levels, targetLevel).map((r) => r.id))
+  const pairs: FailingPair[] = []
+  for (const res of latestResults) {
+    if (res.passed) continue
+    if (!inScope.has(res.ruleId)) continue
+    pairs.push({ entityId: res.entityId, ruleId: res.ruleId })
+  }
+  return pairs
+}
+
+function pairKey(entityId: string, ruleId: string): string {
+  return `${entityId}::${ruleId}`
+}
+
+/**
+ * Diff the current failing pairs against existing action items. Semantics
+ * (docs/plans/2026-07-02-initiatives-ui.md):
+ *  - failing pair with no item → create (status open).
+ *  - item exists (any status), pair still failing → untouched (user state wins).
+ *  - open/in-progress item whose pair now passes or left scope → auto-complete.
+ *  - done item whose pair fails again → reopen.
+ *  - waived item → NEVER touched, in either direction.
+ * Items without a rule id are not sync-managed and are ignored entirely.
+ */
+export function diffActionItems(
+  existing: ActionItemLite[],
+  failing: FailingPair[],
+): ActionItemDiff {
+  const failingKeys = new Set(failing.map((p) => pairKey(p.entityId, p.ruleId)))
+  const existingKeys = new Set<string>()
+  const toComplete: ActionItemLite[] = []
+  const toReopen: ActionItemLite[] = []
+
+  for (const item of existing) {
+    if (item.ruleId == null) continue // manual item — not sync-managed
+    const key = pairKey(item.entityId, item.ruleId)
+    existingKeys.add(key)
+    if (item.status === 'waived') continue // sacrosanct
+
+    if (failingKeys.has(key)) {
+      if (item.status === 'done') toReopen.push(item)
+      // open/in-progress + still failing → leave untouched
+    } else {
+      if (item.status === 'open' || item.status === 'in-progress') toComplete.push(item)
+      // done + now passing → leave untouched
+    }
+  }
+
+  const toCreate: FailingPair[] = []
+  for (const pair of failing) {
+    const key = pairKey(pair.entityId, pair.ruleId)
+    if (existingKeys.has(key)) continue
+    existingKeys.add(key) // dedupe repeated failing pairs defensively
+    toCreate.push(pair)
+  }
+
+  return { toCreate, toComplete, toReopen }
+}
+
+/** Roll up action items into progress counts + a percent-complete. */
+export function computeInitiativeProgress(
+  items: Array<Pick<ActionItemLite, 'status'>>,
+): InitiativeProgress {
+  let open = 0
+  let inProgress = 0
+  let done = 0
+  let waived = 0
+  for (const it of items) {
+    switch (it.status) {
+      case 'open':
+        open++
+        break
+      case 'in-progress':
+        inProgress++
+        break
+      case 'done':
+        done++
+        break
+      case 'waived':
+        waived++
+        break
+    }
+  }
+  const total = items.length
+  const pctComplete = total === 0 ? 100 : Math.round((100 * (done + waived)) / total)
+  return { total, open, inProgress, done, waived, pctComplete }
+}
+
+/**
+ * Reduce raw scorecard-rule-results rows to one latest {@link RuleResultLite}
+ * per (rule, entity). The evaluation pipeline upserts a single row per
+ * (scorecard, rule, entity), so there is normally exactly one row per pair; the
+ * newest-`evaluatedAt`-wins dedupe is a defensive belt-and-suspenders.
+ */
+export function latestRuleResults(rows: ScorecardRuleResult[]): RuleResultLite[] {
+  const byPair = new Map<string, { at: string; lite: RuleResultLite }>()
+  for (const row of rows) {
+    const ruleId = relId(row.rule)
+    const entityId = relId(row.entity)
+    if (!ruleId || !entityId) continue
+    const at = typeof row.evaluatedAt === 'string' ? row.evaluatedAt : ''
+    const key = pairKey(entityId, ruleId)
+    const prev = byPair.get(key)
+    if (!prev || at >= prev.at) {
+      byPair.set(key, { at, lite: { ruleId, entityId, passed: !!row.passed } })
+    }
+  }
+  return [...byPair.values()].map((v) => v.lite)
+}
+
+/** Append `line` to existing notes on a fresh line, preserving prior content. */
+export function appendNote(existing: string | null | undefined, line: string): string {
+  const base = (existing ?? '').trimEnd()
+  return base.length > 0 ? `${base}\n${line}` : line
+}
+
+/** Map a persisted action-item row to the lite shape the diff operates on. */
+export function toActionItemLite(row: InitiativeActionItem): ActionItemLite {
+  return {
+    id: row.id,
+    entityId: relId(row.entity) ?? '',
+    ruleId: relId(row.rule),
+    status: (row.status ?? 'open') as ItemStatus,
+    notes: row.notes ?? null,
+  }
+}
+
+// --- Payload-touching wrapper -----------------------------------------------
+
+const PAGE_SIZE = 100
+
+/** Page-loop read of every doc matching `where` (evaluate.ts convention). */
+async function loadAll<T>(payload: Payload, collection: string, where: unknown): Promise<T[]> {
+  const docs: T[] = []
+  for (let page = 1; ; page++) {
+    const res = await payload.find({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      collection: collection as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      where: where as any,
+      limit: PAGE_SIZE,
+      page,
+      depth: 0,
+      overrideAccess: true,
+    })
+    docs.push(...(res.docs as T[]))
+    if (!res.hasNextPage) break
+  }
+  return docs
+}
+
+/**
+ * Reconcile one initiative's action items against the latest evaluation.
+ *
+ * Loads the initiative (a no-op returning zeros unless it is `active` — syncing
+ * a completed/cancelled initiative must not mutate anything), its scorecard's
+ * rules and latest rule results, and its existing items; applies
+ * {@link diffActionItems}; and returns the counts. New items are created with
+ * status `open`; auto-completions/reopens append a note on a fresh line,
+ * preserving any existing notes. All writes use `overrideAccess` — the caller
+ * (evaluation hook or the RBAC-gated server action) is the authorization point.
+ */
+export async function syncInitiativeActionItems(
+  payload: Payload,
+  initiativeId: string,
+): Promise<SyncResult> {
+  const zero: SyncResult = { created: 0, completed: 0, reopened: 0 }
+
+  let initiative: Initiative
+  try {
+    initiative = (await payload.findByID({
+      collection: 'initiatives',
+      id: initiativeId,
+      depth: 0,
+      overrideAccess: true,
+    })) as Initiative
+  } catch {
+    return zero
+  }
+  if (!initiative || initiative.status !== 'active') return zero
+
+  const scorecardId = relId(initiative.scorecard)
+  const workspaceId = relId(initiative.workspace)
+  if (!scorecardId || !workspaceId) return zero
+  const targetLevel = initiative.targetLevel ?? null
+
+  const scorecard = (await payload.findByID({
+    collection: 'scorecards',
+    id: scorecardId,
+    depth: 0,
+    overrideAccess: true,
+  })) as Scorecard
+  const levels: LevelDef[] = (scorecard.levels ?? []).map((l) => ({ name: l.name, rank: l.rank }))
+
+  const [ruleRows, resultRows, itemRows] = await Promise.all([
+    loadAll<ScorecardRule>(payload, 'scorecard-rules', { scorecard: { equals: scorecardId } }),
+    loadAll<ScorecardRuleResult>(payload, 'scorecard-rule-results', {
+      scorecard: { equals: scorecardId },
+    }),
+    loadAll<InitiativeActionItem>(payload, 'initiative-action-items', {
+      initiative: { equals: initiativeId },
+    }),
+  ])
+
+  const ruleLites: RuleLite[] = ruleRows.map((r) => ({ id: r.id, level: r.level ?? null }))
+  const latestResults = latestRuleResults(resultRows)
+  const existing = itemRows.map(toActionItemLite)
+
+  const failing = computeFailingPairs(ruleLites, latestResults, levels, targetLevel)
+  const { toCreate, toComplete, toReopen } = diffActionItems(existing, failing)
+
+  for (const pair of toCreate) {
+    await payload.create({
+      collection: 'initiative-action-items',
+      data: {
+        workspace: workspaceId,
+        initiative: initiativeId,
+        entity: pair.entityId,
+        rule: pair.ruleId,
+        status: 'open',
+      },
+      overrideAccess: true,
+    })
+  }
+  for (const item of toComplete) {
+    await payload.update({
+      collection: 'initiative-action-items',
+      id: item.id,
+      data: { status: 'done', notes: appendNote(item.notes, AUTO_COMPLETE_NOTE) },
+      overrideAccess: true,
+    })
+  }
+  for (const item of toReopen) {
+    await payload.update({
+      collection: 'initiative-action-items',
+      id: item.id,
+      data: { status: 'open', notes: appendNote(item.notes, REOPEN_NOTE) },
+      overrideAccess: true,
+    })
+  }
+
+  return { created: toCreate.length, completed: toComplete.length, reopened: toReopen.length }
+}
+
+/** Discriminate a populated user doc from a bare id. */
+export function userDisplayName(user: unknown): string | null {
+  if (user && typeof user === 'object') {
+    const u = user as Partial<User>
+    return u.name || u.email || null
+  }
+  return null
+}
+
+// --- assignee validation ----------------------------------------------------
+
+/** True when `userId` is an active member of `workspaceId`. */
+export async function isActiveWorkspaceMember(
+  payload: Payload,
+  userId: string,
+  workspaceId: string,
+): Promise<boolean> {
+  const members = await payload.find({
+    collection: 'workspace-members',
+    where: {
+      and: [
+        { user: { equals: userId } },
+        { workspace: { equals: workspaceId } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+  return members.docs.length > 0
+}
+
+/**
+ * Guard an action-item assignee change: when `assigneeId` is a concrete user
+ * id, that user MUST be an active member of the item's `workspaceId` (otherwise
+ * a member could pin an arbitrary/foreign user, whose name/email would then
+ * render via the detail page's populate — a mild info-disclosure). Clearing the
+ * assignee (`null`/`undefined`) always passes and issues no query. Throws a
+ * clear Error when the target user is not a member.
+ */
+export async function assertAssigneeInWorkspace(
+  payload: Payload,
+  assigneeId: string | null | undefined,
+  workspaceId: string,
+): Promise<void> {
+  if (assigneeId == null || assigneeId === '') return
+  if (!(await isActiveWorkspaceMember(payload, assigneeId, workspaceId))) {
+    throw new Error('The assignee must be an active member of this workspace.')
+  }
+}


### PR DESCRIPTION
## Summary

Delivers item 2 of the scorecards roadmap (`docs/plans/2026-07-02-scorecards-roadmap.md`): the measure→improve loop. The `initiatives` / `initiative-action-items` collections shipped in P2 but had zero UI and no behavior — this PR turns them into the Cortex-style campaign feature.

- **Create an initiative** (scorecard + target level + optional deadline): Orbit immediately generates one action item per failing (entity × in-scope rule at/below the target level). Level-less rules gate every rung, matching `computeEntityLevel`.
- **Work the items**: inline status (open / in-progress / done / waived), notes editor, entity links to the catalog; member-editable, tenancy-bounded.
- **Self-reconciling**: every `runScorecardEvaluation` fire-and-forget syncs active initiatives — items whose rule now passes auto-complete, regressed `done` items reopen, `waived` items are never touched (both directions). With the nightly sweep (#60) campaigns stay current daily. Manual "Sync now" reports `{created, auto-completed, reopened}`.
- **Lifecycle**: complete / cancel / reactivate, gated to workspace owner/admin via `canManageScorecards`; server-side enforcement, not just hidden buttons.
- `/scorecards/initiatives` list (progress bars, overdue flagging) linked from the scorecards header.

## Design
`docs/plans/2026-07-02-initiatives-ui.md`. No schema changes — the P2 collections were already sufficient.

## Verification
- **276 tests green** (`src/lib/scorecards` 198 incl. 42 new sync/RBAC-helper tests; `src/components/features/scorecards` 78 incl. 11 new UI-helper tests); `tsc --noEmit` clean for all touched files.
- **Expert QA audit: all 8 UACs PASS**, including a live agent-browser end-to-end pass against the dev server: create → 3 items auto-generated → status/notes round-trips persisted in Mongo → waive + Sync-now (reopen/auto-complete transitions with correct note appending, waived untouched) → **Evaluate-now auto-reconcile without manual sync** → complete/reactivate → overdue rendering → form validation → no console errors.
- QA's one MINOR finding (assignee id not validated against the item's workspace) fixed pre-PR with unit coverage.

## Follow-ups (deliberately out of scope)
Assignee picker (action already accepts `assigneeId`; no user-picker convention exists in the codebase yet), reports burndown section, email/Slack nudges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpEs7C3mrTpjCysuRGQZh