### PR TITLE
feat(catalog): entity CRUD — entities as first-class primitives

### DIFF
--- a/docs/plans/2026-07-02-catalog-entity-crud.md
+++ b/docs/plans/2026-07-02-catalog-entity-crud.md
@@ -1,0 +1,194 @@
+# Catalog Entity CRUD — Entities as First-Class Primitives
+
+**Date:** 2026-07-02
+**Status:** In progress
+**Roadmap:** new top item (catalog refinement); follows scorecards items 1–2 (PRs #60, #61).
+
+## Product vision (PM summary)
+
+Entities become a first-class primitive, created and edited by humans — not just
+projections from apps/APIs/Kafka:
+
+- **The catalog is the org-wide discovery surface.** Every authenticated user sees
+  ALL entities in the system. You manage the ones you have rights to; you view the
+  rest. Platform admins (`users.role` = `super_admin`/`admin`) manage everything.
+- **Workspaces are the team landpage.** A workspace surfaces its own entities, is
+  where teams create their **team entity** (none can be created today — the
+  `owner` relationship dangles) and relate it to services/APIs/etc.
+- **Workspace becomes optional on entities.** Entities with a workspace are managed
+  by that workspace's members; global entities (no workspace) are platform-admin
+  managed. ServiceNow-sourced entities will later slot in via the existing
+  `source` provenance group (add nothing now; the design must not preclude a
+  `servicenow` source type + bidirectional sync).
+
+### PM decisions (approved direction, veto in review)
+1. Catalog read = org-wide for any authenticated user.
+2. Create/edit = active workspace **members** (any role) for their workspace's
+   entities; **delete** = workspace owner/admin; platform admins = everything,
+   everywhere, incl. global entities.
+3. **Field-ownership policy for projected entities** (`source.type` ≠ `manual`):
+   projection owns identity fields (`name`, `slug`, `kind`, `workspace`,
+   `source`, `health`) — locked in the edit UI, rejected server-side; curation
+   fields (`description`, `lifecycle`, `tier`, `owner`, `links`, `metadata`) are
+   human-editable and the projection becomes **set-if-absent** for them on
+   update (today it clobbers description/links/metadata on every re-sync —
+   `lib/catalog/projection.ts upsertEntity`). Manual entities: fully editable.
+   Projected entities are NOT deletable from the catalog (delete the source).
+4. Relations are part of this feature: create/remove typed relations from entity
+   detail + workspace surface; RBAC = manage rights on the **from** entity.
+
+## Security fix (in scope — found during discovery)
+
+`CatalogEntities.ts`/`CatalogRelations.ts` collection access is a no-op:
+`user.collection === 'users'` is true for every authenticated user (users is the
+only auth collection), so read/update/delete short-circuit to `true` and
+`create` is `!!user`. The dead fallback also compares `workspace-members.user`
+(a Better-Auth id) against the Payload `user.id`. Fix the collection access to
+mirror the new model (defense in depth; server actions with `overrideAccess`
+stay the primary gate):
+- read: any authenticated user (org-wide — now correct BY DESIGN, not by bug)
+- create/update: platform admin, or active workspace membership via
+  `user.betterAuthId` (entity's workspace; null workspace ⇒ platform admin only)
+- delete: platform admin or workspace owner/admin, AND `source.type == 'manual'`
+Projections/internal routes use the local API (`overrideAccess` default) — unaffected.
+
+## Design
+
+### Schema (`collections/catalog/CatalogEntities.ts`, `CatalogRelations.ts`)
+- `workspace` → `required: false` on BOTH collections (relation workspace is
+  derived from the `from` entity at write time; absent for global-from-global).
+- No other field changes. Run `bun run generate:types` after.
+
+### Authz lib (`orbit-www/src/lib/catalog/entity-authz.ts` — single source of truth)
+Follow `lib/scorecards/authz.ts` conventions (Better-Auth id in, payload query,
+`status: 'active'`). Reuse `isPlatformAdmin` from `lib/access/workspace-access.ts`.
+- `canCreateEntity(payload, betterAuthId, isPlatformAdmin, workspaceId | null)`
+- `canManageEntity(payload, betterAuthId, isPlatformAdmin, entity: { workspaceId: string | null })`
+- `canDeleteEntity(payload, betterAuthId, isPlatformAdmin, entity: { workspaceId, sourceType })`
+- `getManageableWorkspaceIds(payload, betterAuthId)` (active memberships — reuse
+  `lib/access/workspace-access.ts` helpers where they fit)
+All pure-ish, unit-tested with the FakePayload convention.
+
+### CRUD lib (`orbit-www/src/lib/catalog/entity-crud.ts` — pure, tested)
+- Types: `CreateEntityInput`, `UpdateEntityPatch`, `EntityFormOptions`,
+  `RelationInput`, `PROJECTION_LOCKED_FIELDS`, `CURATION_FIELDS`.
+- `validateCreateInput` / `validateUpdatePatch(sourceType, patch)` (rejects
+  identity-field edits on projected entities), `slugify(name)` (+ collision
+  suffixing helper), link-array validation (label+url required, url http(s)).
+
+### Projection ownership fix (`lib/catalog/projection.ts`)
+`upsertEntity` update path: always write identity fields; write curation fields
+ONLY when the existing doc's value is empty/undefined (set-if-absent). Unit-test
+the merge (existing description survives re-projection; empty one gets filled).
+
+### Server actions — NEW file `orbit-www/src/app/(frontend)/catalog/entity-actions.ts`
+('use server'; async-only exports; types live in the libs. Session via
+`getCurrentUser()` (Better-Auth id) + `getPayloadUserFromSession()` for role.)
+- `createCatalogEntity(input: CreateEntityInput): Promise<{ id: string }>` —
+  RBAC canCreateEntity; `source.type: 'manual'`; slug from name (unique within
+  workspace scope by suffixing); revalidates catalog + workspace paths.
+- `updateCatalogEntity(id: string, patch: UpdateEntityPatch): Promise<void>` —
+  RBAC canManageEntity; validateUpdatePatch enforces field ownership.
+- `deleteCatalogEntity(id: string): Promise<void>` — RBAC canDeleteEntity;
+  also deletes relations referencing the entity (both directions).
+- `createCatalogRelation(input: { fromId, toId, type }): Promise<{ id: string }>`
+  — RBAC canManageEntity(from); validates type ∈ RELATION_TYPES, from ≠ to,
+  dedupes (workspace, from, to, type); `source.type: 'manual'`.
+- `deleteCatalogRelation(id: string): Promise<void>` — RBAC via from entity;
+  manual relations only (projected relations belong to their projector).
+- `getEntityFormOptions(): Promise<EntityFormOptions>` — workspaces the caller
+  can create in, `canCreateGlobal` (platform admin), team entities per
+  workspace for the owner picker.
+- `searchEntitiesForPicker(query: string, opts?: { kind?, excludeId? }):
+  Promise<{ id, name, kind, workspaceName }[]>` — org-wide, for relation/owner
+  pickers (limit 20).
+
+### Read-path changes (existing files)
+- `catalog/actions.ts searchCatalogEntities` + `getCatalogKindCounts`: drop the
+  workspace-membership filter → org-wide; add `scope?: 'all' | 'mine'` param
+  ('mine' = my active workspaces, the old behavior; default 'all'); return a
+  per-entity `canManage` boolean (computed from one manageable-ids set +
+  isPlatformAdmin — no N+1).
+- `catalog/[id]/actions.ts getCatalogEntityDetail`: explicit org-wide read
+  (authenticated check + `overrideAccess: true` — stop leaning on the broken
+  collection access); returns `canManage`, `canDelete`, `sourceType`, and the
+  relation rows with ids so the UI can delete manual ones.
+
+### UI — catalog (`app/(frontend)/catalog/**`, `components/features/catalog/**`)
+- List page: "New entity" button (shown when the caller can create anywhere);
+  scope toggle All ↔ My workspaces; subtle "managed" affordance on cards the
+  caller can manage; workspace column/badge (or "Global").
+- `/catalog/new`: `EntityForm` (create mode) — kind, name, workspace select
+  (user's manageable workspaces; + "Global (no workspace)" for platform
+  admins), description, lifecycle, tier, owner (team picker), links editor.
+- `/catalog/[id]/edit`: `EntityForm` (edit mode) — projected entities render
+  identity fields read-only with a provenance note ("Synced from Apps");
+  curation fields editable. Delete button (manual only, confirm dialog).
+- Entity detail: "Edit" button (gated); Relations tab gains "Add relation"
+  (direction, type select, org-wide entity picker) + remove on manual relations.
+- Empty catalog list gets a "Create your first entity" CTA when the user can.
+
+### UI — workspace landpage (`app/(frontend)/workspaces/[slug]/page.tsx`)
+- New **Entities card** in the dashboard grid: the workspace's entities grouped
+  by kind (counts + top entries linking to `/catalog/[id]`), "View all in
+  catalog" (catalog pre-filtered to the workspace), and — for members —
+  "New entity" (prefilled workspace) plus a first-class **"Create team"**
+  affordance when the workspace has no team entity yet (fills the dangling
+  `owner` relationship gap).
+
+## User Acceptance Criteria
+
+- **UAC-1 (org-wide catalog):** any authenticated user sees ALL entities in the
+  catalog (incl. other workspaces' + global); scope toggle "My workspaces"
+  restores the scoped view; entity detail is viewable org-wide.
+- **UAC-2 (create from catalog):** a workspace member can create a manual
+  entity into their workspace from the catalog; a platform admin can create
+  into any workspace or as Global; a member cannot create into a workspace
+  they don't belong to (server-side reject, not just UI).
+- **UAC-3 (edit):** members edit their workspace's entities; on projected
+  entities identity fields are locked (UI read-only AND server-side reject)
+  while curation fields save; manual entities are fully editable.
+- **UAC-4 (delete):** workspace owner/admin (or platform admin) can delete a
+  MANUAL entity (with its relations); members cannot; projected entities are
+  not deletable anywhere.
+- **UAC-5 (relations):** a user with manage rights on the from-entity can add
+  a typed relation to any org-visible entity and remove manual relations;
+  duplicates are rejected; from ≠ to enforced.
+- **UAC-6 (workspace landpage):** the workspace page shows its entities grouped
+  by kind with catalog links; members can create entities (incl. a team entity)
+  from it; non-members see the list but no authoring affordances.
+- **UAC-7 (projection ownership):** re-projecting a source (e.g. saving an app)
+  no longer clobbers manually edited description/links/metadata (set-if-absent),
+  while name/kind/health stay projection-owned. Unit-tested.
+- **UAC-8 (security fix):** collection-level access on catalog-entities/relations
+  enforces the model for direct Payload API calls: cross-workspace update/delete
+  by a plain member is rejected; org-wide read allowed for authenticated users
+  only; the betterAuthId comparison bug is fixed. Regression: projections and
+  internal X-API-Key routes still work.
+- **UAC-9 (quality):** authz/crud/projection-merge logic pure + vitest-covered;
+  all catalog/scorecards suites pass; `tsc --noEmit` clean for touched files;
+  `bun run generate:types` regenerates cleanly.
+- **UAC-10 (browser QA):** live agent-browser pass validates UAC-1..6 end-to-end
+  (create entity + team from workspace page, edit projected vs manual entity,
+  add/remove relation, delete manual entity, scope toggle).
+
+## Work packages
+
+| WP | Owner | Scope |
+|---|---|---|
+| WP1 core | opus | schema relax + types regen, entity-authz.ts, entity-crud.ts, projection fix, collection access fix, entity-actions.ts, read-path changes, tests |
+| WP2 catalog UI | opus | EntityForm + pickers + links editor, /catalog/new, /catalog/[id]/edit, list scope toggle + New button, detail Edit + relations add/remove |
+| WP3 workspace UI | sonnet | workspace Entities card + create/team affordances (reuses WP2's EntityForm) |
+| QA | opus | UAC audit incl. RBAC probing + live browser pass |
+
+## Verification
+
+- `cd orbit-www && bunx vitest run src/lib/catalog src/lib/scorecards src/components/features/catalog src/app/api/internal`
+- `cd orbit-www && bunx tsc --noEmit` (touched files clean)
+- agent-browser QA per UAC-10 (pre/post-flight pgrep hygiene per CLAUDE.md)
+
+## Future (explicitly out of scope)
+ServiceNow bidirectional sync (needs: `servicenow` source.type, external-id
+mapping on `source.sourceId`, conflict policy = this plan's field-ownership
+model, outbound webhooks); entity ownership transfer between workspaces (v1:
+platform admin edits workspace directly); granular per-entity permissions.

--- a/docs/plans/2026-07-02-initiatives-ui.md
+++ b/docs/plans/2026-07-02-initiatives-ui.md
@@ -1,7 +1,7 @@
 # Initiatives UI + Auto-Generated Action Items
 
 **Date:** 2026-07-02
-**Status:** In progress
+**Status:** Shipped (PR #61)
 **Roadmap:** `2026-07-02-scorecards-roadmap.md` item 2.
 **Depends on:** P2 collections (`initiatives`, `initiative-action-items` — already
 registered, no schema changes), scorecard evaluation pipeline

--- a/docs/plans/2026-07-02-scheduled-scorecard-evaluation.md
+++ b/docs/plans/2026-07-02-scheduled-scorecard-evaluation.md
@@ -1,7 +1,7 @@
 # Scheduled Scorecard Evaluation
 
 **Date:** 2026-07-02
-**Status:** In progress
+**Status:** Shipped (PR #60)
 **Roadmap:** `2026-07-02-scorecards-roadmap.md` item 1.
 **Depends on:** P4.2 automation Temporal worker (`docs/plans/2026-06-27-automation-temporal-ts-worker.md`),
 scorecard internal routes (P2 / PR #56 / PR #59).

--- a/docs/plans/2026-07-02-scorecards-roadmap.md
+++ b/docs/plans/2026-07-02-scorecards-roadmap.md
@@ -23,7 +23,7 @@ Authoring and measurement are essentially complete on `main`:
 
 ## Gaps, in priority order
 
-### 1. Scheduled evaluation (NOW — see `2026-07-02-scheduled-scorecard-evaluation.md`)
+### 1. Scheduled evaluation — SHIPPED (PR #60, `2026-07-02-scheduled-scorecard-evaluation.md`)
 
 Everything today is on-demand ("Evaluate now", catalog save-time seeding, internal
 routes). Nothing runs nightly, so scores go stale and the reports trend chart only
@@ -32,7 +32,7 @@ accrues history if a human clicks Evaluate. The Temporal automations worker
 P4.2 — wire a scorecard-evaluation sweep into them. This makes everything already
 shipped trustworthy; it ships first.
 
-### 2. Initiatives — data model with no product
+### 2. Initiatives — SHIPPED (PR #61, `2026-07-02-initiatives-ui.md`)
 
 `initiatives` + `initiative-action-items` exist and are registered but have **zero
 UI** and no auto-generation of action items for failing entities. This is the
@@ -67,7 +67,7 @@ per-team drill-down pages.
 
 ## Delivery sequence
 
-1. **Scheduled evaluation** — small, makes shipped value real. ← current
-2. **Initiatives UI + auto action items** — completes measure→improve loop.
+1. **Scheduled evaluation** — SHIPPED (PR #60).
+2. **Initiatives UI + auto action items** — SHIPPED (PR #61).
 3. **Rule preview + templates** — drives authoring adoption.
 4. Notifications, reports follow-ups, governance rules.

--- a/orbit-www/src/app/(frontend)/catalog/[id]/actions.ts
+++ b/orbit-www/src/app/(frontend)/catalog/[id]/actions.ts
@@ -6,6 +6,8 @@ import { getPayloadUserFromSession } from '@/lib/auth/session'
 import type { CatalogEntity, CatalogRelation, EntityScore } from '@/payload-types'
 import { resolveEntityType } from '@/lib/catalog/entity-types'
 import type { EntityKind } from '@/collections/catalog/constants'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
+import { canManageEntity, canDeleteEntity } from '@/lib/catalog/entity-authz'
 
 /** A knowledge page best-effort linked to a catalog entity (via tag == slug). */
 export interface LinkedDoc {
@@ -19,6 +21,12 @@ export interface EntityDetailData {
   entity: CatalogEntity
   relations: CatalogRelation[]
   docs: LinkedDoc[]
+  /** Whether the caller may edit this entity (workspace member or platform admin). */
+  canManage: boolean
+  /** Whether the caller may delete this entity (manual + workspace owner/admin or admin). */
+  canDelete: boolean
+  /** Provenance source type ('manual' = human-authored; anything else = projected). */
+  sourceType: string
 }
 
 /**
@@ -33,6 +41,9 @@ export async function getCatalogEntityDetail(id: string): Promise<EntityDetailDa
 
   const payload = await getPayload({ config })
 
+  // Explicit ORG-WIDE read: any authenticated user can view any entity (the
+  // catalog is the discovery surface). We gate on the session above and read
+  // with overrideAccess rather than leaning on collection access to filter.
   let entity: CatalogEntity
   try {
     entity = (await payload.findByID({
@@ -40,17 +51,18 @@ export async function getCatalogEntityDetail(id: string): Promise<EntityDetailDa
       id,
       // depth 2 populates `owner` (a team entity) and `workspace`.
       depth: 2,
-      user,
+      overrideAccess: true,
     })) as CatalogEntity
   } catch {
-    // findByID throws when the row is missing or filtered out by access control.
+    // findByID throws when the row is missing.
     return null
   }
 
   if (!entity) return null
 
   // Relations touching this entity in either direction. depth 1 populates the
-  // `from`/`to` entities so the UI can render neighbour names and links.
+  // `from`/`to` entities so the UI can render neighbour names and links. Each
+  // row carries its id + `source.type`, so the UI can offer removal on manual ones.
   const relationsRes = await payload.find({
     collection: 'catalog-relations',
     where: {
@@ -58,15 +70,29 @@ export async function getCatalogEntityDetail(id: string): Promise<EntityDetailDa
     },
     depth: 1,
     limit: 200,
-    user,
+    overrideAccess: true,
   })
 
   const docs = await findLinkedDocs(payload, entity, user)
+
+  const isAdmin = isPlatformAdmin(user)
+  const betterAuthId = user.betterAuthId ?? undefined
+  const workspaceId =
+    entity.workspace ? (typeof entity.workspace === 'string' ? entity.workspace : entity.workspace.id) : null
+  const sourceType = entity.source?.type ?? 'manual'
+
+  const [canManage, canDelete] = await Promise.all([
+    canManageEntity(payload, betterAuthId, isAdmin, { workspaceId }),
+    canDeleteEntity(payload, betterAuthId, isAdmin, { workspaceId, sourceType }),
+  ])
 
   return {
     entity,
     relations: relationsRes.docs as CatalogRelation[],
     docs,
+    canManage,
+    canDelete,
+    sourceType,
   }
 }
 
@@ -163,7 +189,8 @@ export async function getEntityScoreBreakdown(entityId: string): Promise<EntityS
   }
   if (!entity) return EMPTY_SCORE_BREAKDOWN
 
-  const workspaceId = typeof entity.workspace === 'string' ? entity.workspace : entity.workspace.id
+  const workspaceId =
+    typeof entity.workspace === 'string' ? entity.workspace : (entity.workspace?.id ?? '')
 
   const [scoresResult, entityType] = await Promise.all([
     payload.find({

--- a/orbit-www/src/app/(frontend)/catalog/[id]/edit/page.tsx
+++ b/orbit-www/src/app/(frontend)/catalog/[id]/edit/page.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import { ArrowLeft, ShieldAlert } from 'lucide-react'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { EntityForm } from '@/components/features/catalog/entity-form'
+import { DeleteEntityButton } from '@/components/features/catalog/DeleteEntityButton'
+import { getCatalogEntityDetail } from '../actions'
+import { getEntityFormOptions } from '../../entity-actions'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * Edit a catalog entity (Catalog Entity CRUD, WP2). Org-wide read resolves the
+ * entity plus the caller's manage/delete rights and its provenance; a viewer
+ * without manage rights is bounced back to the detail page (the RBAC gate is
+ * re-enforced in updateCatalogEntity regardless). Projected entities render
+ * their identity fields read-only inside EntityForm; only manual entities show
+ * the Delete affordance (and only to owner/admins per canDelete).
+ */
+export default async function EditCatalogEntityPage({ params }: PageProps) {
+  const { id } = await params
+
+  const [data, options] = await Promise.all([getCatalogEntityDetail(id), getEntityFormOptions()])
+  if (!data) {
+    notFound()
+  }
+  if (!data.canManage) {
+    redirect(`/catalog/${id}`)
+  }
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex-1 space-y-6 p-8 pt-6">
+          <div>
+            <Link
+              href={`/catalog/${id}`}
+              className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to {data.entity.name}
+            </Link>
+            <h1 className="text-3xl font-bold">Edit entity</h1>
+            <p className="mt-2 text-muted-foreground">
+              Update this entity&rsquo;s details, ownership and links.
+            </p>
+          </div>
+
+          <Card className="max-w-3xl">
+            <CardHeader>
+              <CardTitle className="text-base">Details</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <EntityForm mode="edit" options={options} entity={data.entity} />
+            </CardContent>
+          </Card>
+
+          {data.canDelete && (
+            <Card className="max-w-3xl border-destructive/40">
+              <CardHeader>
+                <CardTitle className="text-base text-destructive">Danger zone</CardTitle>
+              </CardHeader>
+              <CardContent className="flex items-center justify-between gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Deleting removes this entity and every relation touching it. This cannot be
+                  undone.
+                </p>
+                <DeleteEntityButton entityId={data.entity.id} entityName={data.entity.name} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/orbit-www/src/app/(frontend)/catalog/[id]/page.tsx
+++ b/orbit-www/src/app/(frontend)/catalog/[id]/page.tsx
@@ -23,7 +23,12 @@ export default async function CatalogEntityDetailPage({ params }: PageProps) {
       <SidebarInset>
         <SiteHeader />
         <div className="flex-1 space-y-4 p-8 pt-6">
-          <EntityDetail entity={data.entity} relations={data.relations} docs={data.docs} />
+          <EntityDetail
+            entity={data.entity}
+            relations={data.relations}
+            docs={data.docs}
+            canManage={data.canManage}
+          />
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/orbit-www/src/app/(frontend)/catalog/actions.ts
+++ b/orbit-www/src/app/(frontend)/catalog/actions.ts
@@ -1,12 +1,14 @@
 'use server'
 
 import { getPayload } from 'payload'
+import type { Where } from 'payload'
 import config from '@payload-config'
 import type { CatalogEntity, EntityScore, EntityType } from '@/payload-types'
-import { getCurrentUser } from '@/lib/auth/session'
+import { getCurrentUser, getPayloadUserFromSession } from '@/lib/auth/session'
 import { DEFAULT_ENTITY_TYPE } from '@/lib/catalog/entity-types'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
+import { getManageableWorkspaceIds } from '@/lib/catalog/entity-authz'
 import {
-  buildCatalogWhere,
   ENTITY_KIND_VALUES,
   isEntityKind,
   type EntityKind,
@@ -37,35 +39,103 @@ async function getMemberWorkspaceIds(
   )
 }
 
+export type CatalogScope = 'all' | 'mine'
+
 export interface SearchCatalogInput {
+  /** Legacy — identity is resolved from the session; kept for call-site stability. */
   userId?: string
   kind?: string
   query?: string
   limit?: number
   page?: number
+  /** 'all' (default) is org-wide; 'mine' restricts to the caller's active workspaces. */
+  scope?: CatalogScope
+  /** Optional: restrict results to a single workspace (AND-ed with kind/query/scope). */
+  workspaceId?: string
 }
 
+/**
+ * A catalog entity plus the server-computed `canManage` flag for the caller.
+ * Extends CatalogEntity (all existing fields preserved), so existing consumers
+ * that read `docs` as CatalogEntity keep working.
+ */
+export type CatalogEntityWithAccess = CatalogEntity & { canManage: boolean }
+
 export interface SearchCatalogResult {
-  docs: CatalogEntity[]
+  docs: CatalogEntityWithAccess[]
   totalDocs: number
   totalPages: number
   page: number
   hasNextPage: boolean
   hasPrevPage: boolean
+  /** True when the caller can create at least one entity (platform admin or a member somewhere). */
+  canCreate: boolean
+  scope: CatalogScope
+  /** Echoes the applied single-workspace filter (undefined when unfiltered) for the UI filter chip. */
+  workspaceId?: string
 }
 
 /**
- * Search catalog entities scoped to the current user's workspaces.
+ * Build the catalog `Where` clause. Unlike the workspace-scoped
+ * `buildCatalogWhere`, an absent `workspaceIds` yields NO workspace constraint
+ * (org-wide) — the catalog is now the org discovery surface. Passing an explicit
+ * (possibly empty) list scopes to those workspaces ('mine').
+ */
+function buildOrgCatalogWhere(opts: {
+  workspaceIds?: string[]
+  workspaceId?: string
+  kind?: EntityKind
+  query?: string
+}): Where {
+  const conditions: Where[] = []
+  if (opts.workspaceIds) {
+    conditions.push({
+      workspace: { in: opts.workspaceIds.length > 0 ? opts.workspaceIds : ['__none__'] },
+    })
+  }
+  if (opts.workspaceId) conditions.push({ workspace: { equals: opts.workspaceId } })
+  if (opts.kind) conditions.push({ kind: { equals: opts.kind } })
+  const trimmed = opts.query?.trim()
+  if (trimmed) {
+    conditions.push({ or: [{ name: { contains: trimmed } }, { description: { contains: trimmed } }] })
+  }
+  if (conditions.length === 0) return {}
+  return conditions.length > 1 ? { and: conditions } : conditions[0]
+}
+
+/** Resolve an entity's workspace id (populated or raw), or null for a global entity. */
+function entityWorkspaceId(entity: CatalogEntity): string | null {
+  const ws = entity.workspace
+  if (!ws) return null
+  return typeof ws === 'string' ? ws : ws.id
+}
+
+/** Can the caller manage this entity? Pure — no query, uses the precomputed manageable set. */
+function computeCanManage(
+  entity: CatalogEntity,
+  isAdmin: boolean,
+  manageableWorkspaceIds: Set<string>,
+): boolean {
+  if (isAdmin) return true
+  const wsId = entityWorkspaceId(entity)
+  if (!wsId) return false
+  return manageableWorkspaceIds.has(wsId)
+}
+
+/**
+ * Search catalog entities ORG-WIDE for any authenticated user (the catalog is
+ * the discovery surface). `scope: 'mine'` restores the workspace-scoped view.
  *
- * We query with `overrideAccess: true` and supply the workspace `in` filter
- * ourselves (via {@link buildCatalogWhere}) so the result set is the tenant
- * boundary regardless of the collection's own access rules.
+ * Reads run with `overrideAccess: true`; the where clause is the boundary. Each
+ * returned doc carries a `canManage` flag computed from a single manageable-ids
+ * set (no per-row query). Identity is resolved from the session — the client
+ * `userId` is not trusted for authorization.
  */
 export async function searchCatalogEntities(
   input: SearchCatalogInput = {},
 ): Promise<SearchCatalogResult> {
   const payload = await getPayload({ config })
-  const { userId, kind, query, limit = 24, page = 1 } = input
+  const { kind, query, limit = 24, page = 1, scope = 'all', workspaceId } = input
 
   const empty: SearchCatalogResult = {
     docs: [],
@@ -74,15 +144,29 @@ export async function searchCatalogEntities(
     page: 1,
     hasNextPage: false,
     hasPrevPage: false,
+    canCreate: false,
+    scope,
+    workspaceId,
   }
 
-  if (!userId) return empty
+  const sessionUser = await getPayloadUserFromSession()
+  if (!sessionUser) return empty
 
-  const workspaceIds = await getMemberWorkspaceIds(payload, userId)
-  if (workspaceIds.length === 0) return empty
+  const isAdmin = isPlatformAdmin(sessionUser)
+  const betterAuthId = sessionUser.betterAuthId ?? undefined
+  const manageableIds = betterAuthId ? await getManageableWorkspaceIds(payload, betterAuthId) : []
+  const manageableSet = new Set(manageableIds)
+  const canCreate = isAdmin || manageableIds.length > 0
 
-  const where = buildCatalogWhere({
-    workspaceIds,
+  let workspaceFilter: string[] | undefined
+  if (scope === 'mine') {
+    if (manageableIds.length === 0) return { ...empty, canCreate }
+    workspaceFilter = manageableIds
+  }
+
+  const where = buildOrgCatalogWhere({
+    workspaceIds: workspaceFilter,
+    workspaceId,
     kind: isEntityKind(kind) ? kind : undefined,
     query,
   })
@@ -97,13 +181,21 @@ export async function searchCatalogEntities(
     overrideAccess: true,
   })
 
+  const docs: CatalogEntityWithAccess[] = (result.docs as CatalogEntity[]).map((entity) => ({
+    ...entity,
+    canManage: computeCanManage(entity, isAdmin, manageableSet),
+  }))
+
   return {
-    docs: result.docs,
+    docs,
     totalDocs: result.totalDocs,
     totalPages: result.totalPages,
     page: result.page ?? 1,
     hasNextPage: result.hasNextPage ?? false,
     hasPrevPage: result.hasPrevPage ?? false,
+    canCreate,
+    scope,
+    workspaceId,
   }
 }
 
@@ -113,32 +205,39 @@ export type CatalogKindCounts = {
 }
 
 /**
- * Per-kind entity counts for the current user's workspaces, used to drive the
- * kind tabs (which tabs to surface, and their count badges). Respects the
- * active text `query` so counts track the visible result set.
+ * Per-kind entity counts for the kind tabs. Org-wide by default; `scope: 'mine'`
+ * restricts to the caller's active workspaces. Respects the active text `query`.
  */
 export async function getCatalogKindCounts(
-  input: { userId?: string; query?: string } = {},
+  input: { userId?: string; query?: string; scope?: CatalogScope; workspaceId?: string } = {},
 ): Promise<CatalogKindCounts> {
   const payload = await getPayload({ config })
-  const { userId, query } = input
+  const { query, scope = 'all', workspaceId } = input
 
   const zero = ENTITY_KIND_VALUES.reduce(
     (acc, k) => ({ ...acc, [k]: 0 }),
     {} as Record<EntityKind, number>,
   )
 
-  if (!userId) return { all: 0, byKind: zero }
+  const sessionUser = await getPayloadUserFromSession()
+  if (!sessionUser) return { all: 0, byKind: zero }
 
-  const workspaceIds = await getMemberWorkspaceIds(payload, userId)
-  if (workspaceIds.length === 0) return { all: 0, byKind: zero }
+  let workspaceFilter: string[] | undefined
+  if (scope === 'mine') {
+    const betterAuthId = sessionUser.betterAuthId ?? undefined
+    const manageableIds = betterAuthId
+      ? await getManageableWorkspaceIds(payload, betterAuthId)
+      : []
+    if (manageableIds.length === 0) return { all: 0, byKind: zero }
+    workspaceFilter = manageableIds
+  }
 
   const counts = await Promise.all(
     ENTITY_KIND_VALUES.map((kind) =>
       payload
         .count({
           collection: 'catalog-entities',
-          where: buildCatalogWhere({ workspaceIds, kind, query }),
+          where: buildOrgCatalogWhere({ workspaceIds: workspaceFilter, workspaceId, kind, query }),
           overrideAccess: true,
         })
         .then((r) => [kind, r.totalDocs] as const),
@@ -233,7 +332,8 @@ export async function getOverallEntityScores(
   })
   if (missingEntities.docs.length === 0) return map
 
-  const wsOf = (v: string | { id: string }) => (typeof v === 'string' ? v : v.id)
+  const wsOf = (v: string | { id: string } | null | undefined) =>
+    v == null ? '' : typeof v === 'string' ? v : v.id
   const missingWorkspaceIds = [
     ...new Set(missingEntities.docs.map((e) => wsOf((e as CatalogEntity).workspace))),
   ]

--- a/orbit-www/src/app/(frontend)/catalog/entity-actions.ts
+++ b/orbit-www/src/app/(frontend)/catalog/entity-actions.ts
@@ -1,0 +1,512 @@
+'use server'
+
+import { getPayload } from 'payload'
+import type { Where } from 'payload'
+import config from '@payload-config'
+import { revalidatePath } from 'next/cache'
+import { getPayloadUserFromSession } from '@/lib/auth/session'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
+import {
+  canCreateEntity,
+  canManageEntity,
+  canDeleteEntity,
+  getManageableWorkspaceIds,
+  isTeamEntity,
+} from '@/lib/catalog/entity-authz'
+import {
+  slugify,
+  uniqueSlug,
+  validateCreateInput,
+  validateUpdatePatch,
+  validateRelationInput,
+  type CreateEntityInput,
+  type UpdateEntityPatch,
+  type RelationInput,
+  type EntityFormOptions,
+  type EntityOption,
+} from '@/lib/catalog/entity-crud'
+import type { EntityKind } from '@/collections/catalog/constants'
+import type { CatalogEntity } from '@/payload-types'
+
+/**
+ * Catalog entity + relation authoring server actions (Catalog Entity CRUD,
+ * docs/plans/2026-07-02-catalog-entity-crud.md, WP1).
+ *
+ * These are the primary write gate. Every mutation resolves the session,
+ * enforces RBAC through `lib/catalog/entity-authz` (the single source of truth),
+ * and then writes with `overrideAccess: true`. Identity comes from the session
+ * (Better-Auth id + Payload role) — never from client-supplied ids. Validation
+ * reuses the pure `lib/catalog/entity-crud` validators.
+ */
+
+type Payload = Awaited<ReturnType<typeof getPayload>>
+
+interface CatalogSession {
+  payload: Payload
+  betterAuthId: string | undefined
+  isAdmin: boolean
+}
+
+/** Resolve the caller's session or throw. */
+async function requireSession(): Promise<CatalogSession> {
+  const user = await getPayloadUserFromSession()
+  if (!user) throw new Error('Not authenticated')
+  const payload = await getPayload({ config })
+  return {
+    payload,
+    betterAuthId: user.betterAuthId ?? undefined,
+    isAdmin: isPlatformAdmin(user),
+  }
+}
+
+/** Resolve a relationship value (populated or raw id) to its id, or null. */
+function refId(ref: unknown): string | null {
+  if (!ref) return null
+  if (typeof ref === 'string') return ref
+  if (typeof ref === 'object' && 'id' in (ref as Record<string, unknown>)) {
+    return String((ref as { id: string }).id)
+  }
+  return null
+}
+
+/** Where-clause fragment matching a specific workspace, or the global (no-workspace) set. */
+function workspaceClause(workspaceId: string | null): Where {
+  return workspaceId ? { workspace: { equals: workspaceId } } : { workspace: { exists: false } }
+}
+
+/**
+ * Compute a slug for `name` unique within its workspace scope (a null workspace
+ * scopes against global entities). `excludeId` omits the entity being renamed
+ * from the collision set.
+ */
+async function resolveUniqueSlug(
+  payload: Payload,
+  workspaceId: string | null,
+  name: string,
+  excludeId?: string,
+): Promise<string> {
+  const base = slugify(name) || 'entity'
+  const existing = await payload.find({
+    collection: 'catalog-entities',
+    where: { and: [workspaceClause(workspaceId), { slug: { contains: base } }] },
+    limit: 1000,
+    depth: 0,
+    overrideAccess: true,
+  })
+  const taken = existing.docs
+    .filter((d) => d.id !== excludeId)
+    .map((d) => d.slug)
+    .filter((s): s is string => Boolean(s))
+  return uniqueSlug(base, taken)
+}
+
+/** Revalidate the catalog + (when known) the owning workspace landing page. */
+async function revalidateCatalog(payload: Payload, workspaceId: string | null, entityId?: string) {
+  revalidatePath('/catalog')
+  if (entityId) revalidatePath(`/catalog/${entityId}`)
+  if (workspaceId) {
+    try {
+      const ws = await payload.findByID({
+        collection: 'workspaces',
+        id: workspaceId,
+        depth: 0,
+        overrideAccess: true,
+      })
+      if (ws?.slug) revalidatePath(`/workspaces/${ws.slug}`)
+    } catch {
+      // best-effort — a missing workspace just means no workspace page to revalidate.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entities
+// ---------------------------------------------------------------------------
+
+/** Create a manual catalog entity. RBAC: platform admin or member of the target workspace. */
+export async function createCatalogEntity(input: CreateEntityInput): Promise<{ id: string }> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  const validationError = validateCreateInput(input)
+  if (validationError) throw new Error(validationError)
+
+  const workspaceId = input.workspaceId ?? null
+  if (!(await canCreateEntity(payload, betterAuthId, isAdmin, workspaceId))) {
+    throw new Error('You do not have permission to create an entity here.')
+  }
+
+  // A supplied owner must reference an existing team entity (null/undefined = none).
+  if (input.ownerId && !(await isTeamEntity(payload, input.ownerId))) {
+    throw new Error('Owner must reference an existing team entity.')
+  }
+
+  const slug = await resolveUniqueSlug(payload, workspaceId, input.name)
+
+  const created = await payload.create({
+    collection: 'catalog-entities',
+    data: {
+      name: input.name.trim(),
+      slug,
+      kind: input.kind,
+      source: { type: 'manual' as const },
+      ...(workspaceId ? { workspace: workspaceId } : {}),
+      ...(input.description !== undefined ? { description: input.description } : {}),
+      ...(input.lifecycle ? { lifecycle: input.lifecycle } : {}),
+      ...(input.tier ? { tier: input.tier } : {}),
+      ...(input.ownerId ? { owner: input.ownerId } : {}),
+      ...(input.links ? { links: input.links } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    },
+    overrideAccess: true,
+  })
+
+  await revalidateCatalog(payload, workspaceId, created.id)
+  return { id: created.id }
+}
+
+/** Edit an entity. RBAC: manage rights on its workspace. Enforces field ownership. */
+export async function updateCatalogEntity(id: string, patch: UpdateEntityPatch): Promise<void> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  const existing = (await payload.findByID({
+    collection: 'catalog-entities',
+    id,
+    depth: 0,
+    overrideAccess: true,
+  })) as CatalogEntity
+
+  const workspaceId = refId(existing.workspace)
+  if (!(await canManageEntity(payload, betterAuthId, isAdmin, { workspaceId }))) {
+    throw new Error('You do not have permission to edit this entity.')
+  }
+
+  const sourceType = existing.source?.type ?? 'manual'
+  const validationError = validateUpdatePatch(sourceType, patch)
+  if (validationError) throw new Error(validationError)
+
+  // A supplied owner must reference an existing team entity. A null ownerId
+  // (clearing the owner) is allowed and skips this check.
+  if (patch.ownerId && !(await isTeamEntity(payload, patch.ownerId))) {
+    throw new Error('Owner must reference an existing team entity.')
+  }
+
+  // Identity edits are only reachable for manual entities (validateUpdatePatch
+  // rejects them for projected ones). A rename recomputes a unique slug.
+  let nameFields: { name?: string; slug?: string | null } = {}
+  if (patch.name !== undefined) {
+    const name = patch.name.trim()
+    const base = slugify(name)
+    const slug =
+      base === existing.slug ? existing.slug : await resolveUniqueSlug(payload, workspaceId, name, id)
+    nameFields = { name, slug }
+  }
+
+  await payload.update({
+    collection: 'catalog-entities',
+    id,
+    data: {
+      ...(patch.description !== undefined ? { description: patch.description } : {}),
+      ...(patch.lifecycle !== undefined ? { lifecycle: patch.lifecycle } : {}),
+      ...(patch.tier !== undefined ? { tier: patch.tier } : {}),
+      ...(patch.ownerId !== undefined ? { owner: patch.ownerId } : {}),
+      ...(patch.links !== undefined ? { links: patch.links } : {}),
+      ...(patch.metadata !== undefined ? { metadata: patch.metadata } : {}),
+      ...(patch.kind !== undefined ? { kind: patch.kind } : {}),
+      ...nameFields,
+    },
+    overrideAccess: true,
+  })
+
+  await revalidateCatalog(payload, workspaceId, id)
+}
+
+/** Delete a manual entity and every relation touching it. RBAC: owner/admin (or platform admin). */
+export async function deleteCatalogEntity(id: string): Promise<void> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  const existing = (await payload.findByID({
+    collection: 'catalog-entities',
+    id,
+    depth: 0,
+    overrideAccess: true,
+  })) as CatalogEntity
+
+  const workspaceId = refId(existing.workspace)
+  const sourceType = existing.source?.type ?? 'manual'
+  if (!(await canDeleteEntity(payload, betterAuthId, isAdmin, { workspaceId, sourceType }))) {
+    throw new Error('You do not have permission to delete this entity.')
+  }
+
+  // Cascade: remove relations referencing this entity in either direction, and
+  // null out any owner pointers to it (deleting a team entity must not leave
+  // dangling owner refs on the entities it owned). No skipAutomationEmit — an
+  // ownership change is a real entity change worth emitting, and there is no
+  // recursion risk (nulling owner triggers no owner-driven write back here).
+  await payload.delete({
+    collection: 'catalog-relations',
+    where: { or: [{ from: { equals: id } }, { to: { equals: id } }] },
+    overrideAccess: true,
+  })
+  await payload.update({
+    collection: 'catalog-entities',
+    where: { owner: { equals: id } },
+    data: { owner: null },
+    overrideAccess: true,
+  })
+  await payload.delete({
+    collection: 'catalog-entities',
+    id,
+    overrideAccess: true,
+  })
+
+  await revalidateCatalog(payload, workspaceId)
+}
+
+// ---------------------------------------------------------------------------
+// Relations
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a typed relation `from --(type)--> to`. RBAC: manage rights on the
+ * `from` entity. Validates the type + from≠to, dedupes on (workspace, from, to,
+ * type), and derives the relation's workspace from the `from` entity.
+ */
+export async function createCatalogRelation(
+  input: RelationInput,
+): Promise<{ id: string }> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  const validationError = validateRelationInput(input)
+  if (validationError) throw new Error(validationError)
+
+  let fromEntity: CatalogEntity
+  try {
+    fromEntity = (await payload.findByID({
+      collection: 'catalog-entities',
+      id: input.fromId,
+      depth: 0,
+      overrideAccess: true,
+    })) as CatalogEntity
+  } catch {
+    throw new Error('The source entity no longer exists.')
+  }
+
+  const workspaceId = refId(fromEntity.workspace)
+  if (!(await canManageEntity(payload, betterAuthId, isAdmin, { workspaceId }))) {
+    throw new Error('You do not have permission to add relations to this entity.')
+  }
+
+  // The target must exist (org-wide — any authenticated user can relate to any entity).
+  try {
+    await payload.findByID({
+      collection: 'catalog-entities',
+      id: input.toId,
+      depth: 0,
+      overrideAccess: true,
+    })
+  } catch {
+    throw new Error('The target entity no longer exists.')
+  }
+
+  // Dedupe on (workspace, from, to, type).
+  const duplicate = await payload.find({
+    collection: 'catalog-relations',
+    where: {
+      and: [
+        workspaceClause(workspaceId),
+        { from: { equals: input.fromId } },
+        { to: { equals: input.toId } },
+        { type: { equals: input.type } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (duplicate.docs.length > 0) {
+    throw new Error('That relation already exists.')
+  }
+
+  const created = await payload.create({
+    collection: 'catalog-relations',
+    data: {
+      from: input.fromId,
+      to: input.toId,
+      type: input.type,
+      source: { type: 'manual' as const },
+      ...(workspaceId ? { workspace: workspaceId } : {}),
+    },
+    overrideAccess: true,
+  })
+
+  revalidatePath(`/catalog/${input.fromId}`)
+  revalidatePath(`/catalog/${input.toId}`)
+  await revalidateCatalog(payload, workspaceId)
+  return { id: created.id }
+}
+
+/** Delete a MANUAL relation. RBAC: manage rights on the `from` entity's workspace. */
+export async function deleteCatalogRelation(id: string): Promise<void> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  const relation = await payload.findByID({
+    collection: 'catalog-relations',
+    id,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  if ((relation.source?.type ?? 'manual') !== 'manual') {
+    throw new Error('Only manual relations can be removed.')
+  }
+
+  const fromId = refId(relation.from)
+  let workspaceId: string | null = refId(relation.workspace)
+  if (fromId) {
+    try {
+      const fromEntity = (await payload.findByID({
+        collection: 'catalog-entities',
+        id: fromId,
+        depth: 0,
+        overrideAccess: true,
+      })) as CatalogEntity
+      workspaceId = refId(fromEntity.workspace)
+    } catch {
+      // fall back to the relation's own workspace
+    }
+  }
+
+  if (!(await canManageEntity(payload, betterAuthId, isAdmin, { workspaceId }))) {
+    throw new Error('You do not have permission to remove this relation.')
+  }
+
+  await payload.delete({
+    collection: 'catalog-relations',
+    id,
+    overrideAccess: true,
+  })
+
+  const toId = refId(relation.to)
+  if (fromId) revalidatePath(`/catalog/${fromId}`)
+  if (toId) revalidatePath(`/catalog/${toId}`)
+  await revalidateCatalog(payload, workspaceId)
+}
+
+// ---------------------------------------------------------------------------
+// Form options + pickers
+// ---------------------------------------------------------------------------
+
+/** Map a (depth-1) catalog entity to a picker option. */
+function toEntityOption(entity: CatalogEntity): EntityOption {
+  const ws = entity.workspace
+  const workspaceName = ws && typeof ws === 'object' ? ws.name : null
+  return {
+    id: entity.id,
+    name: entity.name,
+    kind: entity.kind as EntityKind,
+    workspaceName,
+  }
+}
+
+/**
+ * Options for the create/edit form: workspaces the caller may author in, whether
+ * they can create global entities, and team entities (for the owner picker)
+ * grouped by workspace plus the global set.
+ */
+export async function getEntityFormOptions(): Promise<EntityFormOptions> {
+  const { payload, betterAuthId, isAdmin } = await requireSession()
+
+  let workspaces: { id: string; name: string }[] = []
+  if (isAdmin) {
+    const all = await payload.find({
+      collection: 'workspaces',
+      limit: 1000,
+      depth: 0,
+      overrideAccess: true,
+      sort: 'name',
+    })
+    workspaces = all.docs.map((w) => ({ id: w.id, name: w.name }))
+  } else {
+    const ids = await getManageableWorkspaceIds(payload, betterAuthId)
+    if (ids.length > 0) {
+      const ws = await payload.find({
+        collection: 'workspaces',
+        where: { id: { in: ids } },
+        limit: 1000,
+        depth: 0,
+        overrideAccess: true,
+        sort: 'name',
+      })
+      workspaces = ws.docs.map((w) => ({ id: w.id, name: w.name }))
+    }
+  }
+
+  const teamsByWorkspace: Record<string, EntityOption[]> = {}
+  const wsIds = workspaces.map((w) => w.id)
+  if (wsIds.length > 0) {
+    const teams = await payload.find({
+      collection: 'catalog-entities',
+      where: { and: [{ kind: { equals: 'team' } }, { workspace: { in: wsIds } }] },
+      limit: 1000,
+      depth: 1,
+      overrideAccess: true,
+      sort: 'name',
+    })
+    for (const team of teams.docs as CatalogEntity[]) {
+      const wsId = refId(team.workspace)
+      if (!wsId) continue
+      ;(teamsByWorkspace[wsId] ??= []).push(toEntityOption(team))
+    }
+  }
+
+  let globalTeams: EntityOption[] = []
+  if (isAdmin) {
+    const gt = await payload.find({
+      collection: 'catalog-entities',
+      where: { and: [{ kind: { equals: 'team' } }, { workspace: { exists: false } }] },
+      limit: 1000,
+      depth: 0,
+      overrideAccess: true,
+      sort: 'name',
+    })
+    globalTeams = (gt.docs as CatalogEntity[]).map(toEntityOption)
+  }
+
+  return {
+    workspaces,
+    canCreateGlobal: isAdmin,
+    teamsByWorkspace,
+    globalTeams,
+  }
+}
+
+/**
+ * Org-wide entity search for relation/owner pickers (limit 20). Any authenticated
+ * user may search; results carry the workspace name for display.
+ */
+export async function searchEntitiesForPicker(
+  query: string,
+  opts?: { kind?: EntityKind; excludeId?: string },
+): Promise<EntityOption[]> {
+  const { payload } = await requireSession()
+
+  const conditions: Where[] = []
+  const trimmed = query?.trim()
+  if (trimmed) conditions.push({ name: { contains: trimmed } })
+  if (opts?.kind) conditions.push({ kind: { equals: opts.kind } })
+  if (opts?.excludeId) conditions.push({ id: { not_equals: opts.excludeId } })
+
+  const where: Where =
+    conditions.length === 0 ? {} : conditions.length === 1 ? conditions[0] : { and: conditions }
+
+  const res = await payload.find({
+    collection: 'catalog-entities',
+    where,
+    limit: 20,
+    depth: 1,
+    sort: 'name',
+    overrideAccess: true,
+  })
+
+  return (res.docs as CatalogEntity[]).map(toEntityOption)
+}

--- a/orbit-www/src/app/(frontend)/catalog/new/page.tsx
+++ b/orbit-www/src/app/(frontend)/catalog/new/page.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link'
+import { ArrowLeft, ShieldAlert } from 'lucide-react'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+import { SiteHeader } from '@/components/site-header'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { EntityForm } from '@/components/features/catalog/entity-form'
+import { ENTITY_KINDS, type EntityKind } from '@/collections/catalog/constants'
+import { getEntityFormOptions } from '../entity-actions'
+
+interface NewEntityPageProps {
+  searchParams: Promise<{ workspace?: string; kind?: string }>
+}
+
+/**
+ * Create a manual catalog entity (Catalog Entity CRUD, WP2). Resolves the
+ * caller's authoring options (workspaces they can create in + platform-admin
+ * global capability) as a defense-in-depth gate on top of the RBAC-enforced
+ * createCatalogEntity action. When the caller can create nowhere, a friendly
+ * gate replaces the form.
+ */
+export default async function NewCatalogEntityPage({ searchParams }: NewEntityPageProps) {
+  const params = await searchParams
+  const options = await getEntityFormOptions()
+  const canCreate = options.workspaces.length > 0 || options.canCreateGlobal
+
+  // Deep-link prefill (WP3 workspace landpage "New entity" / "Create team"):
+  // only honour a workspace the caller can actually author in; ignore otherwise
+  // so the form falls back to a free choice rather than locking to a forbidden
+  // workspace the server would reject anyway.
+  const fixedWorkspaceId = options.workspaces.some((w) => w.id === params.workspace)
+    ? params.workspace
+    : undefined
+  const defaultKind = (ENTITY_KINDS as readonly string[]).includes(params.kind ?? '')
+    ? (params.kind as EntityKind)
+    : undefined
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex-1 space-y-6 p-8 pt-6">
+          <div>
+            <Link
+              href="/catalog"
+              className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Catalog
+            </Link>
+            <h1 className="text-3xl font-bold">New entity</h1>
+            <p className="mt-2 text-muted-foreground">
+              Register a service, API, team, datastore or any other entity by hand. It appears in
+              the catalog immediately and can be related to other entities.
+            </p>
+          </div>
+
+          {canCreate ? (
+            <Card className="max-w-3xl">
+              <CardHeader>
+                <CardTitle className="text-base">Details</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <EntityForm
+                  mode="create"
+                  options={options}
+                  fixedWorkspaceId={fixedWorkspaceId}
+                  defaultKind={defaultKind}
+                  lockKind={defaultKind !== undefined}
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <NotPermitted />
+          )}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}
+
+function NotPermitted() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+      <ShieldAlert className="mb-4 h-12 w-12 text-muted-foreground" />
+      <h3 className="text-lg font-semibold">You can&rsquo;t create entities yet</h3>
+      <p className="mt-1 max-w-md text-sm text-muted-foreground">
+        Creating a catalog entity requires membership in a workspace. Ask a workspace owner to add
+        you, then come back to register your services.
+      </p>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(frontend)/catalog/page.tsx
+++ b/orbit-www/src/app/(frontend)/catalog/page.tsx
@@ -24,7 +24,23 @@ interface PageProps {
     q?: string
     kind?: string
     page?: string
+    scope?: string
+    workspace?: string
   }>
+}
+
+/** Best-effort workspace name from a page of results (populated at depth 1). */
+function resolveWorkspaceName(
+  docs: { workspace?: unknown }[],
+  workspaceId: string,
+): string {
+  for (const doc of docs) {
+    const ws = doc.workspace
+    if (ws && typeof ws === 'object' && 'id' in ws && (ws as { id: string }).id === workspaceId) {
+      return (ws as { name?: string }).name ?? 'this workspace'
+    }
+  }
+  return 'this workspace'
 }
 
 async function CatalogContent({ searchParams }: PageProps) {
@@ -33,6 +49,8 @@ async function CatalogContent({ searchParams }: PageProps) {
 
   const activeKind: EntityKind | 'all' = isEntityKind(params.kind) ? params.kind : 'all'
   const page = params.page ? Math.max(1, parseInt(params.page, 10) || 1) : 1
+  const scope: 'all' | 'mine' = params.scope === 'mine' ? 'mine' : 'all'
+  const workspaceId = params.workspace?.trim() || undefined
 
   const [result, counts] = await Promise.all([
     searchCatalogEntities({
@@ -40,9 +58,18 @@ async function CatalogContent({ searchParams }: PageProps) {
       kind: activeKind === 'all' ? undefined : activeKind,
       query: params.q,
       page,
+      scope,
+      workspaceId,
     }),
-    getCatalogKindCounts({ userId: user?.id, query: params.q }),
+    getCatalogKindCounts({ userId: user?.id, query: params.q, scope, workspaceId }),
   ])
+
+  // Resolve the filtered workspace's display name from a returned doc's
+  // populated (depth-1) workspace — no extra query. Falls back to a generic
+  // label when the filter yields no rows (e.g. an empty workspace).
+  const workspaceFilter = workspaceId
+    ? { id: workspaceId, name: resolveWorkspaceName(result.docs, workspaceId) }
+    : undefined
 
   return (
     <CatalogListClient
@@ -52,6 +79,9 @@ async function CatalogContent({ searchParams }: PageProps) {
       counts={counts}
       initialQuery={params.q}
       activeKind={activeKind}
+      scope={scope}
+      canCreate={result.canCreate}
+      workspaceFilter={workspaceFilter}
     />
   )
 }

--- a/orbit-www/src/app/(frontend)/workspaces/[slug]/page.tsx
+++ b/orbit-www/src/app/(frontend)/workspaces/[slug]/page.tsx
@@ -23,6 +23,8 @@ import {
   WorkspaceMembersCardSimple,
   WorkspaceKafkaOverviewCard,
 } from '@/components/features/workspace'
+import { WorkspaceEntitiesCard } from '@/components/features/workspace/entities/WorkspaceEntitiesCard'
+import type { WorkspaceEntitySummary } from '@/components/features/workspace/entities/workspace-entities-ui'
 
 interface PageProps {
   params: Promise<{
@@ -72,6 +74,7 @@ export default async function WorkspacePage({ params }: PageProps) {
     virtualClusterCountResult,
     topicCountResult,
     pendingShareCountResult,
+    catalogEntitiesResult,
   ] = await Promise.all([
     // Fetch members
     payload.find({
@@ -139,9 +142,25 @@ export default async function WorkspacePage({ params }: PageProps) {
       },
       overrideAccess: true,
     }),
+    // Fetch catalog entities for the Entities card (org-wide read model,
+    // scoped here to this workspace; see catalog-entity-crud plan WP3)
+    payload.find({
+      collection: 'catalog-entities',
+      where: { workspace: { equals: workspace.id } },
+      sort: 'name',
+      limit: 500,
+      depth: 0,
+      overrideAccess: true,
+    }),
   ])
 
   const members = membersResult.docs
+
+  const catalogEntities: WorkspaceEntitySummary[] = catalogEntitiesResult.docs.map((e) => ({
+    id: e.id,
+    name: e.name,
+    kind: e.kind,
+  }))
 
   // Batch-fetch Better Auth user details for member display
   const memberBaUserIds = members
@@ -279,6 +298,11 @@ export default async function WorkspacePage({ params }: PageProps) {
               <div className="space-y-6">
                 <WorkspaceApplicationsCard apps={appsResult.docs} />
                 <WorkspaceAPIsCard apis={apisResult.docs} workspaceSlug={workspace.slug} />
+                <WorkspaceEntitiesCard
+                  entities={catalogEntities}
+                  workspaceId={workspace.id}
+                  isMember={membershipStatus?.isMember ?? false}
+                />
               </div>
 
               {/* Middle Column - Kafka Overview + Registries + Recent Docs */}

--- a/orbit-www/src/app/api/internal/scorecards/due/route.test.ts
+++ b/orbit-www/src/app/api/internal/scorecards/due/route.test.ts
@@ -2,6 +2,8 @@
  * @vitest-environment node
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import type { Payload } from 'payload'
 
 vi.mock('payload', () => ({
   getPayload: vi.fn(),
@@ -20,7 +22,7 @@ const { GET } = await import('./route')
 function req(apiKey?: string | null) {
   const headers: Record<string, string> = {}
   if (apiKey) headers['X-API-Key'] = apiKey
-  return new Request('http://localhost/api/internal/scorecards/due', {
+  return new NextRequest('http://localhost/api/internal/scorecards/due', {
     method: 'GET',
     headers,
   })
@@ -33,17 +35,17 @@ describe('GET /api/internal/scorecards/due', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(getPayload as any).mockResolvedValue(mockPayload)
+    vi.mocked(getPayload).mockResolvedValue(mockPayload as unknown as Payload)
   })
 
   it('returns 401 without an API key', async () => {
-    const response = await GET(req(null) as any)
+    const response = await GET(req(null))
     expect(response.status).toBe(401)
     expect(mockPayload.find).not.toHaveBeenCalled()
   })
 
   it('returns 401 with the wrong API key', async () => {
-    const response = await GET(req('wrong-key') as any)
+    const response = await GET(req('wrong-key'))
     expect(response.status).toBe(401)
     expect(mockPayload.find).not.toHaveBeenCalled()
   })
@@ -57,7 +59,7 @@ describe('GET /api/internal/scorecards/due', () => {
       hasNextPage: false,
     })
 
-    const response = await GET(req('test-api-key') as any)
+    const response = await GET(req('test-api-key'))
     expect(response.status).toBe(200)
 
     const data = await response.json()
@@ -86,7 +88,7 @@ describe('GET /api/internal/scorecards/due', () => {
       hasNextPage: false,
     })
 
-    const response = await GET(req('test-api-key') as any)
+    const response = await GET(req('test-api-key'))
     const data = await response.json()
     expect(data.scorecards).toEqual([{ id: 'sc-1', workspaceId: 'ws-1' }])
   })
@@ -102,7 +104,7 @@ describe('GET /api/internal/scorecards/due', () => {
         hasNextPage: false,
       })
 
-    const response = await GET(req('test-api-key') as any)
+    const response = await GET(req('test-api-key'))
     const data = await response.json()
     expect(data.scorecards).toEqual([
       { id: 'sc-1', workspaceId: 'ws-1' },
@@ -116,7 +118,7 @@ describe('GET /api/internal/scorecards/due', () => {
   it('returns 500 when payload throws', async () => {
     mockPayload.find.mockRejectedValueOnce(new Error('db exploded'))
 
-    const response = await GET(req('test-api-key') as any)
+    const response = await GET(req('test-api-key'))
     expect(response.status).toBe(500)
     const data = await response.json()
     expect(data.error).toBe('db exploded')

--- a/orbit-www/src/collections/catalog/CatalogEntities.ts
+++ b/orbit-www/src/collections/catalog/CatalogEntities.ts
@@ -1,5 +1,7 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { ENTITY_KINDS } from './constants'
+import { canCreateEntity, canManageEntity, canDeleteEntity } from '@/lib/catalog/entity-authz'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
 
 /**
  * CatalogEntities — the unified software-catalog read model (IDP refocus P1).
@@ -34,74 +36,50 @@ export const CatalogEntities: CollectionConfig = {
     description: 'Unified catalog graph — projected from apps, APIs, topics and more.',
   },
   access: {
-    // Read: Payload admins see all; others see workspace-scoped (mirrors apps).
-    read: async ({ req: { user, payload } }) => {
+    // Org-wide read for any authenticated user — the catalog is the discovery
+    // surface (Catalog Entity CRUD, docs/plans/2026-07-02-catalog-entity-crud.md).
+    // Server actions and projections run with overrideAccess and bypass these
+    // rules; they are defense-in-depth for direct Payload REST/GraphQL access.
+    read: ({ req: { user } }) => !!user,
+    // Create/update: platform admin, or an active member of the entity's
+    // workspace. IMPORTANT: workspace-members.user holds a Better-Auth id, so we
+    // pass req.user.betterAuthId — NOT req.user.id (a Payload doc id), which was
+    // the latent access bug. A null workspace (global entity) ⇒ platform admin only.
+    create: async ({ req: { user, payload }, data }) => {
       if (!user) return false
-      if (user.collection === 'users') return true
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-      )
-      return { workspace: { in: workspaceIds } } as Where
+      const ws = (data as { workspace?: string | { id: string } } | undefined)?.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      return canCreateEntity(payload, user.betterAuthId, isPlatformAdmin(user), workspaceId)
     },
-    // Create/update/delete are primarily performed by projection hooks via
-    // overrideAccess. Direct user edits require workspace owner/admin.
-    create: ({ req: { user } }) => !!user,
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
       const entity = await payload.findByID({
         collection: 'catalog-entities',
         id,
+        depth: 0,
         overrideAccess: true,
       })
-      const workspaceId =
-        typeof entity.workspace === 'string' ? entity.workspace : entity.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      const ws = entity.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      return canManageEntity(payload, user.betterAuthId, isPlatformAdmin(user), { workspaceId })
     },
+    // Delete: manual entities only (projected rows are deleted by removing their
+    // source), by a platform admin or workspace owner/admin.
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
       const entity = await payload.findByID({
         collection: 'catalog-entities',
         id,
+        depth: 0,
         overrideAccess: true,
       })
-      const workspaceId =
-        typeof entity.workspace === 'string' ? entity.workspace : entity.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
+      const ws = entity.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      const sourceType = entity.source?.type ?? 'manual'
+      return canDeleteEntity(payload, user.betterAuthId, isPlatformAdmin(user), {
+        workspaceId,
+        sourceType,
       })
-      return members.docs.length > 0
     },
   },
   hooks: {
@@ -154,9 +132,11 @@ export const CatalogEntities: CollectionConfig = {
       name: 'workspace',
       type: 'relationship',
       relationTo: 'workspaces',
-      required: true,
+      // Optional: global entities (no workspace) are platform-admin-managed
+      // (Catalog Entity CRUD). Relations derive workspace from their `from` entity.
+      required: false,
       index: true,
-      admin: { description: 'Security enclave the entity belongs to.' },
+      admin: { description: 'Security enclave the entity belongs to (absent = global).' },
     },
     {
       name: 'owner',

--- a/orbit-www/src/collections/catalog/CatalogRelations.ts
+++ b/orbit-www/src/collections/catalog/CatalogRelations.ts
@@ -1,5 +1,7 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { RELATION_TYPES } from './constants'
+import { canCreateEntity, canManageEntity } from '@/lib/catalog/entity-authz'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
 
 /**
  * CatalogRelations — typed edges in the catalog graph (IDP refocus P1).
@@ -28,71 +30,45 @@ export const CatalogRelations: CollectionConfig = {
     description: 'Typed edges between catalog entities (dependencies, ownership, lineage).',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
+    // Org-wide read for any authenticated user; a relation is visible wherever
+    // its endpoints are (Catalog Entity CRUD). Server actions/projections use
+    // overrideAccess — these rules are defense-in-depth for direct API access.
+    read: ({ req: { user } }) => !!user,
+    // Create/update: platform admin, or an active member of the relation's
+    // workspace (derived from its `from` entity). Better-Auth id via
+    // req.user.betterAuthId — never req.user.id. Null workspace ⇒ admin only.
+    create: async ({ req: { user, payload }, data }) => {
       if (!user) return false
-      if (user.collection === 'users') return true
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-      )
-      return { workspace: { in: workspaceIds } } as Where
+      const ws = (data as { workspace?: string | { id: string } } | undefined)?.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      return canCreateEntity(payload, user.betterAuthId, isPlatformAdmin(user), workspaceId)
     },
-    create: ({ req: { user } }) => !!user,
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
       const rel = await payload.findByID({
         collection: 'catalog-relations',
         id,
+        depth: 0,
         overrideAccess: true,
       })
-      const workspaceId =
-        typeof rel.workspace === 'string' ? rel.workspace : rel.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      const ws = rel.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      return canManageEntity(payload, user.betterAuthId, isPlatformAdmin(user), { workspaceId })
     },
+    // Delete: manual relations only (projected edges belong to their projector),
+    // by anyone with manage rights on the relation's workspace.
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
       const rel = await payload.findByID({
         collection: 'catalog-relations',
         id,
+        depth: 0,
         overrideAccess: true,
       })
-      const workspaceId =
-        typeof rel.workspace === 'string' ? rel.workspace : rel.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      if ((rel.source?.type ?? 'manual') !== 'manual') return false
+      const ws = rel.workspace
+      const workspaceId = ws ? (typeof ws === 'string' ? ws : ws.id) : null
+      return canManageEntity(payload, user.betterAuthId, isPlatformAdmin(user), { workspaceId })
     },
   },
   fields: [
@@ -100,9 +76,11 @@ export const CatalogRelations: CollectionConfig = {
       name: 'workspace',
       type: 'relationship',
       relationTo: 'workspaces',
-      required: true,
+      // Optional: derived from the `from` entity's workspace at write time;
+      // absent for a global-from-global relation (Catalog Entity CRUD).
+      required: false,
       index: true,
-      admin: { description: 'Security enclave the relation belongs to.' },
+      admin: { description: 'Security enclave the relation belongs to (absent = global).' },
     },
     {
       name: 'from',

--- a/orbit-www/src/components/features/catalog/CatalogListClient.tsx
+++ b/orbit-www/src/components/features/catalog/CatalogListClient.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Search, X } from 'lucide-react'
+import { Plus, Search, X } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import type { CatalogEntity } from '@/payload-types'
+import type { CatalogEntityWithAccess } from '@/app/(frontend)/catalog/actions'
 import { EntityList } from './EntityList'
 import { ENTITY_KIND_VALUES, KIND_LABELS, type EntityKind } from './catalog-query'
 
 interface CatalogListClientProps {
-  entities: CatalogEntity[]
+  entities: CatalogEntityWithAccess[]
   totalPages: number
   currentPage: number
   /** All + per-kind counts, used to choose which tabs to render and their badges. */
@@ -19,6 +20,12 @@ interface CatalogListClientProps {
   initialQuery?: string
   /** Active kind tab ('all' or a specific kind). */
   activeKind: EntityKind | 'all'
+  /** Read scope: org-wide ('all') or the caller's workspaces ('mine'). */
+  scope: 'all' | 'mine'
+  /** Whether the caller can create an entity somewhere — gates the New button. */
+  canCreate: boolean
+  /** Active workspace filter (from ?workspace=), or undefined. Drives the filter chip. */
+  workspaceFilter?: { id: string; name: string }
 }
 
 export function CatalogListClient({
@@ -28,6 +35,9 @@ export function CatalogListClient({
   counts,
   initialQuery,
   activeKind,
+  scope,
+  canCreate,
+  workspaceFilter,
 }: CatalogListClientProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -59,6 +69,18 @@ export function CatalogListClient({
   const handleTabChange = (value: string) => {
     updateSearchParams({ kind: value === 'all' ? undefined : value })
   }
+
+  // 'all' is the default, so it clears the param (keeps clean URLs + SSR default).
+  const handleScopeChange = (value: string) => {
+    updateSearchParams({ scope: value === 'mine' ? 'mine' : undefined })
+  }
+
+  // The read action attaches a server-computed `canManage` to each doc; fold
+  // those into a Set for the per-card "Managed" badge.
+  const canManageIds = React.useMemo(
+    () => new Set(entities.filter((e) => e.canManage).map((e) => e.id)),
+    [entities],
+  )
 
   // Only surface tabs for kinds that actually have entities (within the current
   // query), but always keep the active kind visible so a deep-link never lands
@@ -94,6 +116,40 @@ export function CatalogListClient({
         </div>
       </div>
 
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Tabs value={scope} onValueChange={handleScopeChange}>
+          <TabsList>
+            <TabsTrigger value="all">All entities</TabsTrigger>
+            <TabsTrigger value="mine">My workspaces</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {canCreate && (
+          <Button asChild size="sm">
+            <Link href="/catalog/new">
+              <Plus className="h-4 w-4" />
+              New entity
+            </Link>
+          </Button>
+        )}
+      </div>
+
+      {workspaceFilter && (
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-3 py-1 text-sm">
+            <span className="text-muted-foreground">Filtered to</span>
+            <span className="font-medium">{workspaceFilter.name}</span>
+            <button
+              type="button"
+              aria-label="Clear workspace filter"
+              onClick={() => updateSearchParams({ workspace: undefined })}
+              className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </span>
+        </div>
+      )}
+
       <Tabs value={activeKind} onValueChange={handleTabChange}>
         <TabsList className="flex h-auto flex-wrap justify-start gap-1">
           <TabsTrigger value="all">
@@ -111,11 +167,14 @@ export function CatalogListClient({
 
       <EntityList
         entities={entities}
+        canManageIds={canManageIds}
         emptyTitle={initialQuery ? 'No matching entities' : `No ${activeLabel} yet`}
         emptyHint={
           initialQuery
             ? 'Try a different search term or switch tabs.'
-            : 'Entities appear here automatically as services, APIs and topics are registered.'
+            : scope === 'mine'
+              ? 'No entities in your workspaces yet. Create one, or switch to All entities to browse the org.'
+              : 'Create your first entity, or connect a source to project services, APIs and topics automatically.'
         }
       />
 

--- a/orbit-www/src/components/features/catalog/DeleteEntityButton.tsx
+++ b/orbit-www/src/components/features/catalog/DeleteEntityButton.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { deleteCatalogEntity } from '@/app/(frontend)/catalog/entity-actions'
+
+interface DeleteEntityButtonProps {
+  entityId: string
+  entityName: string
+}
+
+/**
+ * Destructive delete for a manual catalog entity (Catalog Entity CRUD, WP2).
+ * Guards the irreversible delete (entity + its relations) behind a confirm
+ * dialog; deleteCatalogEntity re-checks delete rights and manual provenance
+ * server-side before removing anything.
+ */
+export function DeleteEntityButton({ entityId, entityName }: DeleteEntityButtonProps) {
+  const router = useRouter()
+  const [deleting, setDeleting] = useState(false)
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      await deleteCatalogEntity(entityId)
+      toast.success('Entity deleted')
+      router.push('/catalog')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete entity')
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="outline" className="shrink-0 text-destructive">
+          <Trash2 className="h-4 w-4" />
+          Delete entity
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this entity?</AlertDialogTitle>
+          <AlertDialogDescription>
+            &ldquo;{entityName}&rdquo; and every relation to or from it will be permanently removed.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault()
+              handleDelete()
+            }}
+            disabled={deleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/orbit-www/src/components/features/catalog/EntityDetail.tsx
+++ b/orbit-www/src/components/features/catalog/EntityDetail.tsx
@@ -10,15 +10,17 @@ import {
   BookOpen,
   GitBranch,
   Link2,
+  Pencil,
   Users,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type { CatalogEntity, CatalogRelation } from '@/payload-types'
 import { entityKindMeta } from './entity-kind-meta'
 import { EntityGraph } from './EntityGraph'
-import { EntityRelations } from './EntityRelations'
+import { RelationEditor } from './RelationEditor'
 import { EntityDocsTab } from './EntityDocsTab'
 import { EntityScorecardsTab } from './EntityScorecardsTab'
 import { ScoreNumberChip } from '@/components/features/scorecards/ScoreChip'
@@ -32,6 +34,8 @@ interface EntityDetailProps {
   entity: CatalogEntity
   relations: CatalogRelation[]
   docs: LinkedDoc[]
+  /** Whether the caller can manage this entity (edit + add/remove relations). */
+  canManage: boolean
 }
 
 const lifecycleVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
@@ -64,7 +68,7 @@ function MetaRow({ label, children }: { label: string; children: React.ReactNode
   )
 }
 
-export function EntityDetail({ entity, relations, docs }: EntityDetailProps) {
+export function EntityDetail({ entity, relations, docs, canManage }: EntityDetailProps) {
   const meta = entityKindMeta(entity.kind)
   const KindIcon = meta.icon
 
@@ -147,6 +151,14 @@ export function EntityDetail({ entity, relations, docs }: EntityDetailProps) {
             <ScoreNumberChip
               score={scoreBreakdown === null ? undefined : (scoreBreakdown.overall?.score ?? null)}
             />
+            {canManage && (
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/catalog/${entity.id}/edit`}>
+                  <Pencil className="h-4 w-4" />
+                  Edit
+                </Link>
+              </Button>
+            )}
           </div>
         </div>
       </div>
@@ -239,7 +251,11 @@ export function EntityDetail({ entity, relations, docs }: EntityDetailProps) {
 
         {/* Relations */}
         <TabsContent value="relations">
-          <EntityRelations focalId={entity.id} relations={relations} />
+          <RelationEditor
+            focalEntity={{ id: entity.id, name: entity.name, kind: entity.kind }}
+            relations={relations}
+            canManage={canManage}
+          />
         </TabsContent>
 
         {/* Docs */}

--- a/orbit-www/src/components/features/catalog/EntityList.tsx
+++ b/orbit-www/src/components/features/catalog/EntityList.tsx
@@ -21,10 +21,13 @@ export function EntityList({
   entities,
   emptyTitle = 'No entities found',
   emptyHint,
+  canManageIds,
 }: {
   entities: CatalogEntity[]
   emptyTitle?: string
   emptyHint?: string
+  /** Ids of entities the caller can manage — drives the per-card "Managed" badge. */
+  canManageIds?: Set<string>
 }) {
   const [scores, setScores] = useState<Record<string, EntityOverallScore> | null>(null)
 
@@ -63,6 +66,7 @@ export function EntityList({
           entity={entity}
           score={scores ? (scores[entity.id]?.score ?? null) : undefined}
           scoreIsBaseline={scores ? (scores[entity.id]?.baseline ?? false) : false}
+          canManage={canManageIds?.has(entity.id) ?? false}
         />
       ))}
     </div>

--- a/orbit-www/src/components/features/catalog/EntityListItem.tsx
+++ b/orbit-www/src/components/features/catalog/EntityListItem.tsx
@@ -29,6 +29,12 @@ function ownerName(owner: CatalogEntity['owner']): string | null {
   return owner.name ?? null
 }
 
+/** Populated workspace name, or null for a global (no-workspace) entity. */
+function workspaceName(workspace: CatalogEntity['workspace']): string | null {
+  if (workspace == null || typeof workspace === 'string') return null
+  return workspace.name ?? null
+}
+
 /**
  * One catalog entity rendered as a card linking to its detail page
  * (`/catalog/{id}`, owned by the detail agent). No client hooks itself — the
@@ -41,14 +47,18 @@ export function EntityListItem({
   entity,
   score,
   scoreIsBaseline = false,
+  canManage = false,
 }: {
   entity: CatalogEntity
   score?: number | null
   /** True when `score` is the type's inherited base value, not an evaluated score. */
   scoreIsBaseline?: boolean
+  /** True when the caller can manage this entity — surfaces a subtle badge. */
+  canManage?: boolean
 }) {
   const health = entity.health ?? 'unknown'
   const owner = ownerName(entity.owner)
+  const workspace = workspaceName(entity.workspace)
 
   return (
     <Link href={`/catalog/${entity.id}`} className="block focus:outline-none">
@@ -76,6 +86,14 @@ export function EntityListItem({
               </Badge>
             )}
             <EntityScoreInlineChip score={score} baseline={scoreIsBaseline} />
+            <Badge variant="outline" className="font-normal text-muted-foreground">
+              {workspace ?? 'Global'}
+            </Badge>
+            {canManage && (
+              <Badge variant="secondary" className="font-normal">
+                Managed
+              </Badge>
+            )}
           </div>
         </CardHeader>
         <CardContent className="space-y-2">

--- a/orbit-www/src/components/features/catalog/RelationEditor.tsx
+++ b/orbit-www/src/components/features/catalog/RelationEditor.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, Loader2, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useRouter } from 'next/navigation'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { CatalogEntity, CatalogRelation } from '@/payload-types'
+import { RELATION_TYPES, type RelationType } from '@/collections/catalog/constants'
+import { entityKindMeta } from './entity-kind-meta'
+import { toEdges, groupEdgesByType, relationTypeLabel, type RelationEdge } from './entity-relations'
+import { EntityPicker } from './entity-form/EntityPicker'
+import type { PickerEntity } from './entity-form/entity-form-ui'
+import {
+  createCatalogRelation,
+  deleteCatalogRelation,
+  searchEntitiesForPicker,
+} from '@/app/(frontend)/catalog/entity-actions'
+
+interface RelationEditorProps {
+  focalEntity: Pick<CatalogEntity, 'id' | 'name' | 'kind'>
+  relations: CatalogRelation[]
+  /** Whether the caller can manage the focal entity (add/remove relations). */
+  canManage: boolean
+}
+
+type Direction = 'outbound' | 'inbound'
+
+/** Relation ids whose backing source is manual (i.e. user-deletable). */
+function manualRelationIds(relations: CatalogRelation[]): Set<string> {
+  const ids = new Set<string>()
+  for (const rel of relations) {
+    if ((rel.source?.type ?? 'manual') === 'manual') ids.add(rel.id)
+  }
+  return ids
+}
+
+/**
+ * The Relations tab body: renders the focal entity's typed edges grouped by
+ * type/direction (mirroring the read-only EntityRelations look) and, for users
+ * with manage rights, adds an "Add relation" dialog and per-edge remove on
+ * manual relations. Projected relations are never deletable here (they belong
+ * to their projector); the server re-checks RBAC + manual-source on every call.
+ */
+export function RelationEditor({ focalEntity, relations, canManage }: RelationEditorProps) {
+  const router = useRouter()
+  const edges = useMemo(() => toEdges(relations, focalEntity.id), [relations, focalEntity.id])
+  const groups = useMemo(() => groupEdgesByType(edges), [edges])
+  const manualIds = useMemo(() => manualRelationIds(relations), [relations])
+
+  const [removingId, setRemovingId] = useState<string | null>(null)
+
+  async function handleRemove(relationId: string) {
+    setRemovingId(relationId)
+    try {
+      await deleteCatalogRelation(relationId)
+      toast.success('Relation removed')
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove relation')
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {canManage && (
+        <div className="flex justify-end">
+          <AddRelationDialog focalEntity={focalEntity} onCreated={() => router.refresh()} />
+        </div>
+      )}
+
+      {groups.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No relationships yet.{' '}
+            {canManage
+              ? 'Add a dependency, ownership or lineage edge to connect this entity.'
+              : 'Dependencies, ownership and lineage edges appear here as they are added.'}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {groups.map((group) => {
+            const DirIcon = group.direction === 'outbound' ? ArrowRight : ArrowLeft
+            return (
+              <Card key={`${group.type}-${group.direction}`}>
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-sm">
+                    <DirIcon className="h-4 w-4 text-muted-foreground" />
+                    {relationTypeLabel(group.type)}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      ({group.direction === 'outbound' ? 'outgoing' : 'incoming'})
+                    </span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {group.edges.map((edge) => (
+                    <NeighborRow
+                      key={edge.id}
+                      edge={edge}
+                      deletable={canManage && manualIds.has(edge.id)}
+                      pending={removingId === edge.id}
+                      onRemove={() => handleRemove(edge.id)}
+                    />
+                  ))}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NeighborRow({
+  edge,
+  deletable,
+  pending,
+  onRemove,
+}: {
+  edge: RelationEdge
+  deletable: boolean
+  pending: boolean
+  onRemove: () => void
+}) {
+  const meta = entityKindMeta(edge.neighbor.kind)
+  const Icon = meta.icon
+  return (
+    <div className="flex items-center gap-3 rounded-md border px-3 py-2">
+      <Icon className={`h-4 w-4 shrink-0 ${meta.accent}`} />
+      <Link
+        href={`/catalog/${edge.neighbor.id}`}
+        className="flex-1 truncate text-sm font-medium hover:underline"
+      >
+        {edge.neighbor.name}
+      </Link>
+      <Badge variant="outline" className="shrink-0 text-xs">
+        {meta.label}
+      </Badge>
+      {deletable && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Remove relation"
+              disabled={pending}
+              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+            >
+              {pending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove this relation?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The edge to &ldquo;{edge.neighbor.name}&rdquo; will be removed. The entities
+                themselves are unaffected. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault()
+                  onRemove()
+                }}
+                disabled={pending}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Remove
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </div>
+  )
+}
+
+function AddRelationDialog({
+  focalEntity,
+  onCreated,
+}: {
+  focalEntity: Pick<CatalogEntity, 'id' | 'name' | 'kind'>
+  onCreated: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [direction, setDirection] = useState<Direction>('outbound')
+  const [type, setType] = useState<RelationType>('depends-on')
+  const [target, setTarget] = useState<PickerEntity | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  function reset() {
+    setDirection('outbound')
+    setType('depends-on')
+    setTarget(null)
+  }
+
+  const search = useMemo(
+    () => (query: string) => searchEntitiesForPicker(query, { excludeId: focalEntity.id }),
+    [focalEntity.id],
+  )
+
+  async function handleSubmit() {
+    if (!target) {
+      toast.error('Select an entity to relate to.')
+      return
+    }
+    // Direction decides which side the focal entity sits on. RBAC is enforced
+    // on the `from` entity server-side, so an inbound edge from an entity the
+    // caller can't manage is rejected there (surfaced as a toast).
+    const fromId = direction === 'outbound' ? focalEntity.id : target.id
+    const toId = direction === 'outbound' ? target.id : focalEntity.id
+
+    setSubmitting(true)
+    try {
+      await createCatalogRelation({ fromId, toId, type })
+      toast.success('Relation added')
+      setOpen(false)
+      reset()
+      onCreated()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add relation')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button type="button" size="sm">
+          <Plus className="h-4 w-4" />
+          Add relation
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a relation</DialogTitle>
+          <DialogDescription>
+            Connect &ldquo;{focalEntity.name}&rdquo; to another entity with a typed edge.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="relation-direction">Direction</Label>
+            <Select
+              value={direction}
+              onValueChange={(v) => setDirection(v as Direction)}
+              disabled={submitting}
+            >
+              <SelectTrigger id="relation-direction">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="outbound">This entity → other</SelectItem>
+                <SelectItem value="inbound">Other → this entity</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="relation-type">Type</Label>
+            <Select
+              value={type}
+              onValueChange={(v) => setType(v as RelationType)}
+              disabled={submitting}
+            >
+              <SelectTrigger id="relation-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RELATION_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {relationTypeLabel(t)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="relation-target">Entity</Label>
+            <EntityPicker
+              id="relation-target"
+              value={target}
+              onSelect={setTarget}
+              search={search}
+              placeholder="Search the catalog…"
+              disabled={submitting}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={submitting || !target}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Add relation
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/orbit-www/src/components/features/catalog/entity-form/EntityForm.tsx
+++ b/orbit-www/src/components/features/catalog/entity-form/EntityForm.tsx
@@ -1,0 +1,346 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Info, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { CatalogEntity } from '@/payload-types'
+import { ENTITY_KINDS, type EntityKind } from '@/collections/catalog/constants'
+import { KIND_LABELS_SINGULAR } from '../catalog-query'
+import {
+  createCatalogEntity,
+  updateCatalogEntity,
+  searchEntitiesForPicker,
+} from '@/app/(frontend)/catalog/entity-actions'
+import { EntityPicker } from './EntityPicker'
+import { EntityLinksEditor } from './EntityLinksEditor'
+import {
+  LIFECYCLE_OPTIONS,
+  TIER_OPTIONS,
+  buildWorkspaceOptions,
+  collectLinkErrors,
+  idToWorkspaceSelection,
+  isSourceLocked,
+  linksToRows,
+  newLinkRow,
+  rowsToLinks,
+  sourceProvenanceLabel,
+  workspaceSelectionToId,
+  type EntityFormOptions,
+  type LinkRow,
+  type Lifecycle,
+  type PickerEntity,
+  type Tier,
+} from './entity-form-ui'
+
+/** Sentinel `<Select>` value for an unset optional field (lifecycle/tier). */
+const NONE = '__none__'
+
+export interface EntityFormProps {
+  mode: 'create' | 'edit'
+  /** Workspaces the caller can create in + platform-admin global flag. */
+  options: EntityFormOptions
+  /** Edit mode: the entity being edited (prefill + projection source-lock). */
+  entity?: CatalogEntity
+  /**
+   * Preselect AND lock the workspace (WP3 workspace landpage "New entity" /
+   * "Create team"). Ignored in edit mode (workspace is not reassignable here).
+   */
+  fixedWorkspaceId?: string
+  /** Preselect the kind (e.g. WP3 "Create team" → 'team'). Create mode only. */
+  defaultKind?: EntityKind
+  /** Lock the kind selector (e.g. WP3 "Create team"). */
+  lockKind?: boolean
+  /** Redirect target after success. Defaults to the entity detail page. */
+  onSuccessRedirect?: string
+}
+
+function workspaceIdOf(entity: CatalogEntity | undefined): string | null {
+  const ws = entity?.workspace
+  if (ws == null) return null
+  return typeof ws === 'string' ? ws : ws.id
+}
+
+function workspaceNameOf(entity: CatalogEntity | undefined): string | null {
+  const ws = entity?.workspace
+  if (ws == null || typeof ws === 'string') return null
+  return ws.name ?? null
+}
+
+function ownerOf(entity: CatalogEntity | undefined): PickerEntity | null {
+  const owner = entity?.owner
+  if (!owner || typeof owner === 'string') return null
+  return { id: owner.id, name: owner.name, kind: 'team' }
+}
+
+/**
+ * Create/edit form for a catalog entity (WP2). Reused by the catalog `new`/
+ * `edit` pages and the WP3 workspace landpage.
+ *
+ * Field ownership: for a projected entity (`source.type` !== 'manual') the
+ * identity fields (name, kind, workspace) render read-only with a provenance
+ * note; curation fields stay editable. The server re-checks both RBAC and the
+ * field-ownership policy, so this is a UX affordance, not the security gate.
+ */
+export function EntityForm({
+  mode,
+  options,
+  entity,
+  fixedWorkspaceId,
+  defaultKind,
+  lockKind,
+  onSuccessRedirect,
+}: EntityFormProps) {
+  const router = useRouter()
+  const isEdit = mode === 'edit'
+  const sourceType = entity?.source?.type ?? 'manual'
+  const locked = isEdit && isSourceLocked(sourceType)
+  const provenance = sourceProvenanceLabel(sourceType)
+
+  const workspaceOptions = buildWorkspaceOptions(options.workspaces, options.canCreateGlobal)
+
+  const [name, setName] = useState(entity?.name ?? '')
+  const [kind, setKind] = useState<EntityKind>((entity?.kind as EntityKind) ?? defaultKind ?? 'service')
+  const [workspaceSelection, setWorkspaceSelection] = useState<string>(() => {
+    if (isEdit) return idToWorkspaceSelection(workspaceIdOf(entity))
+    if (fixedWorkspaceId) return fixedWorkspaceId
+    return workspaceOptions[0]?.value ?? ''
+  })
+  const [description, setDescription] = useState(entity?.description ?? '')
+  const [lifecycle, setLifecycle] = useState<Lifecycle | typeof NONE>(entity?.lifecycle ?? NONE)
+  const [tier, setTier] = useState<Tier | typeof NONE>(entity?.tier ?? NONE)
+  const [owner, setOwner] = useState<PickerEntity | null>(ownerOf(entity))
+  const [linkRows, setLinkRows] = useState<LinkRow[]>(
+    entity?.links ? linksToRows(entity.links) : [newLinkRow()],
+  )
+  const [submitting, setSubmitting] = useState(false)
+
+  const workspaceLabel =
+    workspaceNameOf(entity) ??
+    (workspaceIdOf(entity) === null ? 'Global (no workspace)' : 'Workspace')
+
+  const searchTeams = useCallback(
+    (query: string) => searchEntitiesForPicker(query, { kind: 'team', excludeId: entity?.id }),
+    [entity?.id],
+  )
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      toast.error('A name is required.')
+      return
+    }
+    if (mode === 'create' && !workspaceSelection) {
+      toast.error('Select a workspace.')
+      return
+    }
+    const linkError = collectLinkErrors(linkRows)
+    if (linkError) {
+      toast.error(linkError)
+      return
+    }
+
+    const links = rowsToLinks(linkRows)
+    const lifecycleValue = lifecycle === NONE ? null : lifecycle
+    const tierValue = tier === NONE ? null : tier
+
+    setSubmitting(true)
+    try {
+      if (mode === 'create') {
+        const { id } = await createCatalogEntity({
+          kind,
+          name: trimmedName,
+          workspaceId: workspaceSelectionToId(workspaceSelection),
+          description: description.trim() || undefined,
+          lifecycle: lifecycleValue ?? undefined,
+          tier: tierValue ?? undefined,
+          ownerId: owner?.id ?? undefined,
+          links,
+        })
+        toast.success('Entity created')
+        router.push(onSuccessRedirect ?? `/catalog/${id}`)
+      } else if (entity) {
+        await updateCatalogEntity(entity.id, {
+          // Identity fields are only sent for manual entities; the server
+          // rejects them on projected entities regardless.
+          ...(locked ? {} : { name: trimmedName, kind }),
+          description: description.trim() || null,
+          lifecycle: lifecycleValue,
+          tier: tierValue,
+          ownerId: owner?.id ?? null,
+          links,
+        })
+        toast.success('Entity updated')
+        router.push(onSuccessRedirect ?? `/catalog/${entity.id}`)
+        router.refresh()
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save entity')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {locked && provenance && (
+        <div className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          <Info className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            {provenance}. Identity fields are managed by the source; edit description, lifecycle,
+            tier, owner and links here.
+          </span>
+        </div>
+      )}
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="entity-kind">Kind</Label>
+          <Select
+            value={kind}
+            onValueChange={(v) => setKind(v as EntityKind)}
+            disabled={locked || lockKind || submitting}
+          >
+            <SelectTrigger id="entity-kind">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ENTITY_KINDS.map((k) => (
+                <SelectItem key={k} value={k}>
+                  {KIND_LABELS_SINGULAR[k]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="entity-workspace">Workspace</Label>
+          {isEdit ? (
+            <Input id="entity-workspace" value={workspaceLabel} disabled readOnly />
+          ) : (
+            <Select
+              value={workspaceSelection}
+              onValueChange={setWorkspaceSelection}
+              disabled={!!fixedWorkspaceId || submitting || workspaceOptions.length === 0}
+            >
+              <SelectTrigger id="entity-workspace">
+                <SelectValue placeholder="Select a workspace" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspaceOptions.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="entity-name">Name</Label>
+        <Input
+          id="entity-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Payments API"
+          disabled={locked || submitting}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="entity-description">Description</Label>
+        <Textarea
+          id="entity-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What this entity is and who relies on it."
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="entity-lifecycle">Lifecycle</Label>
+          <Select
+            value={lifecycle}
+            onValueChange={(v) => setLifecycle(v as Lifecycle | typeof NONE)}
+            disabled={submitting}
+          >
+            <SelectTrigger id="entity-lifecycle">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE}>—</SelectItem>
+              {LIFECYCLE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="entity-tier">Tier</Label>
+          <Select
+            value={tier}
+            onValueChange={(v) => setTier(v as Tier | typeof NONE)}
+            disabled={submitting}
+          >
+            <SelectTrigger id="entity-tier">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE}>—</SelectItem>
+              {TIER_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="entity-owner">Owner team</Label>
+        <EntityPicker
+          id="entity-owner"
+          value={owner}
+          onSelect={setOwner}
+          search={searchTeams}
+          placeholder="Search for a team…"
+          emptyText="No teams found."
+          allowClear
+          disabled={submitting}
+        />
+        <p className="text-xs text-muted-foreground">
+          The team entity that owns this. Create team entities from a workspace to populate this.
+        </p>
+      </div>
+
+      <EntityLinksEditor rows={linkRows} onChange={setLinkRows} disabled={submitting} />
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+          {mode === 'create' ? 'Create entity' : 'Save changes'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/orbit-www/src/components/features/catalog/entity-form/EntityLinksEditor.tsx
+++ b/orbit-www/src/components/features/catalog/entity-form/EntityLinksEditor.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { Plus, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  LINK_TYPE_OPTIONS,
+  newLinkRow,
+  validateLinkRow,
+  type LinkRow,
+} from './entity-form-ui'
+
+interface EntityLinksEditorProps {
+  rows: LinkRow[]
+  onChange: (rows: LinkRow[]) => void
+  disabled?: boolean
+}
+
+/**
+ * Repeatable add/remove editor for an entity's links (docs, dashboards,
+ * runbooks…). Presentational: it owns no async state, just edits the `rows`
+ * array via `onChange`. Per-row validation messages come from the shared pure
+ * helper so the inline hints match the submit-time gate.
+ */
+export function EntityLinksEditor({ rows, onChange, disabled }: EntityLinksEditorProps) {
+  function update(index: number, patch: Partial<Omit<LinkRow, 'key'>>) {
+    onChange(rows.map((row, i) => (i === index ? { ...row, ...patch } : row)))
+  }
+
+  function remove(index: number) {
+    onChange(rows.filter((_, i) => i !== index))
+  }
+
+  function add() {
+    onChange([...rows, newLinkRow()])
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label>Links</Label>
+        <Button type="button" variant="outline" size="sm" onClick={add} disabled={disabled}>
+          <Plus className="h-4 w-4" />
+          Add link
+        </Button>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+          No links yet. Add docs, dashboards or runbooks so others can find them.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((row, index) => {
+            const error = validateLinkRow(row)
+            return (
+              <div key={row.key} className="space-y-1.5">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                  <Input
+                    aria-label="Link label"
+                    placeholder="Label (e.g. API docs)"
+                    value={row.label}
+                    onChange={(e) => update(index, { label: e.target.value })}
+                    disabled={disabled}
+                    className="sm:w-[28%]"
+                  />
+                  <Input
+                    aria-label="Link URL"
+                    placeholder="https://…"
+                    value={row.url}
+                    onChange={(e) => update(index, { url: e.target.value })}
+                    disabled={disabled}
+                    className="flex-1"
+                  />
+                  <Select
+                    value={row.type}
+                    onValueChange={(v) => update(index, { type: v as LinkRow['type'] })}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger aria-label="Link type" className="sm:w-[9rem]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LINK_TYPE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Remove link"
+                    onClick={() => remove(index)}
+                    disabled={disabled}
+                    className="shrink-0 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                {error && <p className="text-xs text-destructive">{error}</p>}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/orbit-www/src/components/features/catalog/entity-form/EntityPicker.tsx
+++ b/orbit-www/src/components/features/catalog/entity-form/EntityPicker.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, ChevronsUpDown, Loader2, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { entityKindMeta } from '../entity-kind-meta'
+import type { PickerEntity } from './entity-form-ui'
+
+interface EntityPickerProps {
+  /** Currently-selected entity (for the trigger label + tick), or null. */
+  value: PickerEntity | null
+  onSelect: (entity: PickerEntity | null) => void
+  /** Org-wide async search — supplied by the caller so this stays decoupled. */
+  search: (query: string) => Promise<PickerEntity[]>
+  placeholder?: string
+  /** Empty-state copy when a non-empty query returns nothing. */
+  emptyText?: string
+  /** When true the selection can be cleared back to null (owner is optional). */
+  allowClear?: boolean
+  disabled?: boolean
+  id?: string
+}
+
+/**
+ * Search-as-you-type entity combobox used by the owner picker and the relation
+ * editor. Presentational + self-contained: it owns query/debounce/loading state
+ * but delegates the actual lookup to the `search` prop, so it never imports a
+ * server action directly (the form/detail wires `searchEntitiesForPicker`).
+ */
+export function EntityPicker({
+  value,
+  onSelect,
+  search,
+  placeholder = 'Search entities…',
+  emptyText = 'No entities found.',
+  allowClear = false,
+  disabled,
+  id,
+}: EntityPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<PickerEntity[]>([])
+  const [loading, setLoading] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runSearch = useCallback(
+    (q: string) => {
+      setQuery(q)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      const trimmed = q.trim()
+      if (trimmed.length < 2) {
+        setResults([])
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const found = await search(trimmed)
+          setResults(found)
+        } catch {
+          setResults([])
+        } finally {
+          setLoading(false)
+        }
+      }, 250)
+    },
+    [search],
+  )
+
+  // Reset the transient search state whenever the popover closes.
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+      setResults([])
+      setLoading(false)
+    }
+  }, [open])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          {value ? (
+            <span className="truncate">{value.name}</span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <span className="ml-2 flex items-center gap-1">
+            {allowClear && value && (
+              <X
+                className="h-3.5 w-3.5 shrink-0 opacity-60 hover:opacity-100"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onSelect(null)
+                }}
+              />
+            )}
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder={placeholder} value={query} onValueChange={runSearch} />
+          <CommandList>
+            {loading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>
+                  {query.trim().length < 2 ? 'Type at least 2 characters…' : emptyText}
+                </CommandEmpty>
+                <CommandGroup>
+                  {results.map((entity) => {
+                    const meta = entityKindMeta(entity.kind)
+                    const Icon = meta.icon
+                    return (
+                      <CommandItem
+                        key={entity.id}
+                        value={entity.id}
+                        onSelect={() => {
+                          onSelect(entity)
+                          setOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4 shrink-0',
+                            value?.id === entity.id ? 'opacity-100' : 'opacity-0',
+                          )}
+                        />
+                        <Icon className={cn('mr-2 h-4 w-4 shrink-0', meta.accent)} />
+                        <span className="flex min-w-0 flex-col">
+                          <span className="truncate font-medium">{entity.name}</span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            {meta.label}
+                            {entity.workspaceName ? ` · ${entity.workspaceName}` : ''}
+                          </span>
+                        </span>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.test.ts
+++ b/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest'
+import {
+  LIFECYCLE_OPTIONS,
+  TIER_OPTIONS,
+  LINK_TYPE_OPTIONS,
+  GLOBAL_WORKSPACE_VALUE,
+  newLinkRow,
+  linksToRows,
+  isRowBlank,
+  validateLinkRow,
+  collectLinkErrors,
+  rowsToLinks,
+  isSourceLocked,
+  sourceProvenanceLabel,
+  buildWorkspaceOptions,
+  workspaceSelectionToId,
+  idToWorkspaceSelection,
+} from './entity-form-ui'
+
+describe('option lists', () => {
+  it('exposes the three lifecycle values with human labels', () => {
+    expect(LIFECYCLE_OPTIONS.map((o) => o.value)).toEqual([
+      'experimental',
+      'production',
+      'deprecated',
+    ])
+    expect(LIFECYCLE_OPTIONS.every((o) => o.label.length > 0)).toBe(true)
+  })
+
+  it('exposes the three tiers', () => {
+    expect(TIER_OPTIONS.map((o) => o.value)).toEqual(['tier-1', 'tier-2', 'tier-3'])
+  })
+
+  it('exposes the five link types', () => {
+    expect(LINK_TYPE_OPTIONS.map((o) => o.value)).toEqual([
+      'docs',
+      'dashboard',
+      'runbook',
+      'repository',
+      'other',
+    ])
+  })
+})
+
+describe('newLinkRow', () => {
+  it('creates a blank row with a unique stable key and default type', () => {
+    const a = newLinkRow()
+    const b = newLinkRow()
+    expect(a.key).not.toEqual(b.key)
+    expect(a.label).toBe('')
+    expect(a.url).toBe('')
+    expect(a.type).toBe('docs')
+  })
+
+  it('accepts partial overrides', () => {
+    const row = newLinkRow({ label: 'Runbook', url: 'https://x.dev', type: 'runbook' })
+    expect(row.label).toBe('Runbook')
+    expect(row.type).toBe('runbook')
+  })
+})
+
+describe('linksToRows', () => {
+  it('maps persisted entity links to editable rows (defaulting type)', () => {
+    const rows = linksToRows([
+      { label: 'Docs', url: 'https://docs.dev', type: 'docs', id: 'x' },
+      { label: 'Dash', url: 'https://d.dev', type: null, id: 'y' },
+    ])
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({ label: 'Docs', url: 'https://docs.dev', type: 'docs' })
+    expect(rows[1].type).toBe('other')
+    expect(rows[0].key).not.toEqual(rows[1].key)
+  })
+
+  it('returns an empty array for null/undefined', () => {
+    expect(linksToRows(null)).toEqual([])
+    expect(linksToRows(undefined)).toEqual([])
+  })
+})
+
+describe('isRowBlank', () => {
+  it('is true only when both label and url are empty/whitespace', () => {
+    expect(isRowBlank(newLinkRow())).toBe(true)
+    expect(isRowBlank(newLinkRow({ label: '  ' }))).toBe(true)
+    expect(isRowBlank(newLinkRow({ label: 'x' }))).toBe(false)
+    expect(isRowBlank(newLinkRow({ url: 'https://x.dev' }))).toBe(false)
+  })
+})
+
+describe('validateLinkRow', () => {
+  it('treats a fully blank row as valid (it will be dropped)', () => {
+    expect(validateLinkRow(newLinkRow())).toBeNull()
+  })
+
+  it('requires a label when a url is present', () => {
+    expect(validateLinkRow(newLinkRow({ url: 'https://x.dev' }))).toMatch(/label/i)
+  })
+
+  it('requires a url when a label is present', () => {
+    expect(validateLinkRow(newLinkRow({ label: 'Docs' }))).toMatch(/URL/i)
+  })
+
+  it('rejects a non-http(s) url', () => {
+    expect(validateLinkRow(newLinkRow({ label: 'Docs', url: 'ftp://x.dev' }))).toMatch(/http/i)
+    expect(validateLinkRow(newLinkRow({ label: 'Docs', url: 'javascript:alert(1)' }))).toMatch(
+      /http/i,
+    )
+  })
+
+  it('accepts a well-formed http(s) link', () => {
+    expect(validateLinkRow(newLinkRow({ label: 'Docs', url: 'https://x.dev' }))).toBeNull()
+    expect(validateLinkRow(newLinkRow({ label: 'Docs', url: 'http://x.dev' }))).toBeNull()
+  })
+})
+
+describe('collectLinkErrors', () => {
+  it('returns the first blocking error across rows', () => {
+    const rows = [
+      newLinkRow({ label: 'Good', url: 'https://good.dev' }),
+      newLinkRow({ label: 'Bad' }),
+    ]
+    expect(collectLinkErrors(rows)).toMatch(/URL/i)
+  })
+
+  it('returns null when every row is valid or blank', () => {
+    const rows = [newLinkRow({ label: 'Good', url: 'https://good.dev' }), newLinkRow()]
+    expect(collectLinkErrors(rows)).toBeNull()
+  })
+})
+
+describe('rowsToLinks', () => {
+  it('drops blank rows, trims, and normalizes to the entity link shape', () => {
+    const rows = [
+      newLinkRow({ label: '  Docs  ', url: '  https://docs.dev  ', type: 'docs' }),
+      newLinkRow(),
+    ]
+    expect(rowsToLinks(rows)).toEqual([{ label: 'Docs', url: 'https://docs.dev', type: 'docs' }])
+  })
+})
+
+describe('isSourceLocked', () => {
+  it('is false for manual / null / undefined (fully editable)', () => {
+    expect(isSourceLocked('manual')).toBe(false)
+    expect(isSourceLocked(null)).toBe(false)
+    expect(isSourceLocked(undefined)).toBe(false)
+  })
+
+  it('is true for any projected source', () => {
+    expect(isSourceLocked('apps')).toBe(true)
+    expect(isSourceLocked('api-schemas')).toBe(true)
+    expect(isSourceLocked('kafka')).toBe(true)
+    expect(isSourceLocked('sync')).toBe(true)
+  })
+})
+
+describe('sourceProvenanceLabel', () => {
+  it('is null for manual sources', () => {
+    expect(sourceProvenanceLabel('manual')).toBeNull()
+    expect(sourceProvenanceLabel(null)).toBeNull()
+  })
+
+  it('produces a human "Synced from …" note for projected sources', () => {
+    expect(sourceProvenanceLabel('apps')).toBe('Synced from Apps')
+    expect(sourceProvenanceLabel('api-schemas')).toBe('Synced from API schemas')
+    expect(sourceProvenanceLabel('kafka')).toBe('Synced from Kafka')
+  })
+})
+
+describe('buildWorkspaceOptions', () => {
+  const ws = [
+    { id: 'w1', name: 'Payments' },
+    { id: 'w2', name: 'Platform' },
+  ]
+
+  it('lists workspaces alone when the caller cannot create global entities', () => {
+    expect(buildWorkspaceOptions(ws, false)).toEqual([
+      { value: 'w1', label: 'Payments' },
+      { value: 'w2', label: 'Platform' },
+    ])
+  })
+
+  it('prepends a Global option for platform admins', () => {
+    const opts = buildWorkspaceOptions(ws, true)
+    expect(opts[0].value).toBe(GLOBAL_WORKSPACE_VALUE)
+    expect(opts[0].label).toMatch(/global/i)
+    expect(opts.slice(1).map((o) => o.value)).toEqual(['w1', 'w2'])
+  })
+})
+
+describe('workspace selection <-> id round-trip', () => {
+  it('maps the Global sentinel to null and back', () => {
+    expect(workspaceSelectionToId(GLOBAL_WORKSPACE_VALUE)).toBeNull()
+    expect(idToWorkspaceSelection(null)).toBe(GLOBAL_WORKSPACE_VALUE)
+  })
+
+  it('passes a real workspace id through unchanged', () => {
+    expect(workspaceSelectionToId('w1')).toBe('w1')
+    expect(idToWorkspaceSelection('w1')).toBe('w1')
+  })
+})

--- a/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.ts
+++ b/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.ts
@@ -1,0 +1,202 @@
+import type { CatalogEntity } from '@/payload-types'
+import type { EntityKind } from '@/collections/catalog/constants'
+
+/**
+ * Pure, React-free helpers for the catalog EntityForm (WP2). Kept out of the
+ * client component so the link-row validation, source-lock predicate and
+ * workspace-option shaping can be unit-tested directly (mirrors the
+ * `catalog-query.ts` / `initiative-ui.ts` convention).
+ *
+ * The server contract (createCatalogEntity/updateCatalogEntity and the
+ * CreateEntityInput/UpdateEntityPatch/EntityFormOptions types) lives in the
+ * WP1 libs; nothing here imports it, so these helpers stay dependency-light and
+ * safe on both server and client.
+ */
+
+export type Lifecycle = NonNullable<CatalogEntity['lifecycle']>
+export type Tier = NonNullable<CatalogEntity['tier']>
+type PersistedLink = NonNullable<CatalogEntity['links']>[number]
+export type EntityLinkType = NonNullable<PersistedLink['type']>
+
+export const LIFECYCLE_OPTIONS: { value: Lifecycle; label: string }[] = [
+  { value: 'experimental', label: 'Experimental' },
+  { value: 'production', label: 'Production' },
+  { value: 'deprecated', label: 'Deprecated' },
+]
+
+export const TIER_OPTIONS: { value: Tier; label: string }[] = [
+  { value: 'tier-1', label: 'Tier 1 — critical' },
+  { value: 'tier-2', label: 'Tier 2 — important' },
+  { value: 'tier-3', label: 'Tier 3 — supporting' },
+]
+
+export const LINK_TYPE_OPTIONS: { value: EntityLinkType; label: string }[] = [
+  { value: 'docs', label: 'Docs' },
+  { value: 'dashboard', label: 'Dashboard' },
+  { value: 'runbook', label: 'Runbook' },
+  { value: 'repository', label: 'Repository' },
+  { value: 'other', label: 'Other' },
+]
+
+/**
+ * Sentinel `<Select>` value for the "Global (no workspace)" option. A select
+ * value must be a non-empty string, so a null workspace (global entity) is
+ * represented by this constant in the UI and mapped back to `null` on submit.
+ */
+export const GLOBAL_WORKSPACE_VALUE = '__global__'
+
+// ---------------------------------------------------------------------------
+// Links editor
+// ---------------------------------------------------------------------------
+
+/** One editable link row. `key` is a stable React key, never persisted. */
+export interface LinkRow {
+  key: string
+  label: string
+  url: string
+  type: EntityLinkType
+}
+
+let linkKeySeq = 0
+
+/** A fresh link row (optionally pre-filled) with a process-unique React key. */
+export function newLinkRow(partial?: Partial<Omit<LinkRow, 'key'>>): LinkRow {
+  linkKeySeq += 1
+  return {
+    key: `link-${linkKeySeq}`,
+    label: partial?.label ?? '',
+    url: partial?.url ?? '',
+    type: partial?.type ?? 'docs',
+  }
+}
+
+/** Prefill editable rows from an entity's persisted links (edit mode). */
+export function linksToRows(links: CatalogEntity['links'] | null | undefined): LinkRow[] {
+  if (!links) return []
+  return links.map((l) =>
+    newLinkRow({ label: l.label ?? '', url: l.url ?? '', type: l.type ?? 'other' }),
+  )
+}
+
+/** True when neither field is filled — such rows are ignored, not errors. */
+export function isRowBlank(row: LinkRow): boolean {
+  return row.label.trim() === '' && row.url.trim() === ''
+}
+
+function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim())
+}
+
+/**
+ * Validate a single link row, returning a human message or null. A fully blank
+ * row is valid (it gets dropped on submit); a partially filled row is not.
+ */
+export function validateLinkRow(row: LinkRow): string | null {
+  if (isRowBlank(row)) return null
+  if (row.label.trim() === '') return 'Every link needs a label.'
+  if (row.url.trim() === '') return `Add a URL for “${row.label.trim()}”.`
+  if (!isHttpUrl(row.url)) return 'Link URLs must start with http:// or https://.'
+  return null
+}
+
+/** First blocking link error across all rows, or null when all are valid. */
+export function collectLinkErrors(rows: LinkRow[]): string | null {
+  for (const row of rows) {
+    const err = validateLinkRow(row)
+    if (err) return err
+  }
+  return null
+}
+
+/** Normalize rows to the persisted link shape for submit (drops blanks, trims). */
+export function rowsToLinks(rows: LinkRow[]): { label: string; url: string; type: EntityLinkType }[] {
+  return rows
+    .filter((r) => !isRowBlank(r))
+    .map((r) => ({ label: r.label.trim(), url: r.url.trim(), type: r.type }))
+}
+
+// ---------------------------------------------------------------------------
+// Source-lock (projection field-ownership policy)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the entity's identity fields (name, kind, workspace) are owned by a
+ * projection and must render read-only. Manual/absent source ⇒ fully editable.
+ */
+export function isSourceLocked(sourceType: string | null | undefined): boolean {
+  return !!sourceType && sourceType !== 'manual'
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  apps: 'Apps',
+  'api-schemas': 'API schemas',
+  kafka: 'Kafka',
+  sync: 'Sync',
+}
+
+/** Provenance note for a projected entity ("Synced from Apps"), or null. */
+export function sourceProvenanceLabel(sourceType: string | null | undefined): string | null {
+  if (!isSourceLocked(sourceType)) return null
+  const label = SOURCE_LABELS[sourceType as string] ?? (sourceType as string)
+  return `Synced from ${label}`
+}
+
+// ---------------------------------------------------------------------------
+// Workspace select shaping
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceChoice {
+  id: string
+  name: string
+}
+
+/**
+ * Build the workspace `<Select>` options: the manageable workspaces, prefixed
+ * with a "Global (no workspace)" option when the caller is a platform admin.
+ */
+export function buildWorkspaceOptions(
+  workspaces: WorkspaceChoice[],
+  canCreateGlobal: boolean,
+): { value: string; label: string }[] {
+  const options = workspaces.map((w) => ({ value: w.id, label: w.name }))
+  if (canCreateGlobal) {
+    return [{ value: GLOBAL_WORKSPACE_VALUE, label: 'Global (no workspace)' }, ...options]
+  }
+  return options
+}
+
+/** Map a workspace select value to the id the server expects (Global ⇒ null). */
+export function workspaceSelectionToId(value: string): string | null {
+  return value === GLOBAL_WORKSPACE_VALUE ? null : value
+}
+
+/** Map a persisted workspace id (null = global) to its select value. */
+export function idToWorkspaceSelection(workspaceId: string | null): string {
+  return workspaceId === null ? GLOBAL_WORKSPACE_VALUE : workspaceId
+}
+
+// ---------------------------------------------------------------------------
+// Form-facing contracts (structural — kept decoupled from the WP1 libs)
+// ---------------------------------------------------------------------------
+
+/**
+ * One org-wide entity result for the owner / relation pickers. Structurally
+ * matches `searchEntitiesForPicker`'s return so the real action can be wired in
+ * without an adapter.
+ */
+export interface PickerEntity {
+  id: string
+  name: string
+  kind: EntityKind
+  workspaceName?: string | null
+}
+
+/**
+ * The subset of `getEntityFormOptions()` the EntityForm reads. Declared
+ * structurally so the server action's richer return type is assignable without
+ * importing the WP1 lib (create-anywhere workspaces + platform-admin global).
+ */
+export interface EntityFormOptions {
+  workspaces: WorkspaceChoice[]
+  canCreateGlobal: boolean
+}

--- a/orbit-www/src/components/features/catalog/entity-form/index.ts
+++ b/orbit-www/src/components/features/catalog/entity-form/index.ts
@@ -1,0 +1,4 @@
+export { EntityForm, type EntityFormProps } from './EntityForm'
+export { EntityPicker } from './EntityPicker'
+export { EntityLinksEditor } from './EntityLinksEditor'
+export * from './entity-form-ui'

--- a/orbit-www/src/components/features/workspace/entities/WorkspaceEntitiesCard.test.tsx
+++ b/orbit-www/src/components/features/workspace/entities/WorkspaceEntitiesCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WorkspaceEntitiesCard } from './WorkspaceEntitiesCard'
+import type { WorkspaceEntitySummary } from './workspace-entities-ui'
+
+afterEach(() => {
+  cleanup()
+})
+
+const entities: WorkspaceEntitySummary[] = [
+  { id: '1', name: 'Checkout Service', kind: 'service' },
+  { id: '2', name: 'Payments API', kind: 'api' },
+]
+
+describe('WorkspaceEntitiesCard', () => {
+  it('shows the empty state with no authoring affordance for a non-member', () => {
+    render(<WorkspaceEntitiesCard entities={[]} workspaceId="ws1" isMember={false} />)
+    expect(screen.getByText('No entities yet')).toBeInTheDocument()
+    expect(screen.queryByText('New entity')).not.toBeInTheDocument()
+    expect(screen.queryByText('Create your first entity')).not.toBeInTheDocument()
+  })
+
+  it('shows an authoring CTA in the empty state for a member', () => {
+    render(<WorkspaceEntitiesCard entities={[]} workspaceId="ws1" isMember />)
+    expect(screen.getByText('No entities yet')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Create your first entity' })).toHaveAttribute(
+      'href',
+      '/catalog/new?workspace=ws1',
+    )
+  })
+
+  it('groups entities by kind with counts and links to the entity detail page', () => {
+    render(<WorkspaceEntitiesCard entities={entities} workspaceId="ws1" isMember={false} />)
+    expect(screen.getByText('Services')).toBeInTheDocument()
+    expect(screen.getByText('APIs')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Checkout Service' })).toHaveAttribute('href', '/catalog/1')
+    expect(screen.getByRole('link', { name: 'Payments API' })).toHaveAttribute('href', '/catalog/2')
+  })
+
+  it('does not show "New entity" or the "Create team" callout for a non-member', () => {
+    render(<WorkspaceEntitiesCard entities={entities} workspaceId="ws1" isMember={false} />)
+    expect(screen.queryByText('New entity')).not.toBeInTheDocument()
+    expect(screen.queryByText('Create your team entity')).not.toBeInTheDocument()
+  })
+
+  it('shows "New entity" and the "Create team" callout for a member with no team entity', () => {
+    render(<WorkspaceEntitiesCard entities={entities} workspaceId="ws1" isMember />)
+    expect(screen.getByRole('link', { name: /New entity/ })).toHaveAttribute(
+      'href',
+      '/catalog/new?workspace=ws1',
+    )
+    expect(screen.getByText('Create your team entity')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Create team' })).toHaveAttribute(
+      'href',
+      '/catalog/new?workspace=ws1&kind=team',
+    )
+  })
+
+  it('hides the "Create team" callout once the workspace has a team entity', () => {
+    const withTeam: WorkspaceEntitySummary[] = [...entities, { id: '3', name: 'Platform Team', kind: 'team' }]
+    render(<WorkspaceEntitiesCard entities={withTeam} workspaceId="ws1" isMember />)
+    expect(screen.queryByText('Create your team entity')).not.toBeInTheDocument()
+  })
+
+  it('always renders a "View all in catalog" link, filtered to the workspace', () => {
+    render(<WorkspaceEntitiesCard entities={entities} workspaceId="ws1" isMember={false} />)
+    expect(screen.getByRole('link', { name: /View all in catalog/ })).toHaveAttribute(
+      'href',
+      '/catalog?workspace=ws1',
+    )
+  })
+
+  it('renders the total-entity count badge', () => {
+    render(<WorkspaceEntitiesCard entities={entities} workspaceId="ws1" isMember={false} />)
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+})

--- a/orbit-www/src/components/features/workspace/entities/WorkspaceEntitiesCard.tsx
+++ b/orbit-www/src/components/features/workspace/entities/WorkspaceEntitiesCard.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link'
+import { Boxes, Plus, Sparkles } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  catalogEntityHref,
+  catalogNewEntityHref,
+  catalogNewTeamHref,
+  catalogViewAllHref,
+  groupEntitiesByKind,
+  hasTeamEntity,
+  totalEntityCount,
+  type WorkspaceEntitySummary,
+} from './workspace-entities-ui'
+
+interface WorkspaceEntitiesCardProps {
+  /** The workspace's catalog entities, as plain `{ id, name, kind }` rows. */
+  entities: WorkspaceEntitySummary[]
+  workspaceId: string
+  /**
+   * Active membership in this workspace (any role) — gates the authoring
+   * affordances ("New entity" / "Create team"). Non-members see a read-only
+   * list. Mirrors the PM decision: create/edit = active workspace members,
+   * any role (docs/plans/2026-07-02-catalog-entity-crud.md).
+   */
+  isMember: boolean
+}
+
+/**
+ * Workspace landpage "Entities" card (Catalog Entity CRUD WP3). Lists the
+ * workspace's catalog entities grouped by kind, links out to the org-wide
+ * catalog, and — for active members — surfaces "New entity" plus a
+ * first-class "Create team" callout when the workspace has no team entity
+ * yet (the dangling `owner` relationship gap called out in the plan).
+ *
+ * "New entity" / "Create team" currently link to `/catalog/new` (query-param
+ * prefill) rather than embedding the shared `EntityForm` in a dialog: that
+ * component is owned by a parallel work package and hadn't landed on this
+ * branch as of this card's implementation. Swap in an inline dialog once it
+ * ships — see docs/plans/2026-07-02-catalog-entity-crud.md WP2/WP3.
+ */
+export function WorkspaceEntitiesCard({ entities, workspaceId, isMember }: WorkspaceEntitiesCardProps) {
+  const groups = groupEntitiesByKind(entities)
+  const total = totalEntityCount(groups)
+  const showCreateTeamCallout = isMember && !hasTeamEntity(entities)
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Boxes className="h-5 w-5" />
+            <CardTitle className="text-base">Entities</CardTitle>
+            {total > 0 && (
+              <Badge variant="secondary" className="font-normal">
+                {total}
+              </Badge>
+            )}
+          </div>
+          {isMember && (
+            <Button size="sm" className="bg-orange-500 hover:bg-orange-600" asChild>
+              <Link href={catalogNewEntityHref(workspaceId)}>
+                <Plus className="h-4 w-4 mr-1" />
+                New entity
+              </Link>
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {showCreateTeamCallout && (
+          <div className="mb-4 flex items-start gap-3 rounded-lg border border-dashed p-3">
+            <Sparkles className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium">Create your team entity</p>
+              <p className="text-xs text-muted-foreground">
+                Own services, APIs, and other entities under one team.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={catalogNewTeamHref(workspaceId)}>Create team</Link>
+            </Button>
+          </div>
+        )}
+
+        {total === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-muted-foreground mb-4">No entities yet</p>
+            {isMember && (
+              <Button variant="outline" size="sm" asChild>
+                <Link href={catalogNewEntityHref(workspaceId)}>Create your first entity</Link>
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {groups.map((group) => (
+              <div key={group.kind}>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase">{group.label}</p>
+                  <Badge variant="outline" className="text-xs font-normal">
+                    {group.count}
+                  </Badge>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  {group.topEntities.map((e) => (
+                    <Link
+                      key={e.id}
+                      href={catalogEntityHref(e.id)}
+                      className="truncate rounded px-2 py-1 text-sm hover:bg-muted/50"
+                    >
+                      {e.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="pt-4 mt-2 border-t text-center">
+          <Button variant="link" size="sm" asChild>
+            <Link href={catalogViewAllHref(workspaceId)}>View all in catalog →</Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/orbit-www/src/components/features/workspace/entities/workspace-entities-ui.test.ts
+++ b/orbit-www/src/components/features/workspace/entities/workspace-entities-ui.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  catalogEntityHref,
+  catalogNewEntityHref,
+  catalogNewTeamHref,
+  catalogViewAllHref,
+  groupEntitiesByKind,
+  hasTeamEntity,
+  totalEntityCount,
+  type WorkspaceEntitySummary,
+} from './workspace-entities-ui'
+
+const entity = (id: string, name: string, kind: WorkspaceEntitySummary['kind']): WorkspaceEntitySummary => ({
+  id,
+  name,
+  kind,
+})
+
+describe('groupEntitiesByKind', () => {
+  it('groups by kind, sorts entities alphabetically within a group, and caps the preview', () => {
+    const entities = [
+      entity('1', 'Zeta Service', 'service'),
+      entity('2', 'Alpha Service', 'service'),
+      entity('3', 'Mid Service', 'service'),
+      entity('4', 'Payments API', 'api'),
+    ]
+
+    const groups = groupEntitiesByKind(entities, 2)
+
+    const services = groups.find((g) => g.kind === 'service')
+    expect(services?.count).toBe(3)
+    expect(services?.topEntities.map((e) => e.name)).toEqual(['Alpha Service', 'Mid Service'])
+
+    const apis = groups.find((g) => g.kind === 'api')
+    expect(apis?.count).toBe(1)
+    expect(apis?.label).toBe('APIs')
+  })
+
+  it('orders groups by count descending, then label ascending', () => {
+    const entities = [
+      entity('1', 'A', 'domain'),
+      entity('2', 'B', 'service'),
+      entity('3', 'C', 'service'),
+      entity('4', 'D', 'api'),
+      entity('5', 'E', 'api'),
+    ]
+
+    const groups = groupEntitiesByKind(entities)
+    // service and api both have count 2, domain has count 1 -> service/api tie broken alphabetically by label
+    expect(groups.map((g) => g.kind)).toEqual(['api', 'service', 'domain'])
+  })
+
+  it('returns an empty array for no entities', () => {
+    expect(groupEntitiesByKind([])).toEqual([])
+  })
+
+  it('defaults the preview cap to 5', () => {
+    const entities = Array.from({ length: 8 }, (_, i) => entity(String(i), `Service ${i}`, 'service'))
+    const [group] = groupEntitiesByKind(entities)
+    expect(group.count).toBe(8)
+    expect(group.topEntities).toHaveLength(5)
+  })
+})
+
+describe('totalEntityCount', () => {
+  it('sums counts across groups', () => {
+    const groups = groupEntitiesByKind([
+      entity('1', 'A', 'service'),
+      entity('2', 'B', 'service'),
+      entity('3', 'C', 'api'),
+    ])
+    expect(totalEntityCount(groups)).toBe(3)
+  })
+
+  it('is zero for no groups', () => {
+    expect(totalEntityCount([])).toBe(0)
+  })
+})
+
+describe('hasTeamEntity', () => {
+  it('is true when a team-kind entity is present', () => {
+    expect(hasTeamEntity([entity('1', 'Platform Team', 'team')])).toBe(true)
+  })
+
+  it('is false when no team-kind entity is present', () => {
+    expect(hasTeamEntity([entity('1', 'A', 'service'), entity('2', 'B', 'api')])).toBe(false)
+  })
+
+  it('is false for an empty list', () => {
+    expect(hasTeamEntity([])).toBe(false)
+  })
+})
+
+describe('link helpers', () => {
+  it('builds the entity detail link', () => {
+    expect(catalogEntityHref('abc123')).toBe('/catalog/abc123')
+  })
+
+  it('builds the new-entity link with the workspace preselected', () => {
+    expect(catalogNewEntityHref('ws1')).toBe('/catalog/new?workspace=ws1')
+  })
+
+  it('URL-encodes the workspace id in link helpers', () => {
+    expect(catalogNewEntityHref('ws 1')).toBe('/catalog/new?workspace=ws%201')
+  })
+
+  it('builds the create-team link preset to kind=team', () => {
+    expect(catalogNewTeamHref('ws1')).toBe('/catalog/new?workspace=ws1&kind=team')
+  })
+
+  it('builds the view-all-in-catalog link, filtered to the workspace', () => {
+    expect(catalogViewAllHref('ws1')).toBe('/catalog?workspace=ws1')
+  })
+
+  it('URL-encodes the workspace id in the view-all-in-catalog link', () => {
+    expect(catalogViewAllHref('ws 1')).toBe('/catalog?workspace=ws%201')
+  })
+})

--- a/orbit-www/src/components/features/workspace/entities/workspace-entities-ui.ts
+++ b/orbit-www/src/components/features/workspace/entities/workspace-entities-ui.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure presentation helpers for the workspace landpage Entities card
+ * (Catalog Entity CRUD, WP3 — docs/plans/2026-07-02-catalog-entity-crud.md).
+ *
+ * Framework-light on purpose (mirrors scorecards/initiatives' `*-ui.ts`
+ * convention): no 'use server', no React, no Payload imports, so the
+ * component can stay a server component and this module can be unit-tested
+ * directly. Kind labels are kept LOCAL to this file rather than imported from
+ * `components/features/catalog/**` — that package is owned by a different
+ * work package landing in parallel on the same branch; duplicating a small
+ * label map avoids a cross-agent coupling point (same rationale as
+ * `catalog/entity-kind-meta.ts`'s "self-contained" comment).
+ */
+
+import type { CatalogEntity } from '@/payload-types'
+
+export type EntityKind = CatalogEntity['kind']
+
+/** Human-friendly, pluralised labels — mirrors catalog-query.ts KIND_LABELS values. */
+export const KIND_LABELS: Record<EntityKind, string> = {
+  service: 'Services',
+  api: 'APIs',
+  resource: 'Resources',
+  datastore: 'Datastores',
+  'kafka-topic': 'Kafka Topics',
+  domain: 'Domains',
+  system: 'Systems',
+  team: 'Teams',
+  environment: 'Environments',
+}
+
+/** Minimal shape the card needs per entity — deliberately plain, not the full CatalogEntity. */
+export interface WorkspaceEntitySummary {
+  id: string
+  name: string
+  kind: EntityKind
+}
+
+export interface EntityKindGroup {
+  kind: EntityKind
+  label: string
+  count: number
+  /** Up to `maxPerKind` entities, alphabetical by name. */
+  topEntities: WorkspaceEntitySummary[]
+}
+
+const DEFAULT_MAX_PER_KIND = 5
+
+/**
+ * Group a workspace's entities by kind, each group carrying its full count
+ * plus a capped, alphabetised preview list. Groups are ordered by count
+ * (largest first), ties broken alphabetically by label, so the card leads
+ * with the workspace's most substantial kind.
+ */
+export function groupEntitiesByKind(
+  entities: WorkspaceEntitySummary[],
+  maxPerKind: number = DEFAULT_MAX_PER_KIND,
+): EntityKindGroup[] {
+  const byKind = new Map<EntityKind, WorkspaceEntitySummary[]>()
+  for (const entity of entities) {
+    const list = byKind.get(entity.kind)
+    if (list) {
+      list.push(entity)
+    } else {
+      byKind.set(entity.kind, [entity])
+    }
+  }
+
+  const groups: EntityKindGroup[] = []
+  for (const [kind, list] of byKind) {
+    const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name))
+    groups.push({
+      kind,
+      label: KIND_LABELS[kind] ?? kind,
+      count: list.length,
+      topEntities: sorted.slice(0, maxPerKind),
+    })
+  }
+
+  return groups.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+}
+
+/** Sum of all group counts — the card's total-entities badge. */
+export function totalEntityCount(groups: EntityKindGroup[]): number {
+  return groups.reduce((sum, group) => sum + group.count, 0)
+}
+
+/** True when the workspace already has a `team`-kind entity (the "Create team" callout gate). */
+export function hasTeamEntity(entities: Pick<WorkspaceEntitySummary, 'kind'>[]): boolean {
+  return entities.some((entity) => entity.kind === 'team')
+}
+
+/** Detail-page link for one entity. */
+export function catalogEntityHref(id: string): string {
+  return `/catalog/${id}`
+}
+
+/**
+ * "New entity" link, preselecting this workspace. Points at `/catalog/new`
+ * (owned by the WP2 catalog-UI work package landing in parallel) with a
+ * `workspace` query param for prefill; falls back gracefully to the bare
+ * create page if that param isn't wired up yet.
+ */
+export function catalogNewEntityHref(workspaceId: string): string {
+  return `/catalog/new?workspace=${encodeURIComponent(workspaceId)}`
+}
+
+/** "Create team" link — same create page, preset to kind=team. */
+export function catalogNewTeamHref(workspaceId: string): string {
+  return `/catalog/new?workspace=${encodeURIComponent(workspaceId)}&kind=team`
+}
+
+/**
+ * "View all in catalog" link, pre-filtered to this workspace via the catalog
+ * list's `?workspace=<id>` param (core-dev + catalog-ui-dev added org-wide
+ * read + a real workspace filter — see
+ * docs/plans/2026-07-02-catalog-entity-crud.md's read-path-changes note).
+ */
+export function catalogViewAllHref(workspaceId: string): string {
+  return `/catalog?workspace=${encodeURIComponent(workspaceId)}`
+}

--- a/orbit-www/src/lib/catalog/entity-authz.test.ts
+++ b/orbit-www/src/lib/catalog/entity-authz.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Payload } from 'payload'
+import {
+  canCreateEntity,
+  canManageEntity,
+  canDeleteEntity,
+  getManageableWorkspaceIds,
+  isTeamEntity,
+} from './entity-authz'
+
+/**
+ * Hand-rolled payload mock. `members` is the list of workspace-member docs the
+ * `workspace-members` collection returns; the mock filters it against the
+ * `where.and` clauses the authz helpers build (workspace + user + role + status)
+ * so a single fixture drives member/admin/non-member cases.
+ */
+function makePayload(members: { workspace: string; user: string; role: string; status: string }[]) {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const find = vi.fn(async (args: any) => {
+    if (args.collection !== 'workspace-members') return { docs: [] }
+    const and: any[] = args.where?.and ?? []
+    const filtered = members.filter((m) =>
+      and.every((cond) => {
+        if (cond.workspace) return m.workspace === cond.workspace.equals
+        if (cond.user) return m.user === cond.user.equals
+        if (cond.status) return m.status === cond.status.equals
+        if (cond.role?.equals) return m.role === cond.role.equals
+        if (cond.role?.in) return cond.role.in.includes(m.role)
+        return true
+      }),
+    )
+    return { docs: filtered }
+  })
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  return { payload: { find } as unknown as Payload, find }
+}
+
+const memberDoc = (role: string) => ({ workspace: 'ws-1', user: 'ba-1', role, status: 'active' })
+
+describe('canCreateEntity', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lets a platform admin create anywhere without a membership query', async () => {
+    const { payload, find } = makePayload([])
+    expect(await canCreateEntity(payload, 'ba-1', true, 'ws-1')).toBe(true)
+    expect(await canCreateEntity(payload, 'ba-1', true, null)).toBe(true)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('lets an active member (any role) create into their workspace', async () => {
+    const { payload } = makePayload([memberDoc('member')])
+    expect(await canCreateEntity(payload, 'ba-1', false, 'ws-1')).toBe(true)
+  })
+
+  it('denies a non-member', async () => {
+    const { payload } = makePayload([memberDoc('member')])
+    expect(await canCreateEntity(payload, 'ba-1', false, 'ws-2')).toBe(false)
+  })
+
+  it('denies a non-admin for a global (null-workspace) entity', async () => {
+    const { payload, find } = makePayload([memberDoc('owner')])
+    expect(await canCreateEntity(payload, 'ba-1', false, null)).toBe(false)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('denies when betterAuthId is missing', async () => {
+    const { payload } = makePayload([memberDoc('owner')])
+    expect(await canCreateEntity(payload, null, false, 'ws-1')).toBe(false)
+  })
+})
+
+describe('canManageEntity', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('mirrors create against the entity workspace', async () => {
+    const { payload } = makePayload([memberDoc('member')])
+    expect(await canManageEntity(payload, 'ba-1', false, { workspaceId: 'ws-1' })).toBe(true)
+    expect(await canManageEntity(payload, 'ba-1', false, { workspaceId: 'ws-2' })).toBe(false)
+  })
+
+  it('admin-only for a global entity', async () => {
+    const { payload } = makePayload([memberDoc('owner')])
+    expect(await canManageEntity(payload, 'ba-1', false, { workspaceId: null })).toBe(false)
+    expect(await canManageEntity(payload, 'ba-1', true, { workspaceId: null })).toBe(true)
+  })
+})
+
+describe('canDeleteEntity', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('denies a projected entity even for a platform admin', async () => {
+    const { payload } = makePayload([])
+    expect(
+      await canDeleteEntity(payload, 'ba-1', true, { workspaceId: 'ws-1', sourceType: 'apps' }),
+    ).toBe(false)
+  })
+
+  it('allows a workspace owner/admin to delete a manual entity', async () => {
+    const { payload } = makePayload([memberDoc('admin')])
+    expect(
+      await canDeleteEntity(payload, 'ba-1', false, { workspaceId: 'ws-1', sourceType: 'manual' }),
+    ).toBe(true)
+  })
+
+  it('denies a plain member deleting a manual entity (delete needs owner/admin)', async () => {
+    const { payload } = makePayload([memberDoc('member')])
+    expect(
+      await canDeleteEntity(payload, 'ba-1', false, { workspaceId: 'ws-1', sourceType: 'manual' }),
+    ).toBe(false)
+  })
+
+  it('allows a platform admin to delete a manual global entity', async () => {
+    const { payload } = makePayload([])
+    expect(
+      await canDeleteEntity(payload, 'ba-1', true, { workspaceId: null, sourceType: 'manual' }),
+    ).toBe(true)
+  })
+
+  it('denies a non-admin deleting a manual global entity', async () => {
+    const { payload } = makePayload([memberDoc('owner')])
+    expect(
+      await canDeleteEntity(payload, 'ba-1', false, { workspaceId: null, sourceType: 'manual' }),
+    ).toBe(false)
+  })
+})
+
+describe('getManageableWorkspaceIds', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns active membership workspace ids', async () => {
+    const { payload } = makePayload([
+      { workspace: 'ws-1', user: 'ba-1', role: 'member', status: 'active' },
+      { workspace: 'ws-2', user: 'ba-1', role: 'owner', status: 'active' },
+    ])
+    expect(await getManageableWorkspaceIds(payload, 'ba-1')).toEqual(['ws-1', 'ws-2'])
+  })
+
+  it('returns [] for a missing id without querying', async () => {
+    const { payload, find } = makePayload([])
+    expect(await getManageableWorkspaceIds(payload, null)).toEqual([])
+    expect(find).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('isTeamEntity', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('is true for an existing entity of kind team', async () => {
+    const payload = {
+      findByID: vi.fn(async () => ({ id: 'e1', kind: 'team' })),
+    } as unknown as Payload
+    expect(await isTeamEntity(payload, 'e1')).toBe(true)
+  })
+
+  it('is false for an existing non-team entity', async () => {
+    const payload = {
+      findByID: vi.fn(async () => ({ id: 'e1', kind: 'service' })),
+    } as unknown as Payload
+    expect(await isTeamEntity(payload, 'e1')).toBe(false)
+  })
+
+  it('is false when the entity does not exist (findByID throws)', async () => {
+    const payload = {
+      findByID: vi.fn(async () => {
+        throw new Error('not found')
+      }),
+    } as unknown as Payload
+    expect(await isTeamEntity(payload, 'missing')).toBe(false)
+  })
+})

--- a/orbit-www/src/lib/catalog/entity-authz.ts
+++ b/orbit-www/src/lib/catalog/entity-authz.ts
@@ -1,0 +1,106 @@
+import type { Payload } from 'payload'
+import {
+  isWorkspaceMember,
+  isWorkspaceAdminOrOwner,
+  getMemberWorkspaceIds,
+} from '@/lib/access/workspace-access'
+
+/**
+ * Catalog entity authorization — the SINGLE server-side source of truth for
+ * "can this user create / manage / delete this entity" (Catalog Entity CRUD,
+ * docs/plans/2026-07-02-catalog-entity-crud.md, WP1). The collection `access`
+ * rules, the authoring server actions, and the server-computed UI `canManage`
+ * flags all route through these functions.
+ *
+ * Policy (PM decisions 1–4):
+ *  - create / manage = platform admin, OR an active workspace member (ANY role)
+ *    of the entity's workspace. A null workspace (global entity) ⇒ platform
+ *    admin only.
+ *  - delete = the entity is MANUAL (`source.type === 'manual'`) AND the caller
+ *    is a platform admin or a workspace owner/admin. Projected entities are not
+ *    deletable anywhere — deleting them means deleting their source.
+ *
+ * IMPORTANT: `workspace-members.user` holds a **Better-Auth** id, so every
+ * membership lookup here takes `betterAuthId` — NEVER a Payload `user.id`.
+ * Comparing the Payload doc id against `workspace-members.user` was the latent
+ * access bug this feature fixes.
+ */
+
+/**
+ * True if `betterAuthId` may create an entity in `workspaceId`. Platform admins
+ * may create anywhere (incl. global); a null `workspaceId` is global and so is
+ * platform-admin-only.
+ */
+export async function canCreateEntity(
+  payload: Payload,
+  betterAuthId: string | null | undefined,
+  isPlatformAdmin: boolean,
+  workspaceId: string | null,
+): Promise<boolean> {
+  if (isPlatformAdmin) return true
+  if (!workspaceId || !betterAuthId) return false
+  return isWorkspaceMember(payload, betterAuthId, workspaceId)
+}
+
+/**
+ * True if `betterAuthId` may edit `entity`. Same rule as create against the
+ * entity's own workspace (active membership, any role; global ⇒ admin only).
+ */
+export async function canManageEntity(
+  payload: Payload,
+  betterAuthId: string | null | undefined,
+  isPlatformAdmin: boolean,
+  entity: { workspaceId: string | null },
+): Promise<boolean> {
+  return canCreateEntity(payload, betterAuthId, isPlatformAdmin, entity.workspaceId)
+}
+
+/**
+ * True if `betterAuthId` may delete `entity`. Requires the entity to be manual
+ * AND the caller to be a platform admin or workspace owner/admin. Projected
+ * entities (`sourceType !== 'manual'`) are never deletable — even for admins.
+ */
+export async function canDeleteEntity(
+  payload: Payload,
+  betterAuthId: string | null | undefined,
+  isPlatformAdmin: boolean,
+  entity: { workspaceId: string | null; sourceType: string },
+): Promise<boolean> {
+  if (entity.sourceType !== 'manual') return false
+  if (isPlatformAdmin) return true
+  if (!entity.workspaceId || !betterAuthId) return false
+  return isWorkspaceAdminOrOwner(payload, betterAuthId, entity.workspaceId)
+}
+
+/**
+ * Workspace ids the user is an active member of (any role) — the set they can
+ * create/manage entities in. Reuses the shared membership helper. Returns [] for
+ * a missing id.
+ */
+export async function getManageableWorkspaceIds(
+  payload: Payload,
+  betterAuthId: string | null | undefined,
+): Promise<string[]> {
+  if (!betterAuthId) return []
+  return getMemberWorkspaceIds(payload, betterAuthId)
+}
+
+/**
+ * True if `entityId` references an existing catalog entity of kind `team`. Used
+ * to validate an `owner` pointer before persisting it — ownership is keyed to a
+ * team entity (the Cortex/Backstage pattern), so a non-team or missing id is
+ * rejected. Missing rows (findByID throws) are treated as invalid.
+ */
+export async function isTeamEntity(payload: Payload, entityId: string): Promise<boolean> {
+  try {
+    const entity = await payload.findByID({
+      collection: 'catalog-entities',
+      id: entityId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    return entity?.kind === 'team'
+  } catch {
+    return false
+  }
+}

--- a/orbit-www/src/lib/catalog/entity-crud.test.ts
+++ b/orbit-www/src/lib/catalog/entity-crud.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  slugify,
+  uniqueSlug,
+  validateLinks,
+  validateCreateInput,
+  validateUpdatePatch,
+  validateRelationInput,
+  PROJECTION_LOCKED_FIELDS,
+  CURATION_FIELDS,
+  type CreateEntityInput,
+} from './entity-crud'
+
+describe('slugify', () => {
+  it.each([
+    ['Payments Service', 'payments-service'],
+    ['  Trim  Me  ', 'trim-me'],
+    ['Special!@#Chars', 'special-chars'],
+    ['Café Über', 'cafe-uber'],
+    ['', ''],
+  ])('slugifies %j -> %j', (input, expected) => {
+    expect(slugify(input)).toBe(expected)
+  })
+
+  it('handles null/undefined', () => {
+    expect(slugify(null)).toBe('')
+    expect(slugify(undefined)).toBe('')
+  })
+})
+
+describe('uniqueSlug', () => {
+  it('returns the base when free', () => {
+    expect(uniqueSlug('payments', [])).toBe('payments')
+    expect(uniqueSlug('payments', ['other'])).toBe('payments')
+  })
+
+  it('suffixes to the first free -N (starting at 2)', () => {
+    expect(uniqueSlug('payments', ['payments'])).toBe('payments-2')
+    expect(uniqueSlug('payments', ['payments', 'payments-2'])).toBe('payments-3')
+  })
+
+  it('skips gaps to the first actually-free suffix', () => {
+    expect(uniqueSlug('payments', ['payments', 'payments-3'])).toBe('payments-2')
+  })
+
+  it('accepts a Set as well as an array', () => {
+    expect(uniqueSlug('payments', new Set(['payments']))).toBe('payments-2')
+  })
+})
+
+describe('field-ownership constants', () => {
+  it('locks identity fields and curates the rest with no overlap', () => {
+    expect(PROJECTION_LOCKED_FIELDS).toContain('name')
+    expect(PROJECTION_LOCKED_FIELDS).toContain('workspace')
+    expect(PROJECTION_LOCKED_FIELDS).toContain('health')
+    expect(CURATION_FIELDS).toContain('description')
+    expect(CURATION_FIELDS).toContain('links')
+    const overlap = PROJECTION_LOCKED_FIELDS.filter((f) =>
+      (CURATION_FIELDS as readonly string[]).includes(f),
+    )
+    expect(overlap).toEqual([])
+  })
+})
+
+describe('validateLinks', () => {
+  it('passes for absent/empty links', () => {
+    expect(validateLinks(undefined)).toBeNull()
+    expect(validateLinks([])).toBeNull()
+  })
+
+  it('passes for well-formed http(s) links', () => {
+    expect(validateLinks([{ label: 'Docs', url: 'https://x.dev' }])).toBeNull()
+    expect(validateLinks([{ label: 'Docs', url: 'http://x.dev' }])).toBeNull()
+  })
+
+  it('requires a label', () => {
+    expect(validateLinks([{ label: '', url: 'https://x.dev' }])).toMatch(/label/i)
+  })
+
+  it('requires a url', () => {
+    expect(validateLinks([{ label: 'Docs', url: '' }])).toMatch(/URL/i)
+  })
+
+  it('rejects a non-http url', () => {
+    expect(validateLinks([{ label: 'Docs', url: 'ftp://x.dev' }])).toMatch(/http/i)
+  })
+})
+
+describe('validateCreateInput', () => {
+  const base: CreateEntityInput = { kind: 'service', name: 'Payments', workspaceId: 'ws-1' }
+
+  it('passes for a valid manual create (incl. global workspaceId=null)', () => {
+    expect(validateCreateInput(base)).toBeNull()
+    expect(validateCreateInput({ ...base, workspaceId: null })).toBeNull()
+  })
+
+  it('requires a name', () => {
+    expect(validateCreateInput({ ...base, name: '  ' })).toMatch(/name/i)
+  })
+
+  it('requires a valid kind', () => {
+    expect(validateCreateInput({ ...base, kind: 'bogus' as CreateEntityInput['kind'] })).toMatch(
+      /kind/i,
+    )
+  })
+
+  it('surfaces link errors', () => {
+    expect(validateCreateInput({ ...base, links: [{ label: 'x', url: 'nope' }] })).toMatch(/http/i)
+  })
+})
+
+describe('validateUpdatePatch', () => {
+  it('allows any curation edit on a manual entity', () => {
+    expect(
+      validateUpdatePatch('manual', { name: 'New', kind: 'api', description: 'd' }),
+    ).toBeNull()
+  })
+
+  it('rejects an identity-field edit on a projected entity', () => {
+    expect(validateUpdatePatch('apps', { name: 'Renamed' })).toMatch(/synced|source/i)
+    expect(validateUpdatePatch('apps', { kind: 'api' })).toMatch(/synced|source/i)
+  })
+
+  it('allows curation edits on a projected entity', () => {
+    expect(
+      validateUpdatePatch('apps', { description: 'human note', links: [], tier: 'tier-1' }),
+    ).toBeNull()
+  })
+
+  it('rejects an empty name on a manual entity', () => {
+    expect(validateUpdatePatch('manual', { name: '   ' })).toMatch(/empty/i)
+  })
+})
+
+describe('validateRelationInput', () => {
+  it('passes a valid relation', () => {
+    expect(validateRelationInput({ fromId: 'a', toId: 'b', type: 'depends-on' })).toBeNull()
+  })
+
+  it('rejects self-relations', () => {
+    expect(validateRelationInput({ fromId: 'a', toId: 'a', type: 'depends-on' })).toMatch(/itself/i)
+  })
+
+  it('rejects an unknown type', () => {
+    expect(
+      validateRelationInput({
+        fromId: 'a',
+        toId: 'b',
+        type: 'bogus' as ReturnType<() => never>,
+      }),
+    ).toMatch(/type/i)
+  })
+
+  it('requires both ids', () => {
+    expect(validateRelationInput({ fromId: '', toId: 'b', type: 'depends-on' })).toMatch(/required/i)
+  })
+})

--- a/orbit-www/src/lib/catalog/entity-crud.ts
+++ b/orbit-www/src/lib/catalog/entity-crud.ts
@@ -1,0 +1,231 @@
+import type { EntityKind, RelationType } from '@/collections/catalog/constants'
+import { ENTITY_KINDS, RELATION_TYPES } from '@/collections/catalog/constants'
+
+/**
+ * Catalog entity CRUD — pure, framework-light input types + validators
+ * (Catalog Entity CRUD, docs/plans/2026-07-02-catalog-entity-crud.md, WP1).
+ *
+ * This module holds NO Payload / React / server-only imports so it is safe to
+ * pull into the client `EntityForm` for live validation, and directly unit
+ * testable. The `'use server'` entity-actions layer imports these validators
+ * and enforces them again server-side (a client that skips them still hits the
+ * same gate). `slugify` lives here as the canonical implementation; the
+ * projection layer re-exports it so there is exactly one slug algorithm.
+ */
+
+// ---------------------------------------------------------------------------
+// Field-ownership policy (PM decision 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Identity fields owned by the projection for a projected (`source.type` !=
+ * `manual`) entity. Locked in the edit UI and rejected server-side. Editing any
+ * of these on a projected entity is a validation error.
+ */
+export const PROJECTION_LOCKED_FIELDS = [
+  'name',
+  'slug',
+  'kind',
+  'workspace',
+  'source',
+  'health',
+] as const
+
+/**
+ * Human-editable curation fields. On a projected entity these stay editable and
+ * the projection becomes set-if-absent for them (see
+ * `mergeProjectionUpdate` in projection.ts). On a manual entity everything is
+ * editable.
+ */
+export const CURATION_FIELDS = [
+  'description',
+  'lifecycle',
+  'tier',
+  'owner',
+  'links',
+  'metadata',
+] as const
+
+// ---------------------------------------------------------------------------
+// Input types (consumed by EntityForm + entity-actions)
+// ---------------------------------------------------------------------------
+
+export type EntityLifecycle = 'experimental' | 'production' | 'deprecated'
+export type EntityTier = 'tier-1' | 'tier-2' | 'tier-3'
+export type LinkType = 'docs' | 'dashboard' | 'runbook' | 'repository' | 'other'
+
+/** A single link row on an entity (docs, dashboard, runbook, …). */
+export interface EntityLink {
+  label: string
+  url: string
+  type?: LinkType
+}
+
+/** Payload for creating a new manual entity. `workspaceId: null` = Global. */
+export interface CreateEntityInput {
+  kind: EntityKind
+  name: string
+  /** Owning workspace, or null for a global (platform-admin-only) entity. */
+  workspaceId: string | null
+  description?: string | null
+  lifecycle?: EntityLifecycle | null
+  tier?: EntityTier | null
+  /** Owning team entity id (a catalog entity of kind `team`). */
+  ownerId?: string | null
+  links?: EntityLink[]
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Patch for editing an entity. Identity fields (`name`, `kind`) are only
+ * accepted for manual entities — `validateUpdatePatch` rejects them for
+ * projected entities. Curation fields are always accepted.
+ */
+export interface UpdateEntityPatch {
+  name?: string
+  kind?: EntityKind
+  description?: string | null
+  lifecycle?: EntityLifecycle | null
+  tier?: EntityTier | null
+  ownerId?: string | null
+  links?: EntityLink[]
+  metadata?: Record<string, unknown> | null
+}
+
+/** Input for creating a typed relation between two entities. */
+export interface RelationInput {
+  fromId: string
+  toId: string
+  type: RelationType
+}
+
+/** A workspace the caller may author into. */
+export interface WorkspaceOption {
+  id: string
+  name: string
+}
+
+/** A pickable entity (relation target / owner team picker). */
+export interface EntityOption {
+  id: string
+  name: string
+  kind: EntityKind
+  /** Null for a global entity. */
+  workspaceName: string | null
+}
+
+/** Options driving the create/edit form (workspaces, global capability, team pickers). */
+export interface EntityFormOptions {
+  /** Workspaces the caller can create entities in. */
+  workspaces: WorkspaceOption[]
+  /** True when the caller (platform admin) may create global (no-workspace) entities. */
+  canCreateGlobal: boolean
+  /** Team entities per workspace id, for the owner picker. */
+  teamsByWorkspace: Record<string, EntityOption[]>
+  /** Global (no-workspace) team entities, for the owner picker on global entities. */
+  globalTeams: EntityOption[]
+}
+
+// ---------------------------------------------------------------------------
+// slugify (canonical) + collision suffixing
+// ---------------------------------------------------------------------------
+
+/**
+ * URL-safe slug from a display name. Lowercase, diacritics stripped,
+ * non-alphanumerics collapsed to single hyphens, trimmed. Deterministic for a
+ * given name. Canonical home for the algorithm — projection.ts re-exports this.
+ */
+export function slugify(name: string | null | undefined): string {
+  return String(name ?? '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Return `base` if free, else the first `base-N` (N starting at 2) not present
+ * in `taken`. Used to make a slug unique within its workspace scope.
+ */
+export function uniqueSlug(base: string, taken: Iterable<string>): string {
+  const takenSet = taken instanceof Set ? taken : new Set(taken)
+  if (!takenSet.has(base)) return base
+  let n = 2
+  while (takenSet.has(`${base}-${n}`)) n++
+  return `${base}-${n}`
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const HTTP_URL = /^https?:\/\//i
+
+function isEntityKind(value: unknown): value is EntityKind {
+  return typeof value === 'string' && (ENTITY_KINDS as readonly string[]).includes(value)
+}
+
+function isRelationType(value: unknown): value is RelationType {
+  return typeof value === 'string' && (RELATION_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * Validate an array of link rows: each needs a non-empty label and an http(s)
+ * url. Returns an error message, or null when valid (or absent).
+ */
+export function validateLinks(links: EntityLink[] | undefined | null): string | null {
+  if (!links || links.length === 0) return null
+  for (const link of links) {
+    if (!link.label?.trim()) return 'Each link needs a label.'
+    if (!link.url?.trim()) return 'Each link needs a URL.'
+    if (!HTTP_URL.test(link.url.trim())) return 'Link URLs must start with http:// or https://.'
+  }
+  return null
+}
+
+/**
+ * Validate a create payload (shape only — RBAC is enforced separately in the
+ * server action). Returns an error message, or null when valid.
+ */
+export function validateCreateInput(input: CreateEntityInput): string | null {
+  if (!input.name?.trim()) return 'Name is required.'
+  if (!isEntityKind(input.kind)) return 'A valid entity kind is required.'
+  const linkError = validateLinks(input.links)
+  if (linkError) return linkError
+  return null
+}
+
+/**
+ * Validate an update patch against the entity's provenance. For a projected
+ * entity (`sourceType` != `manual`) any {@link PROJECTION_LOCKED_FIELDS} key
+ * present in the patch is rejected; curation fields are always allowed. Returns
+ * an error message, or null when valid.
+ */
+export function validateUpdatePatch(sourceType: string, patch: UpdateEntityPatch): string | null {
+  const isManual = sourceType === 'manual'
+  if (!isManual) {
+    const locked = new Set<string>(PROJECTION_LOCKED_FIELDS)
+    for (const key of Object.keys(patch)) {
+      if (locked.has(key)) {
+        return `The ${key} of a synced entity is owned by its source and cannot be edited here.`
+      }
+    }
+  }
+  if (patch.name !== undefined && !patch.name.trim()) return 'Name cannot be empty.'
+  if (patch.kind !== undefined && !isEntityKind(patch.kind)) return 'A valid entity kind is required.'
+  const linkError = validateLinks(patch.links)
+  if (linkError) return linkError
+  return null
+}
+
+/**
+ * Validate a relation input: known type and `from` != `to`. Returns an error
+ * message, or null when valid.
+ */
+export function validateRelationInput(input: RelationInput): string | null {
+  if (!input.fromId || !input.toId) return 'Both entities are required.'
+  if (input.fromId === input.toId) return 'A relation cannot point an entity at itself.'
+  if (!isRelationType(input.type)) return 'A valid relation type is required.'
+  return null
+}

--- a/orbit-www/src/lib/catalog/projection.test.ts
+++ b/orbit-www/src/lib/catalog/projection.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Payload } from 'payload'
 import {
   slugify,
+  mergeProjectionUpdate,
   projectAppEntity,
   projectApiSchemaEntity,
   projectKafkaTopicEntity,
@@ -357,5 +358,61 @@ describe('removeProjectedRelationsForSource', () => {
         { 'source.sourceId': { equals: 'edge-1' } },
       ],
     })
+  })
+})
+
+
+describe('mergeProjectionUpdate (field-ownership / set-if-absent)', () => {
+  const incoming = {
+    name: 'Payments Service',
+    slug: 'payments-service',
+    kind: 'service' as const,
+    workspace: 'ws-1',
+    description: 'Auto description from source',
+    health: 'healthy' as const,
+    lifecycle: 'production' as const,
+    links: [{ label: 'Repository', url: 'https://github.com/acme/payments' }],
+    metadata: { build: { language: 'go' } },
+  }
+
+  it('always writes projection-owned identity fields (name/slug/kind/workspace/health)', () => {
+    const out = mergeProjectionUpdate({ description: 'Human edited' }, incoming)
+    expect(out).toMatchObject({
+      name: 'Payments Service',
+      slug: 'payments-service',
+      kind: 'service',
+      workspace: 'ws-1',
+      health: 'healthy',
+    })
+  })
+
+  it('preserves a human-entered description/links/metadata (does not write them)', () => {
+    const out = mergeProjectionUpdate(
+      {
+        description: 'Human edited',
+        links: [{ label: 'Runbook', url: 'https://rb' }],
+        metadata: { note: 'kept' },
+      },
+      incoming,
+    )
+    expect(out.description).toBeUndefined()
+    expect(out.links).toBeUndefined()
+    expect(out.metadata).toBeUndefined()
+  })
+
+  it('fills curation fields when the existing value is empty/absent', () => {
+    const out = mergeProjectionUpdate(
+      { description: '', links: [], metadata: {} },
+      incoming,
+    )
+    expect(out.description).toBe('Auto description from source')
+    expect(out.lifecycle).toBe('production')
+    expect(out.links).toEqual(incoming.links)
+    expect(out.metadata).toEqual(incoming.metadata)
+  })
+
+  it('never emits a source key (provenance is create-only)', () => {
+    const out = mergeProjectionUpdate({}, incoming)
+    expect('source' in out).toBe(false)
   })
 })

--- a/orbit-www/src/lib/catalog/projection.ts
+++ b/orbit-www/src/lib/catalog/projection.ts
@@ -6,6 +6,7 @@ import type {
   KafkaLineageEdge,
   KafkaTopic,
 } from '@/payload-types'
+import { slugify } from './entity-crud'
 
 /**
  * Catalog projection layer (IDP refocus P1).
@@ -38,18 +39,9 @@ function relId<T extends { id: string }>(ref: Ref<T>): string | undefined {
   return ref.id
 }
 
-/**
- * URL-safe slug from a display name. Lowercase, non-alphanumerics collapsed to
- * single hyphens, trimmed. Always produces a deterministic value for a name.
- */
-export function slugify(name: string | null | undefined): string {
-  return String(name ?? '')
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
+// slugify is defined canonically in ./entity-crud (client-safe) and re-exported
+// here for back-compat with `import { slugify } from './projection'`.
+export { slugify }
 
 /** Provenance values used by entity projections. */
 type EntitySource = { type: 'apps' | 'api-schemas' | 'kafka'; sourceId: string }
@@ -68,6 +60,55 @@ interface EntityData {
   lifecycle?: 'experimental' | 'production' | 'deprecated'
   links?: { label: string; url: string; type?: 'repository' | 'docs' | 'other' }[]
   metadata?: Record<string, unknown>
+}
+
+/**
+ * Merge incoming projected data onto an existing catalog-entities row for the
+ * UPDATE path, honouring the field-ownership policy (PM decision 3): identity
+ * fields the projection owns (name, slug, kind, workspace, health) are always
+ * written; curation fields (description, lifecycle, links, metadata) are
+ * SET-IF-ABSENT — written only when the existing row has no human-entered value
+ * — so re-projecting a source never clobbers manual edits. `source`, `tier` and
+ * `owner` are never written by the projection. Pure + unit-tested.
+ */
+export function mergeProjectionUpdate(
+  existing: {
+    description?: string | null
+    lifecycle?: string | null
+    links?: unknown[] | null
+    metadata?: unknown
+  },
+  data: EntityData,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    name: data.name,
+    slug: data.slug,
+    kind: data.kind,
+    workspace: data.workspace,
+  }
+  if (data.health) out.health = data.health
+
+  if (isBlank(existing.description)) out.description = data.description ?? null
+  if (data.lifecycle && isBlank(existing.lifecycle)) out.lifecycle = data.lifecycle
+  if (data.links && isEmptyArray(existing.links)) out.links = data.links
+  if (data.metadata && isEmptyMetadata(existing.metadata)) out.metadata = data.metadata
+
+  return out
+}
+
+function isBlank(v: unknown): boolean {
+  return v == null || (typeof v === 'string' && v.trim() === '')
+}
+
+function isEmptyArray(v: unknown): boolean {
+  return !Array.isArray(v) || v.length === 0
+}
+
+function isEmptyMetadata(v: unknown): boolean {
+  if (v == null) return true
+  if (Array.isArray(v)) return v.length === 0
+  if (typeof v === 'object') return Object.keys(v as object).length === 0
+  return false
 }
 
 /**
@@ -107,7 +148,8 @@ async function upsertEntity(
     const updated = await payload.update({
       collection: 'catalog-entities',
       id: existing.docs[0].id,
-      data: fields,
+      // set-if-absent for curation fields so a re-sync never clobbers manual edits.
+      data: mergeProjectionUpdate(existing.docs[0], data),
       overrideAccess: true,
     })
     return updated.id

--- a/orbit-www/src/lib/env.ts
+++ b/orbit-www/src/lib/env.ts
@@ -27,8 +27,7 @@ declare global {
  * the bundler from recognizing the process.env pattern.
  */
 function readServerEnv(key: string): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const env = (globalThis as any)['process']?.['env']
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
   return env?.[key] ?? ''
 }
 

--- a/orbit-www/src/lib/permissions.ts
+++ b/orbit-www/src/lib/permissions.ts
@@ -65,7 +65,7 @@ export function hasPermission(
 }
 
 /**
- * Check if user has any of the specified permissions
+ * Check if user holds at least one of the specified permissions
  */
 export function hasAnyPermission(
   workspaceId: string,

--- a/orbit-www/src/lib/scorecards/initiatives.ts
+++ b/orbit-www/src/lib/scorecards/initiatives.ts
@@ -1,4 +1,4 @@
-import type { Payload } from 'payload'
+import type { CollectionSlug, Payload, Where } from 'payload'
 import type {
   CatalogEntity,
   Initiative,
@@ -336,14 +336,12 @@ export function toActionItemLite(row: InitiativeActionItem): ActionItemLite {
 const PAGE_SIZE = 100
 
 /** Page-loop read of every doc matching `where` (evaluate.ts convention). */
-async function loadAll<T>(payload: Payload, collection: string, where: unknown): Promise<T[]> {
+async function loadAll<T>(payload: Payload, collection: CollectionSlug, where: Where): Promise<T[]> {
   const docs: T[] = []
   for (let page = 1; ; page++) {
     const res = await payload.find({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      collection: collection as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      where: where as any,
+      collection,
+      where,
       limit: PAGE_SIZE,
       page,
       depth: 0,

--- a/orbit-www/src/lib/temporal/automation-schedules.test.ts
+++ b/orbit-www/src/lib/temporal/automation-schedules.test.ts
@@ -80,7 +80,7 @@ describe('ensureAutomationSchedule', () => {
 
     await ensureAutomationSchedule({ id: 'a1', workspaceId: 'ws1', cron: '0 * * * *', enabled: false })
 
-    expect((create.mock.calls[0][0] as any).state.paused).toBe(true)
+    expect((create.mock.calls[0][0] as { state: { paused: boolean } }).state.paused).toBe(true)
   })
 
   it('falls back to update when the schedule already exists, converging spec/action/paused', async () => {

--- a/orbit-www/src/payload-types.ts
+++ b/orbit-www/src/payload-types.ts
@@ -3427,9 +3427,9 @@ export interface CatalogEntity {
   description?: string | null;
   kind: 'service' | 'api' | 'resource' | 'datastore' | 'kafka-topic' | 'domain' | 'system' | 'team' | 'environment';
   /**
-   * Security enclave the entity belongs to.
+   * Security enclave the entity belongs to (absent = global).
    */
-  workspace: string | Workspace;
+  workspace?: (string | null) | Workspace;
   /**
    * Owning team (a catalog-entities row of kind "team").
    */
@@ -3488,9 +3488,9 @@ export interface CatalogEntity {
 export interface CatalogRelation {
   id: string;
   /**
-   * Security enclave the relation belongs to.
+   * Security enclave the relation belongs to (absent = global).
    */
-  workspace: string | Workspace;
+  workspace?: (string | null) | Workspace;
   from: string | CatalogEntity;
   to: string | CatalogEntity;
   type:

--- a/orbit-www/src/scripts/seed-example-actions.ts
+++ b/orbit-www/src/scripts/seed-example-actions.ts
@@ -102,7 +102,8 @@ async function main() {
     )
     process.exit(1)
   }
-  const workspaceId = typeof first.workspace === 'string' ? first.workspace : first.workspace.id
+  const workspaceId =
+    (typeof first.workspace === 'string' ? first.workspace : first.workspace?.id) ?? ''
   console.log(`[seed-actions] Seeding Actions into workspace ${workspaceId}.`)
 
   for (const seed of ACTIONS) {

--- a/orbit-www/src/scripts/seed-example-scorecard.ts
+++ b/orbit-www/src/scripts/seed-example-scorecard.ts
@@ -78,7 +78,8 @@ async function seed() {
   }
   const firstEntity = entitiesRes.docs[0]
   const workspaceId =
-    typeof firstEntity.workspace === 'string' ? firstEntity.workspace : firstEntity.workspace.id
+    (typeof firstEntity.workspace === 'string' ? firstEntity.workspace : firstEntity.workspace?.id) ??
+    ''
   console.log(`Using workspace ${workspaceId} (from catalog-entity ${firstEntity.id}).`)
 
   // --- upsert the scorecard (keyed on name + workspace) --------------------


### PR DESCRIPTION
## Summary

Delivers the catalog-refinement vision (`docs/plans/2026-07-02-catalog-entity-crud.md`): entities are now a first-class, human-authored primitive surfaced through **two complementary surfaces** —

- **The catalog is the org-wide discovery layer.** Every authenticated user sees ALL entities (other workspaces' + Global); a scope toggle (All ↔ My workspaces) and a `?workspace=` filter (with a clear-able chip) narrow the view. You manage what you have rights to; you view the rest.
- **Workspaces are the team landpage.** A new Entities card on the workspace dashboard groups the workspace's entities by kind with catalog links, a member-gated **New entity** flow, and a first-class **Create team** callout — filling the gap where nothing could create `kind: team` entities (the `owner` relationship had no producer).

### RBAC model
- Workspace **members** create/edit entities in their workspace; **owner/admin** delete; **platform admins** (`users.role` super_admin/admin) manage everything, including **Global entities** (workspace is now optional on both catalog collections).
- All mutations enforce server-side (session-only identity, `lib/catalog/entity-authz.ts` as the single source of truth); UI gating is presentation only.

### 🔒 Security fix (found during discovery)
Collection access on `catalog-entities`/`catalog-relations` was a **no-op**: a `user.collection === 'users'` short-circuit granted every authenticated user org-wide read/update/delete via the direct Payload API, and the dead membership fallback compared the Payload user id against Better-Auth ids. Access is rewritten to enforce the real model (defense in depth behind the server actions), using `req.user.betterAuthId` correctly.

### Projected entities: field-ownership policy
Identity fields (name, kind, workspace, source, health) stay projection-owned — locked in the edit UI with a provenance banner AND rejected server-side. Curation fields (description, lifecycle, tier, owner, links, metadata) are human-editable, and re-projection is now **set-if-absent** instead of clobbering manual edits. Manual entities are fully editable; projected entities are not deletable (delete the source).

### Relations
Add/remove typed relations from the entity detail (org-wide search-as-you-type picker); RBAC follows the `from` entity; manual relations only are removable; entity deletion cascades relations **and** nulls dangling `owner` pointers.

## Verification
- **367 tests green** across catalog lib (85), scorecards, catalog components (61), workspace components (23); `tsc --noEmit` at the pre-existing 111-error baseline — zero net-new.
- **Expert QA audit: all 10 UACs PASS**, security-first probing (bypass removal, betterAuthId, null-workspace admin-only, projected-delete denial, unauthenticated read paths) plus a full live agent-browser pass on both surfaces: org-wide list + scope toggle, manual create → edit → relation add/remove → cascade-verified delete (checked in Mongo), projected-entity identity locking with curation edits persisting, Create-team flow on a teamless workspace, Global entity create/edit, workspace filter chip, graceful bogus-param/404/validation handling. QA's two MINORs (owner-pointer cascade, server-side ownerId must-reference-a-team validation) fixed and re-verified pre-PR.

## Deliberate follow-ups
Global entities show "No score" (scoring is workspace-scoped by design — needs a deliberate n/a treatment); embed EntityForm as a dialog in the workspace card (links + prefill work today); slug/relation dedupe is find-then-create (consistent with the projection layer's in-code idempotency); orphaned `EntityRelations.tsx` removable later; **ServiceNow bidirectional sync** slots into the `source` provenance model per the plan's Future section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZpEs7C3mrTpjCysuRGQZh