### PR TITLE
fix(security): tenant-unbounded collection access + RBAC privilege-escalation chain (#63)

### DIFF
--- a/docs/plans/2026-07-02-collection-access-control-remediation.md
+++ b/docs/plans/2026-07-02-collection-access-control-remediation.md
@@ -1,0 +1,139 @@
+# Collection Access-Control Remediation (GitHub issue #63)
+
+**Date:** 2026-07-02
+**Status:** Implemented on `fix/63-collection-access-control` — QA validated (all 13 UAC PASS, zero must-fix findings). Final scope grew beyond the original 27 files: +4 kafka files with a `user?.collection` variant, +16 WP4 files including the RBAC privilege-escalation chain (Roles/Permissions/UserWorkspaceRoles `!!user` writes + `loadUserPermissions` trusting them), +Deployments/KnowledgeSpaces create gaps.
+**Owner:** PM session (Claude) directing engineer + QA agents
+
+## Problem
+
+PR #62 fixed a broken access pattern on `catalog-entities`/`catalog-relations`; the
+same two bugs exist verbatim in 27 more files, and 10 further collections carry
+bug 2 alone:
+
+1. **Bug 1 — universal admin bypass.** `if (user.collection === 'users') return true`
+   was meant as a Payload-admin bypass, but `users` is the ONLY auth collection
+   (`payload.config.ts` registers no other), so every authenticated Better-Auth
+   user short-circuits to full read/update/delete. `kafka/KafkaServiceAccounts.ts`
+   has the guard *inverted* (`!== 'users'`) — a no-op that never denies.
+2. **Bug 2 — wrong identity in membership checks.** Fallback queries filter
+   `workspace-members.user: { equals: user.id }` with the Payload doc id, but that
+   TEXT field stores the **Better-Auth id** (`WorkspaceMembers.ts:75`, rows created
+   with `user: betterAuthId` in `Workspaces.ts:279`). The query always returns
+   nothing. Today correctness is carried entirely by bug 1; fixing bug 1 alone
+   would lock members out — both must be fixed together.
+
+Impact: the direct Payload REST/GraphQL API is effectively tenant-unbounded for
+any logged-in user across apps, API schemas, Kafka, scorecards, actions, and
+automations. (The UI is safe: server actions scope by workspace and run with
+`overrideAccess`.) The 10 bug-2-only collections are the inverse failure —
+broken *closed*: legitimate members get nothing via the direct API.
+
+## Fix reference (proven in PR #62)
+
+- `orbit-www/src/lib/access/workspace-access.ts` — correct membership helpers,
+  all keyed on `betterAuthId`; `isPlatformAdmin(user)` = `user.role` ∈
+  `super_admin`/`admin`.
+- `orbit-www/src/lib/catalog/entity-authz.ts` + `collections/catalog/CatalogEntities.ts`
+  — the collection-access shape to replicate.
+- Test pattern: pure Vitest with a hand-rolled `makePayload(members)` mock
+  (`src/lib/catalog/entity-authz.test.ts`, `src/lib/access/__tests__/workspace-access.test.ts`).
+
+## User Acceptance Criteria (UAC)
+
+The work is DONE only when every criterion below holds:
+
+- **UAC-1** `grep -rn "collection === 'users'\|collection !== 'users'" orbit-www/src/collections/` returns **zero** matches.
+- **UAC-2** No access rule queries `workspace-members` with a Payload `user.id`.
+  Every membership lookup in access code passes `user.betterAuthId`. Grep guard:
+  no `user: { equals: user.id }` (or equivalent) against `workspace-members`
+  anywhere under `src/collections/`.
+- **UAC-3** The only privilege bypass in collection access is `isPlatformAdmin(user)`
+  (role-based). A user with `role: 'user'` gets **no** bypass anywhere.
+- **UAC-4** Unauthenticated requests (`!user`) are denied every operation on every
+  affected collection.
+- **UAC-5** An authenticated non-member of workspace W cannot: read W-scoped docs
+  (read filter excludes them), create docs bound to W (`data.workspace`
+  validated), or update/delete W's docs — on every affected collection.
+- **UAC-6** An active member of W retains the collection's *intended* semantics:
+  workspace-filtered read; mutations gated by the same role lists the code
+  intended before the fix (see policy matrix). No collection's read scope is
+  broadened.
+- **UAC-7** System/global collections and system-written rows are platform-admin
+  only from the user-facing API: BifrostConfig, KafkaTopicPolicies,
+  KafkaTopicSharePolicies (all ops); Archetype-B writes (metrics/activity/
+  lag/lineage/snapshots/etc.); KafkaApplicationQuotas writes.
+- **UAC-8** KafkaServiceAccounts: inverted no-op guard removed; create/update
+  require workspace **owner/admin** (workspace resolved via the referenced
+  application/virtualCluster); delete stays `false` (soft-delete via revoke).
+- **UAC-9** Internal writeback paths are untouched: no changes to server actions,
+  `/api/internal/**` X-API-Key routes, or any `overrideAccess: true` call sites.
+- **UAC-10** All fixed access logic routes through ONE shared library
+  (`src/lib/access/collection-access.ts`); the three duplicated
+  `{scorecards,actions,automations}/access.ts` modules are thin re-exports of it
+  (import sites unchanged) or their importers point at the library directly.
+- **UAC-11** Vitest unit tests (makePayload mock pattern) cover, at minimum:
+  role-based admin bypass grants; `role: 'user'` gets NO bypass (bug-1 regression
+  guard); membership queries assert the exact where-shape uses the Better-Auth id
+  (bug-2 regression guard); member vs non-member outcomes; role gating
+  (owner/admin vs member); indirect workspace resolution (parent-relation
+  collections); null/missing `data.workspace` on create ⇒ deny (admin excepted
+  only where policy says global-admin-only).
+- **UAC-12** `pnpm exec vitest run` (frontend suite), `make lint-frontend`, and a
+  production typecheck of orbit-www all pass.
+- **UAC-13** The 10 bug-2-only collections (KnowledgePages, Templates, Launches,
+  DeploymentGenerators, CloudAccounts, LLMProviders, AgentTools,
+  AgentToolVersions, AgentRuns, PendingApprovals) use the shared library and
+  work for legitimate members.
+
+Out of scope (tracked separately): the 3 server-component `user.id` call sites
+(`catalog/apis/[id]/page.tsx:46`, `agent/page.tsx:38`, `workspaces/actions.ts:96`)
+— broken-closed UI bugs, follow-up issue to be filed at ship time. Go-layer #50
+is unchanged.
+
+## Policy matrix (PM decisions)
+
+| Collection(s) | read | create | update | delete |
+|---|---|---|---|---|
+| scorecards suite (8 colls via `scorecards/access.ts`), actions suite (2), automations (1) | admin ∪ member-workspaces filter | preserve intended role (manage-create = owner/admin of `data.workspace`; member-create = active member) | preserve intended role list on doc's workspace | same |
+| Apps, PatternInstances, KafkaApplications, KafkaSchemas, KafkaTopics | admin ∪ member filter | **active member of `data.workspace`** (was `!!user` — gap closed) | intended roles (e.g. owner/admin/member) | intended roles (e.g. owner/admin) |
+| APISchemas | preserve visibility semantics (public/workspace/private), membership fixed; verify `createdBy` comparison semantics (relationship to users ⇒ `user.id` is correct — do not blindly change) | active member of `data.workspace` | intended | intended |
+| APISchemaVersions | admin ∪ member filter (denormalized `workspace`) | active member of `data.workspace` | platform admin only (was system-only intent) | platform admin only |
+| KafkaApplicationRequests | preserve `or` shape (own requests ∪ member workspaces), identities fixed | active member of `data.workspace` | intended | requester-only preserved |
+| KafkaTopicShares | admin ∪ member filter over `ownerWorkspace`/`targetWorkspace` | preserve manage-create role on `data.ownerWorkspace` | intended | intended |
+| KafkaLineageEdge | `or` over `sourceWorkspace`/`targetWorkspace`, identities fixed | platform admin | platform admin | platform admin |
+| Archetype B (KafkaClientActivity, KafkaConsumerGroupLagHistory, KafkaConsumerGroups, KafkaLineageSnapshot, KafkaUsageMetrics, KafkaSchemaVersions, KafkaVirtualClusters, KafkaOffsetCheckpoints, HealthChecks) | admin ∪ member filter (indirect: resolve via parent — OffsetCheckpoints via virtualCluster→application→workspace; HealthChecks via app→workspace) | platform admin (system rows come via overrideAccess) | platform admin (or keep hard `false` where already `false`) | preserve (admin / `false`) |
+| BifrostConfig, KafkaTopicPolicies, KafkaTopicSharePolicies | platform admin only (all ops; preserve `delete: false` on BifrostConfig). Workspace-scoping the two Policies collections is a product follow-up, NOT this PR | | | |
+| KafkaApplicationQuotas | owner/admin-of-workspace filter (as intended), identities fixed | platform admin | platform admin | platform admin |
+| KafkaServiceAccounts | admin ∪ member filter, workspace resolved via application/virtualCluster | **owner/admin** of resolved workspace | owner/admin | `false` (unchanged) |
+| WP4 ten collections | keep each file's intended shape; swap identity to `betterAuthId` via shared helpers | same | same | same |
+
+Cross-cutting rules:
+- `!user` ⇒ `false`, always, first line.
+- Missing/`null` `data.workspace` on create ⇒ deny for non-admins (catalog "global ⇒ admin-only" rule).
+- Missing `user.betterAuthId` (pre-first-login edge) ⇒ treat as non-member; never throw.
+- Read filters return `Where` objects (never fetch-all-then-filter); admin returns `true`.
+
+## Work packages
+
+- **WP1 (Opus)** — `src/lib/access/collection-access.ts`: composable access-rule
+  factories built on `workspace-access.ts` (e.g. `workspaceScopedRead()`,
+  `memberCreate()`, `manageCreate(roles)`, `docWorkspaceMutate(slug, roles,
+  resolveWorkspace?)`, `adminOnly`, multi-field read filters, indirect resolvers).
+  TDD: tests first (makePayload pattern), watch fail, implement. Rewrite the three
+  shared `access.ts` modules on top. This unblocks WP2–4.
+- **WP2 (Sonnet)** — the 19 `kafka/` files, per the matrix + archetype notes.
+- **WP3 (Sonnet)** — Apps, HealthChecks, PatternInstances, APISchemas,
+  APISchemaVersions.
+- **WP4 (Sonnet)** — the 10 bug-2-only collections; verify-then-skip
+  UserWorkspaceRoles.ts / PageLinks.ts (their `user` fields likely store Payload
+  ids — confirm and do not change if so).
+- **QA** — adversarial review against every UAC; grep audits; full test/lint/build.
+
+## Verification
+
+1. UAC-1/2 grep audits (commands in UAC).
+2. `cd orbit-www && pnpm exec vitest run` — all green.
+3. `make lint-frontend` — clean.
+4. `cd orbit-www && pnpm exec tsc --noEmit` — clean.
+5. QA agent adversarial pass: for each archetype, walk a non-member / member /
+   owner / platform-admin / anonymous matrix through the new closures.

--- a/orbit-www/src/collections/AgentRuns.ts
+++ b/orbit-www/src/collections/AgentRuns.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { getMemberWorkspaceIds } from '@/lib/access/workspace-access'
+import { memberCreate, docWorkspaceMutate } from '@/lib/access/collection-access'
 
 /**
  * AgentRuns Collection
@@ -22,22 +24,16 @@ export const AgentRuns: CollectionConfig = {
   access: {
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [{ user: { equals: user.id } }, { status: { equals: 'active' } }],
-        },
-        limit: 100,
-      })
-      const workspaceIds = members.docs.map((m) =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id,
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
       return { workspace: { in: workspaceIds } }
     },
-    // Runs are created/updated by the gRPC AgentService (server-side). End
-    // users may not directly mutate runs.
-    create: ({ req: { user } }) => Boolean(user),
-    update: ({ req: { user } }) => Boolean(user),
+    // Runs are created/updated server-side (infra-agent server action, the
+    // internal agent-runs API route) with overrideAccess: true — verified by
+    // grepping every `collection: 'agent-runs'` write site. These rules only
+    // gate direct end-user access via Payload's REST/GraphQL API.
+    create: memberCreate(),
+    update: docWorkspaceMutate('agent-runs', ['owner', 'admin', 'member']),
     delete: () => false,
   },
   fields: [

--- a/orbit-www/src/collections/AgentToolVersions.ts
+++ b/orbit-www/src/collections/AgentToolVersions.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, Where } from 'payload'
+import { getMemberWorkspaceIds } from '@/lib/access/workspace-access'
 
 /**
  * AgentToolVersions Collection
@@ -33,31 +34,23 @@ export const AgentToolVersions: CollectionConfig = {
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
       if (user.role === 'super_admin' || user.role === 'admin') return true
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [{ user: { equals: user.id } }, { status: { equals: 'active' } }],
-        },
-        limit: 100,
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+      if (workspaceIds.length === 0) {
+        const denyAll: Where = { id: { equals: '__nope__' } }
+        return denyAll
+      }
+      // Join through the parent AgentTools row's workspace: a version row
+      // is visible only if its `tool` belongs to a workspace the caller is
+      // an active member of.
+      const tools = await payload.find({
+        collection: 'agent-tools',
+        where: { workspace: { in: workspaceIds } },
+        limit: 1000,
         overrideAccess: true,
       })
-      const workspaceIds = memberships.docs.map((m) =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id,
-      )
-      // We can't join through `tool.workspace` in a Payload `where`, so
-      // we filter at the surface by querying tools first then versions.
-      // For MVP, return all rows the workspace-membership query would
-      // allow at the tool layer. Practical effect: a workspace member
-      // sees every version row for tools they could already see.
-      const where: Where = {
-        // Cheap heuristic: deny by default unless an editedBy user or
-        // viewer is in those workspaces. Concrete narrowing happens in
-        // the page layer that joins to AgentTools.
-        // (Better filter: server-side only; this collection isn't a
-        // primary surface for end users, so a permissive read is OK.)
-        and: workspaceIds.length > 0 ? [] : [{ id: { equals: '__nope__' } }],
-      }
-      return where
+      const toolIds = tools.docs.map((t) => t.id)
+      return { tool: { in: toolIds } }
     },
     create: () => false,
     update: () => false,

--- a/orbit-www/src/collections/AgentTools.ts
+++ b/orbit-www/src/collections/AgentTools.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { getMemberWorkspaceIds } from '@/lib/access/workspace-access'
 
 /**
  * AgentTools Collection
@@ -23,16 +24,8 @@ export const AgentTools: CollectionConfig = {
   access: {
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [{ user: { equals: user.id } }, { status: { equals: 'active' } }],
-        },
-        limit: 100,
-      })
-      const workspaceIds = members.docs.map((m) =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id,
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
       return { workspace: { in: workspaceIds } }
     },
     // Rows are written via the temporal worker's internal API; humans

--- a/orbit-www/src/collections/Apps.ts
+++ b/orbit-www/src/collections/Apps.ts
@@ -1,5 +1,10 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { healthClient } from '@/lib/grpc/health-client'
+import {
+  workspaceScopedRead,
+  memberCreate,
+  docWorkspaceMutate,
+} from '@/lib/access/collection-access'
 
 export const Apps: CollectionConfig = {
   slug: 'apps',
@@ -188,100 +193,14 @@ export const Apps: CollectionConfig = {
     ],
   },
   access: {
-    // Read: Admins see all, others see workspace-scoped
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Payload admin users can see all apps (user.collection indicates Payload auth)
-      // TODO: Add proper role-based check when roles are implemented
-      if (user.collection === 'users') return true
-
-      // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Return query constraint: in user's workspaces
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    // Create: Users with app:create permission (workspace membership checked by workspace field)
-    create: ({ req: { user } }) => !!user,
-    // Update: Admins or workspace members (owner, admin, or member role)
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Payload admin users can update all apps
-      if (user.collection === 'users') return true
-
-      const app = await payload.findByID({
-        collection: 'apps',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof app.workspace === 'string'
-        ? app.workspace
-        : app.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    // Delete: System admins or workspace owners/admins only
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Payload admin users can delete all apps
-      if (user.collection === 'users') return true
-
-      const app = await payload.findByID({
-        collection: 'apps',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof app.workspace === 'string'
-        ? app.workspace
-        : app.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
+    // Read: platform admin sees all; others see their active workspaces.
+    read: workspaceScopedRead(),
+    // Create: any active member of the target `data.workspace`.
+    create: memberCreate(),
+    // Update: workspace owner, admin, or member.
+    update: docWorkspaceMutate('apps', ['owner', 'admin', 'member']),
+    // Delete: workspace owner or admin only.
+    delete: docWorkspaceMutate('apps', ['owner', 'admin']),
   },
   fields: [
     {

--- a/orbit-www/src/collections/CloudAccounts.ts
+++ b/orbit-www/src/collections/CloudAccounts.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig, Where } from 'payload'
 import { isAdmin } from '../access/isAdmin'
+import { getMemberWorkspaceIds } from '@/lib/access/workspace-access'
 
 export const CloudAccounts: CollectionConfig = {
   slug: 'cloud-accounts',
@@ -18,19 +19,8 @@ export const CloudAccounts: CollectionConfig = {
       if (role === 'super_admin' || role === 'admin') return true
 
       // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
       // Return query constraint: cloud accounts linked to user's workspaces
       return {

--- a/orbit-www/src/collections/DeploymentGenerators.ts
+++ b/orbit-www/src/collections/DeploymentGenerators.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, Where } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceAdminOrOwner, getWorkspaceMembership } from '@/lib/access/workspace-access'
 
 export const DeploymentGenerators: CollectionConfig = {
   slug: 'deployment-generators',
@@ -13,19 +14,8 @@ export const DeploymentGenerators: CollectionConfig = {
       if (!user) return false
 
       // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
       // Return generators in user's workspaces OR built-in generators (no workspace)
       return {
@@ -42,19 +32,13 @@ export const DeploymentGenerators: CollectionConfig = {
       if (data?.isBuiltIn) return false
       if (!data?.workspace) return false
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: data.workspace } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+
+      const workspaceId = typeof data.workspace === 'string' ? data.workspace : data.workspace?.id
+      if (!workspaceId) return false
+
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
     // Update: Built-in = admin only, custom = workspace admins
     update: async ({ req: { user, payload }, id }) => {
@@ -75,19 +59,10 @@ export const DeploymentGenerators: CollectionConfig = {
         ? generator.workspace
         : generator.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
     // Delete: Only custom generators, workspace owners only
     delete: async ({ req: { user, payload }, id }) => {
@@ -108,19 +83,11 @@ export const DeploymentGenerators: CollectionConfig = {
         ? generator.workspace
         : generator.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { equals: 'owner' } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+
+      const membership = await getWorkspaceMembership(payload, betterAuthId, workspaceId)
+      return membership?.role === 'owner'
     },
   },
   fields: [

--- a/orbit-www/src/collections/Deployments.ts
+++ b/orbit-www/src/collections/Deployments.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, Where } from 'payload'
+import { memberCreate } from '@/lib/access/collection-access'
 
 export const Deployments: CollectionConfig = {
   slug: 'deployments',
@@ -47,8 +48,30 @@ export const Deployments: CollectionConfig = {
         app: { in: appIds },
       } as Where
     },
-    // Create: Users with active workspace membership (validated through app access)
-    create: ({ req: { user } }) => !!user,
+    // Create: active member of the workspace owning `data.app` (was `!!user`
+    // — gap closed; the app→workspace relation is indirect, so resolve via
+    // the apps record rather than a direct `workspace` field).
+    create: memberCreate({
+      field: 'app',
+      resolveWorkspace: async ({ data, payload }) => {
+        const appId =
+          typeof (data as { app?: unknown } | undefined)?.app === 'string'
+            ? (data as { app?: string }).app
+            : (data as { app?: { id?: string } } | undefined)?.app?.id
+        if (!appId) return null
+        try {
+          const app = await payload.findByID({
+            collection: 'apps',
+            id: appId,
+            depth: 0,
+            overrideAccess: true,
+          })
+          return typeof app.workspace === 'string' ? app.workspace : app.workspace?.id ?? null
+        } catch {
+          return null
+        }
+      },
+    }),
     // Update: Workspace members (owner, admin, or member role)
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false

--- a/orbit-www/src/collections/HealthChecks.ts
+++ b/orbit-www/src/collections/HealthChecks.ts
@@ -2,6 +2,8 @@
 // See README.md "Frozen Capabilities" and docs/plans/2026-06-09-product-focus-strategy.md.
 
 import type { CollectionConfig, Where } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
+import { isPlatformAdmin, getMemberWorkspaceIds } from '@/lib/access/workspace-access'
 
 export const HealthChecks: CollectionConfig = {
   slug: 'health-checks',
@@ -10,26 +12,17 @@ export const HealthChecks: CollectionConfig = {
     defaultColumns: ['app', 'status', 'responseTime', 'checkedAt'],
   },
   access: {
-    // Same workspace-scoped access as Apps
+    // Read: workspace is indirect (health-check -> app -> workspace), so this
+    // is a hand-rolled resolver rather than `workspaceScopedRead` (which only
+    // supports fields on the doc itself). Platform admin sees all; otherwise
+    // resolve the caller's member workspaces, then the apps within them.
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      if (user.collection === 'users') return true
+      if (isPlatformAdmin(user)) return true
 
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Get apps in user's workspaces
       const apps = await payload.find({
         collection: 'apps',
         where: { workspace: { in: workspaceIds } },
@@ -45,7 +38,7 @@ export const HealthChecks: CollectionConfig = {
     },
     create: () => false, // Only system can create
     update: () => false, // Immutable records
-    delete: ({ req: { user } }) => user?.collection === 'users', // Admin only
+    delete: adminOnly, // Platform admin only
   },
   fields: [
     {

--- a/orbit-www/src/collections/KnowledgePages.ts
+++ b/orbit-www/src/collections/KnowledgePages.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceAdminOrOwner } from '@/lib/access/workspace-access'
+import { memberCreate } from '@/lib/access/collection-access'
 
 export const KnowledgePages: CollectionConfig = {
   slug: 'knowledge-pages',
@@ -13,20 +15,10 @@ export const KnowledgePages: CollectionConfig = {
     // Read: Based on knowledge space access (workspace members)
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-      })
-      
-      const workspaceIds = memberships.docs.map(m =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id
-      )
-      
+
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+
       // Filter pages by knowledge spaces that belong to user's workspaces
       const spaces = await payload.find({
         collection: 'knowledge-spaces',
@@ -34,16 +26,38 @@ export const KnowledgePages: CollectionConfig = {
           workspace: { in: workspaceIds }
         },
         limit: 1000,
+        overrideAccess: true,
       })
-      
+
       const spaceIds = spaces.docs.map(s => s.id)
-      
+
       return {
         knowledgeSpace: { in: spaceIds }
       }
     },
-    // Create: Authenticated workspace members
-    create: ({ req: { user } }) => !!user,
+    // Create: active member of the workspace owning `data.knowledgeSpace`
+    // (was `!!user` — gap closed). Indirect relation, so resolve via the
+    // knowledge-spaces record rather than a direct `workspace` field.
+    create: memberCreate({
+      resolveWorkspace: async ({ data, payload }) => {
+        const spaceId =
+          typeof (data as { knowledgeSpace?: unknown } | undefined)?.knowledgeSpace === 'string'
+            ? (data as { knowledgeSpace?: string }).knowledgeSpace
+            : (data as { knowledgeSpace?: { id?: string } } | undefined)?.knowledgeSpace?.id
+        if (!spaceId) return null
+        try {
+          const space = await payload.findByID({
+            collection: 'knowledge-spaces',
+            id: spaceId,
+            depth: 0,
+            overrideAccess: true,
+          })
+          return typeof space.workspace === 'string' ? space.workspace : space.workspace?.id ?? null
+        } catch {
+          return null
+        }
+      },
+    }),
     // Update: Authors and workspace admins
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
@@ -52,73 +66,57 @@ export const KnowledgePages: CollectionConfig = {
         collection: 'knowledge-pages',
         id,
         depth: 2,
+        overrideAccess: true,
       })
-      
+
       // Get workspace through space relationship
-      const space = typeof page.knowledgeSpace === 'object' 
-        ? page.knowledgeSpace 
-        : await payload.findByID({ collection: 'knowledge-spaces', id: page.knowledgeSpace as string })
-      
+      const space = typeof page.knowledgeSpace === 'object'
+        ? page.knowledgeSpace
+        : await payload.findByID({ collection: 'knowledge-spaces', id: page.knowledgeSpace as string, overrideAccess: true })
+
       const workspaceId = typeof space.workspace === 'string'
         ? space.workspace
         : space.workspace.id
-      
+
       // Check if user is author or workspace admin/owner
-      const isAuthor = page.author === user.id || 
+      const isAuthor = page.author === user.id ||
         (typeof page.author === 'object' && page.author.id === user.id)
-      
+
       if (isAuthor) return true
-      
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-      })
-      
-      return members.docs.length > 0
+
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
     // Delete: Authors and workspace admins
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      
+
       const page = await payload.findByID({
         collection: 'knowledge-pages',
         id,
         depth: 2,
+        overrideAccess: true,
       })
-      
+
       const space = typeof page.knowledgeSpace === 'object'
         ? page.knowledgeSpace
-        : await payload.findByID({ collection: 'knowledge-spaces', id: page.knowledgeSpace as string })
-      
+        : await payload.findByID({ collection: 'knowledge-spaces', id: page.knowledgeSpace as string, overrideAccess: true })
+
       const workspaceId = typeof space.workspace === 'string'
         ? space.workspace
         : space.workspace.id
-      
+
       const isAuthor = page.author === user.id ||
         (typeof page.author === 'object' && page.author.id === user.id)
-      
+
       if (isAuthor) return true
-      
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-      })
-      
-      return members.docs.length > 0
+
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
   },
   fields: [

--- a/orbit-www/src/collections/KnowledgeSpaces.ts
+++ b/orbit-www/src/collections/KnowledgeSpaces.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { memberCreate } from '@/lib/access/collection-access'
 
 export const KnowledgeSpaces: CollectionConfig = {
   slug: 'knowledge-spaces',
@@ -37,8 +38,8 @@ export const KnowledgeSpaces: CollectionConfig = {
         workspace: { in: workspaceIds }
       }
     },
-    // Create: Any authenticated user
-    create: ({ req: { user } }) => !!user,
+    // Create: active member of the target `data.workspace` (was `!!user` — gap closed)
+    create: memberCreate(),
     // Update: Platform admins or workspace admins/owners
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false

--- a/orbit-www/src/collections/LLMProviders.ts
+++ b/orbit-www/src/collections/LLMProviders.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceAdminOrOwner, getWorkspaceMembership, isPlatformAdmin } from '@/lib/access/workspace-access'
 
 /**
  * LLMProviders Collection
@@ -23,33 +24,20 @@ export const LLMProviders: CollectionConfig = {
   access: {
     read: async ({ req: { user, payload } }) => {
       if (!user) return false
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [{ user: { equals: user.id } }, { status: { equals: 'active' } }],
-        },
-        limit: 100,
-      })
-      const workspaceIds = members.docs.map((m) =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id,
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
       return { workspace: { in: workspaceIds } }
     },
     create: async ({ req: { user, payload }, data }) => {
       if (!user) return false
-      if (!data?.workspace) return true
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: data.workspace } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-      })
-      return members.docs.length > 0
+      // A null workspace means global/platform-level provider config —
+      // restricted to platform admins, not every authenticated user.
+      if (!data?.workspace) return isPlatformAdmin(user)
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+      const workspaceId = typeof data.workspace === 'string' ? data.workspace : data.workspace?.id
+      if (!workspaceId) return false
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
@@ -57,19 +45,13 @@ export const LLMProviders: CollectionConfig = {
         const doc = await payload.findByID({
           collection: 'llm-providers',
           id: id as string,
+          overrideAccess: true,
         })
-        const members = await payload.find({
-          collection: 'workspace-members',
-          where: {
-            and: [
-              { workspace: { equals: doc.workspace } },
-              { user: { equals: user.id } },
-              { role: { in: ['owner', 'admin'] } },
-              { status: { equals: 'active' } },
-            ],
-          },
-        })
-        return members.docs.length > 0
+        const betterAuthId = user.betterAuthId
+        if (!betterAuthId) return false
+        const workspaceId = typeof doc.workspace === 'string' ? doc.workspace : doc.workspace?.id
+        if (!workspaceId) return false
+        return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
       } catch {
         return false
       }
@@ -80,19 +62,14 @@ export const LLMProviders: CollectionConfig = {
         const doc = await payload.findByID({
           collection: 'llm-providers',
           id: id as string,
+          overrideAccess: true,
         })
-        const members = await payload.find({
-          collection: 'workspace-members',
-          where: {
-            and: [
-              { workspace: { equals: doc.workspace } },
-              { user: { equals: user.id } },
-              { role: { equals: 'owner' } },
-              { status: { equals: 'active' } },
-            ],
-          },
-        })
-        return members.docs.length > 0
+        const betterAuthId = user.betterAuthId
+        if (!betterAuthId) return false
+        const workspaceId = typeof doc.workspace === 'string' ? doc.workspace : doc.workspace?.id
+        if (!workspaceId) return false
+        const membership = await getWorkspaceMembership(payload, betterAuthId, workspaceId)
+        return membership?.role === 'owner'
       } catch {
         return false
       }

--- a/orbit-www/src/collections/Launches.ts
+++ b/orbit-www/src/collections/Launches.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig, Where } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceMember, isWorkspaceAdminOrOwner } from '@/lib/access/workspace-access'
+import { memberCreate } from '@/lib/access/collection-access'
 
 export const Launches: CollectionConfig = {
   slug: 'launches',
@@ -17,27 +19,16 @@ export const Launches: CollectionConfig = {
       if (role === 'super_admin' || role === 'admin') return true
 
       // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
       // Return query constraint: launches in user's workspaces
       return {
         workspace: { in: workspaceIds },
       } as Where
     },
-    // Create: Any authenticated user
-    create: ({ req: { user } }) => !!user,
+    // Create: active member of the target `data.workspace` (was `!!user` — gap closed)
+    create: memberCreate(),
     // Update: Workspace members with owner, admin, or member role
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
@@ -52,20 +43,11 @@ export const Launches: CollectionConfig = {
         ? launch.workspace
         : launch.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
 
-      return members.docs.length > 0
+      // owner/admin/member is every active role, i.e. any active member
+      return isWorkspaceMember(payload, betterAuthId, workspaceId)
     },
     // Delete: Workspace owners and admins only
     delete: async ({ req: { user, payload }, id }) => {
@@ -81,20 +63,10 @@ export const Launches: CollectionConfig = {
         ? launch.workspace
         : launch.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
 
-      return members.docs.length > 0
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
   },
   fields: [

--- a/orbit-www/src/collections/PageLinks.ts
+++ b/orbit-www/src/collections/PageLinks.ts
@@ -1,4 +1,32 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig, Payload } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceMember } from '@/lib/access/workspace-access'
+
+/**
+ * Resolve the workspace a `fromPage` (knowledge-pages id) belongs to, via
+ * knowledgeSpace → workspace. Missing/broken chain link ⇒ null (deny).
+ */
+async function resolveWorkspaceIdForFromPage(payload: Payload, fromPageId: string): Promise<string | null> {
+  try {
+    const page = await payload.findByID({
+      collection: 'knowledge-pages',
+      id: fromPageId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    const spaceId = typeof page.knowledgeSpace === 'string' ? page.knowledgeSpace : page.knowledgeSpace?.id
+    if (!spaceId) return null
+    const space = await payload.findByID({
+      collection: 'knowledge-spaces',
+      id: spaceId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    const workspaceId = typeof space.workspace === 'string' ? space.workspace : space.workspace?.id
+    return workspaceId ?? null
+  } catch {
+    return null
+  }
+}
 
 export const PageLinks: CollectionConfig = {
   slug: 'page-links',
@@ -8,17 +36,64 @@ export const PageLinks: CollectionConfig = {
     hidden: false,
   },
   access: {
-    read: ({ req: { user } }) => {
+    read: async ({ req: { user, payload } }) => {
       if (!user) return false
+
+      // `workspaces.members` is not a real field (no join/relationship by
+      // that name exists on Workspaces) — the previous dot-path query could
+      // never match anything and silently denied every caller. Resolve the
+      // same intent explicitly: a link is visible if its source page's
+      // knowledge space belongs to a workspace the caller actively belongs to.
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+
+      const spaces = await payload.find({
+        collection: 'knowledge-spaces',
+        where: { workspace: { in: workspaceIds } },
+        limit: 1000,
+        overrideAccess: true,
+      })
+      const spaceIds = spaces.docs.map((s) => s.id)
+
+      const pages = await payload.find({
+        collection: 'knowledge-pages',
+        where: { knowledgeSpace: { in: spaceIds } },
+        limit: 1000,
+        overrideAccess: true,
+      })
+      const pageIds = pages.docs.map((p) => p.id)
+
       return {
-        'fromPage.knowledgeSpace.workspace.members.user': {
-          equals: user.id,
-        },
+        fromPage: { in: pageIds },
       }
     },
-    create: ({ req: { user } }) => !!user,
+    create: async ({ req: { user, payload }, data }) => {
+      if (!user) return false
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+      const fromPageId = typeof data?.fromPage === 'string' ? data.fromPage : data?.fromPage?.id
+      if (!fromPageId) return false
+      const workspaceId = await resolveWorkspaceIdForFromPage(payload, fromPageId)
+      if (!workspaceId) return false
+      return isWorkspaceMember(payload, betterAuthId, workspaceId)
+    },
     update: () => false, // Links are immutable after creation
-    delete: ({ req: { user } }) => !!user,
+    delete: async ({ req: { user, payload }, id }) => {
+      if (!user || !id) return false
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+      let link
+      try {
+        link = await payload.findByID({ collection: 'page-links', id: id as string, depth: 0, overrideAccess: true })
+      } catch {
+        return false
+      }
+      const fromPageId = typeof link.fromPage === 'string' ? link.fromPage : link.fromPage?.id
+      if (!fromPageId) return false
+      const workspaceId = await resolveWorkspaceIdForFromPage(payload, fromPageId)
+      if (!workspaceId) return false
+      return isWorkspaceMember(payload, betterAuthId, workspaceId)
+    },
   },
   fields: [
     {

--- a/orbit-www/src/collections/PatternInstances.ts
+++ b/orbit-www/src/collections/PatternInstances.ts
@@ -1,4 +1,9 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import {
+  workspaceScopedRead,
+  memberCreate,
+  docWorkspaceMutate,
+} from '@/lib/access/collection-access'
 
 /**
  * PatternInstances Collection
@@ -27,80 +32,18 @@ export const PatternInstances: CollectionConfig = {
     group: 'Agent',
   },
   access: {
-    // Read: workspace members see their own; Payload admins see all.
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-      )
-      return { workspace: { in: workspaceIds } } as Where
-    },
-    // Create: any authenticated user; workspace membership checked via
-    // the agent dispatch + the workspace field. Direct user-driven
-    // creation from a future browse UI follows the same path.
-    create: ({ req: { user } }) => !!user,
+    // Read: platform admin sees all; workspace members see their own.
+    read: workspaceScopedRead(),
+    // Create: any active member of the target `data.workspace`; workspace
+    // membership is checked via the agent dispatch + the workspace field.
+    // Direct user-driven creation from a future browse UI follows the same path.
+    create: memberCreate(),
     // Update: workspace owner/admin/member. Status writebacks from the
     // temporal worker go through /api/internal/pattern-instances/[id]/
     // status with X-API-Key, bypassing this access check.
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-      const inst = await payload.findByID({
-        collection: 'pattern-instances',
-        id,
-        overrideAccess: true,
-      })
-      const workspaceId =
-        typeof inst.workspace === 'string' ? inst.workspace : inst.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
-    },
+    update: docWorkspaceMutate('pattern-instances', ['owner', 'admin', 'member']),
     // Delete: workspace owner/admin only.
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-      const inst = await payload.findByID({
-        collection: 'pattern-instances',
-        id,
-        overrideAccess: true,
-      })
-      const workspaceId =
-        typeof inst.workspace === 'string' ? inst.workspace : inst.workspace.id
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-      return members.docs.length > 0
-    },
+    delete: docWorkspaceMutate('pattern-instances', ['owner', 'admin']),
   },
   fields: [
     {

--- a/orbit-www/src/collections/PendingApprovals.ts
+++ b/orbit-www/src/collections/PendingApprovals.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, Where } from 'payload'
+import { getMemberWorkspaceIds } from '@/lib/access/workspace-access'
 
 /**
  * PendingApprovals Collection (Spike 7 commit γ)
@@ -37,17 +38,8 @@ export const PendingApprovals: CollectionConfig = {
       if (!user) return false
       // Platform admins see everything (they own the queue page).
       if (user.role === 'super_admin' || user.role === 'admin') return true
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [{ user: { equals: user.id } }, { status: { equals: 'active' } }],
-        },
-        limit: 100,
-        overrideAccess: true,
-      })
-      const workspaceIds = memberships.docs.map((m) =>
-        typeof m.workspace === 'string' ? m.workspace : m.workspace.id,
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
       if (workspaceIds.length === 0) {
         const denyAll: Where = { id: { equals: '__none__' } }
         return denyAll

--- a/orbit-www/src/collections/Permissions.ts
+++ b/orbit-www/src/collections/Permissions.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const Permissions: CollectionConfig = {
   slug: 'permissions',
@@ -8,11 +9,13 @@ export const Permissions: CollectionConfig = {
     group: 'Access Control',
   },
   access: {
-    // Read: all users | Write: authenticated users (TODO: restrict to admins via UserWorkspaceRoles)
-    read: () => true,
-    create: ({ req: { user } }) => !!user,
-    update: ({ req: { user } }) => !!user,
-    delete: ({ req: { user } }) => !!user,
+    // Read: authenticated users. Write: platform admins only — permission
+    // definitions are system config (was `!!user`, part of the issue #63
+    // privilege-escalation chain).
+    read: ({ req: { user } }) => !!user,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/Roles.ts
+++ b/orbit-www/src/collections/Roles.ts
@@ -1,5 +1,7 @@
 // orbit-www/src/collections/Roles.ts
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
+import { isPlatformAdmin } from '@/lib/access/workspace-access'
 
 export const Roles: CollectionConfig = {
   slug: 'roles',
@@ -9,15 +11,21 @@ export const Roles: CollectionConfig = {
     group: 'Access Control',
   },
   access: {
-    read: () => true,
-    create: ({ req: { user } }) => !!user,
-    update: ({ req: { user } }) => !!user,
-    // Prevent deletion of system roles
+    // Role definitions are internal config; UI pickers run logged-in.
+    read: ({ req: { user } }) => !!user,
+    // Role definitions are platform-admin config (was `!!user` — part of the
+    // issue #63 privilege-escalation chain: an authenticated caller could
+    // define a platform-scoped role with arbitrary permissions).
+    create: adminOnly,
+    update: adminOnly,
+    // Admin-only, and even a platform admin must not delete system roles.
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
+      if (!isPlatformAdmin(user)) return false
       const role = await payload.findByID({
         collection: 'roles',
         id,
+        overrideAccess: true,
       })
       return !role.isSystem
     },

--- a/orbit-www/src/collections/Templates.ts
+++ b/orbit-www/src/collections/Templates.ts
@@ -1,5 +1,7 @@
 // orbit-www/src/collections/Templates.ts
 import type { CollectionConfig, Where } from 'payload'
+import { getMemberWorkspaceIds, isWorkspaceAdminOrOwner, getWorkspaceMembership } from '@/lib/access/workspace-access'
+import { memberCreate } from '@/lib/access/collection-access'
 
 export const Templates: CollectionConfig = {
   slug: 'templates',
@@ -14,19 +16,8 @@ export const Templates: CollectionConfig = {
       if (!user) return false
 
       // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
       // Return query constraint: public OR in user's workspaces OR shared with user's workspaces
       return {
@@ -37,8 +28,8 @@ export const Templates: CollectionConfig = {
         ],
       } as Where
     },
-    // Create: Users with template:create permission
-    create: ({ req: { user } }) => !!user,
+    // Create: active member of the target `data.workspace` (was `!!user` — gap closed)
+    create: memberCreate(),
     // Update: Workspace admins/owners
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
@@ -53,20 +44,10 @@ export const Templates: CollectionConfig = {
         ? template.workspace
         : template.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
 
-      return members.docs.length > 0
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
     // Delete: Workspace owners only
     delete: async ({ req: { user, payload }, id }) => {
@@ -82,20 +63,11 @@ export const Templates: CollectionConfig = {
         ? template.workspace
         : template.workspace.id
 
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { equals: 'owner' } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
 
-      return members.docs.length > 0
+      const membership = await getWorkspaceMembership(payload, betterAuthId, workspaceId)
+      return membership?.role === 'owner'
     },
   },
   fields: [

--- a/orbit-www/src/collections/UserWorkspaceRoles.ts
+++ b/orbit-www/src/collections/UserWorkspaceRoles.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const UserWorkspaceRoles: CollectionConfig = {
   slug: 'user-workspace-roles',
@@ -24,9 +25,13 @@ export const UserWorkspaceRoles: CollectionConfig = {
       })
       return assignment.user === user.id
     },
-    create: ({ req: { user } }) => !!user,
-    update: ({ req: { user } }) => !!user,
-    delete: ({ req: { user } }) => !!user,
+    // Role assignment is a platform-admin operation until the Permissions
+    // system activates workspace-owner delegation (future product decision,
+    // not this PR). Previously `!!user`, which let any authenticated caller
+    // assign themselves a platform-scoped role (issue #63 escalation chain).
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/actions/access.ts
+++ b/orbit-www/src/collections/actions/access.ts
@@ -1,96 +1,28 @@
-import type { Access, Where } from 'payload'
+import type { Access } from 'payload'
+import {
+  workspaceScopedRead as scopedRead,
+  memberCreate,
+  manageCreate,
+  docWorkspaceMutate,
+} from '@/lib/access/collection-access'
 
 /**
- * Workspace-scoped access for the Self-Service actions collections (IDP refocus
- * P3). Same model as the scorecards collections: the tenant boundary is the
- * caller's active workspace memberships. Authoring Actions is owner/admin;
- * RUNNING an action (creating an action-run) is open to any active member.
- *
- * NOTE: this mirrors src/collections/scorecards/access.ts — a future cleanup
- * could promote these to one shared module.
+ * Workspace-scoped access for the Self-Service actions collections — thin
+ * adapters over the shared `@/lib/access/collection-access` factories (issue
+ * #63). The tenant boundary is the caller's active workspace memberships, keyed
+ * on the Better-Auth id; the only bypass is a platform admin. Authoring an
+ * Action is owner/admin; RUNNING one (an action-run) is open to any active
+ * member. Server actions / internal writebacks run with overrideAccess.
  */
 
-export const workspaceScopedRead: Access = async ({ req: { user, payload } }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const memberships = await payload.find({
-    collection: 'workspace-members',
-    where: { user: { equals: user.id }, status: { equals: 'active' } },
-    limit: 1000,
-    overrideAccess: true,
-  })
-  const workspaceIds = memberships.docs.map((m) =>
-    String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-  )
-  return { workspace: { in: workspaceIds } } as Where
-}
+export const workspaceScopedRead: Access = scopedRead()
 
-/** Create allowed for any active member of the target workspace (data.workspace). */
-export const workspaceScopedMemberCreate: Access = async ({ req: { user, payload }, data }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const workspaceId =
-    typeof data?.workspace === 'string' ? data.workspace : data?.workspace?.id
-  if (!workspaceId) return false
-  const members = await payload.find({
-    collection: 'workspace-members',
-    where: {
-      and: [
-        { workspace: { equals: workspaceId } },
-        { user: { equals: user.id } },
-        { status: { equals: 'active' } },
-      ],
-    },
-    limit: 1,
-    overrideAccess: true,
-  })
-  return members.docs.length > 0
-}
+/** Create allowed for any active member of the target `data.workspace`. */
+export const workspaceScopedMemberCreate: Access = memberCreate()
 
-/** Create gated on owner/admin of the target workspace (for authoring Actions). */
-export const workspaceScopedManageCreate: Access = async ({ req: { user, payload }, data }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const workspaceId =
-    typeof data?.workspace === 'string' ? data.workspace : data?.workspace?.id
-  if (!workspaceId) return false
-  const members = await payload.find({
-    collection: 'workspace-members',
-    where: {
-      and: [
-        { workspace: { equals: workspaceId } },
-        { user: { equals: user.id } },
-        { role: { in: ['owner', 'admin'] } },
-        { status: { equals: 'active' } },
-      ],
-    },
-    limit: 1,
-    overrideAccess: true,
-  })
-  return members.docs.length > 0
-}
+/** Create gated on owner/admin of the target `data.workspace` (authoring Actions). */
+export const workspaceScopedManageCreate: Access = manageCreate(['owner', 'admin'])
 
-export const workspaceScopedMutate =
-  (slug: string, roles: string[]): Access =>
-  async ({ req: { user, payload }, id }) => {
-    if (!user || !id) return false
-    if (user.collection === 'users') return true
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = await payload.findByID({ collection: slug as any, id, overrideAccess: true })
-    const workspaceId =
-      typeof doc.workspace === 'string' ? doc.workspace : doc.workspace?.id
-    if (!workspaceId) return false
-    const members = await payload.find({
-      collection: 'workspace-members',
-      where: {
-        and: [
-          { workspace: { equals: workspaceId } },
-          { user: { equals: user.id } },
-          { role: { in: roles } },
-          { status: { equals: 'active' } },
-        ],
-      },
-      overrideAccess: true,
-    })
-    return members.docs.length > 0
-  }
+/** Update/delete: active member of the doc's workspace holding one of `roles`. */
+export const workspaceScopedMutate = (slug: string, roles: string[]): Access =>
+  docWorkspaceMutate(slug, roles)

--- a/orbit-www/src/collections/api-catalog/APISchemaVersions.ts
+++ b/orbit-www/src/collections/api-catalog/APISchemaVersions.ts
@@ -1,5 +1,6 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { createHash } from 'crypto'
+import { workspaceScopedRead, memberCreate, adminOnly } from '@/lib/access/collection-access'
 
 export const APISchemaVersions: CollectionConfig = {
   slug: 'api-schema-versions',
@@ -10,33 +11,16 @@ export const APISchemaVersions: CollectionConfig = {
     description: 'Version history for API schemas',
   },
   access: {
-    // Read: Inherit from parent schema (via workspace)
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    // Only allow create/update/delete for authenticated users (managed via schema hooks)
-    create: ({ req: { user } }) => !!user,
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    // Read: denormalized `workspace` field — platform admin sees all, others
+    // scoped to their active workspace memberships.
+    read: workspaceScopedRead(),
+    // Create: any active member of the target `data.workspace`.
+    create: memberCreate(),
+    // Update/delete: versions are immutable snapshots — platform admin only
+    // (the prior "Payload auth collection" check was intended as a
+    // system-only gate, not a universal bypass for every logged-in user).
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/api-catalog/APISchemas.ts
+++ b/orbit-www/src/collections/api-catalog/APISchemas.ts
@@ -1,4 +1,11 @@
 import type { CollectionConfig, Where } from 'payload'
+import { memberCreate } from '@/lib/access/collection-access'
+import {
+  isPlatformAdmin,
+  isWorkspaceMember,
+  isWorkspaceAdminOrOwner,
+  getMemberWorkspaceIds,
+} from '@/lib/access/workspace-access'
 
 export const APISchemas: CollectionConfig = {
   slug: 'api-schemas',
@@ -18,25 +25,17 @@ export const APISchemas: CollectionConfig = {
         } as Where
       }
 
-      // Payload admin users can see all
-      if (user.collection === 'users') return true
+      // Platform admin can see all
+      if (isPlatformAdmin(user)) return true
 
-      // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
+      // Get user's workspace memberships (keyed on the Better-Auth id)
+      const betterAuthId = user.betterAuthId
+      const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
 
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Can see: public APIs, workspace APIs in their workspaces, private APIs they created
+      // Can see: public APIs, workspace APIs in their workspaces, private APIs
+      // they created. `createdBy` is a relationship to `users`, so comparing
+      // against the Payload `user.id` here is correct (unlike workspace-members
+      // lookups, which store the Better-Auth id).
       return {
         or: [
           { visibility: { equals: 'public' } },
@@ -55,18 +54,21 @@ export const APISchemas: CollectionConfig = {
         ],
       } as Where
     },
-    create: ({ req: { user } }) => !!user,
+    // Create: any active member of the target `data.workspace`.
+    create: memberCreate(),
     update: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
+      if (isPlatformAdmin(user)) return true
 
       const schema = await payload.findByID({
         collection: 'api-schemas',
         id,
+        depth: 0,
         overrideAccess: true,
       })
 
-      // Creator can always edit
+      // Creator can always edit (createdBy is a relationship to `users`, so
+      // user.id is the correct comparison here).
       const createdById = typeof schema.createdBy === 'string'
         ? schema.createdBy
         : schema.createdBy?.id
@@ -74,35 +76,27 @@ export const APISchemas: CollectionConfig = {
 
       const workspaceId = typeof schema.workspace === 'string'
         ? schema.workspace
-        : schema.workspace.id
+        : schema.workspace?.id
+      if (!workspaceId) return false
 
       // Workspace owners/admins/members can edit
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+      return isWorkspaceMember(payload, betterAuthId, workspaceId)
     },
     delete: async ({ req: { user, payload }, id }) => {
       if (!user || !id) return false
-      if (user.collection === 'users') return true
+      if (isPlatformAdmin(user)) return true
 
       const schema = await payload.findByID({
         collection: 'api-schemas',
         id,
+        depth: 0,
         overrideAccess: true,
       })
 
-      // Creator can delete
+      // Creator can delete (createdBy is a relationship to `users`, so user.id
+      // is the correct comparison here).
       const createdById = typeof schema.createdBy === 'string'
         ? schema.createdBy
         : schema.createdBy?.id
@@ -110,23 +104,13 @@ export const APISchemas: CollectionConfig = {
 
       const workspaceId = typeof schema.workspace === 'string'
         ? schema.workspace
-        : schema.workspace.id
+        : schema.workspace?.id
+      if (!workspaceId) return false
 
       // Only workspace owners/admins can delete
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
+      const betterAuthId = user.betterAuthId
+      if (!betterAuthId) return false
+      return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
     },
   },
   fields: [

--- a/orbit-www/src/collections/automations/access.ts
+++ b/orbit-www/src/collections/automations/access.ts
@@ -1,76 +1,27 @@
-import type { Access, Where } from 'payload'
+import type { Access } from 'payload'
+import {
+  workspaceScopedRead as scopedRead,
+  manageCreate,
+  docWorkspaceMutate,
+} from '@/lib/access/collection-access'
 
 /**
- * Workspace-scoped access for the Automations collection (IDP refocus P4).
- *
- * Mirrors the scorecards/actions access model: the tenant boundary is the
- * caller's active workspace memberships. Authoring an Automation (the "when X,
- * do Y" rule) is a privileged config change, so create/update/delete are gated
- * on workspace owner/admin — the same Option A choice P2/P3 made. There is no
- * member-create path: automations are management config, not a self-service run.
- *
- * NOTE: this mirrors src/collections/actions/access.ts and
- * src/collections/scorecards/access.ts — a future cleanup could promote these
- * to one shared module.
+ * Workspace-scoped access for the Automations collection — thin adapters over
+ * the shared `@/lib/access/collection-access` factories (issue #63). The tenant
+ * boundary is the caller's active workspace memberships, keyed on the
+ * Better-Auth id; the only bypass is a platform admin. Authoring an Automation
+ * is a privileged config change, so create/update/delete are gated on workspace
+ * owner/admin — there is no member-create path. Internal writebacks run with
+ * overrideAccess.
  */
 
-export const workspaceScopedRead: Access = async ({ req: { user, payload } }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const memberships = await payload.find({
-    collection: 'workspace-members',
-    where: { user: { equals: user.id }, status: { equals: 'active' } },
-    limit: 1000,
-    overrideAccess: true,
-  })
-  const workspaceIds = memberships.docs.map((m) =>
-    String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-  )
-  return { workspace: { in: workspaceIds } } as Where
-}
+export const workspaceScopedRead: Access = scopedRead()
 
-/** Create gated on owner/admin of the target workspace (data.workspace). */
-export const workspaceScopedManageCreate: Access = async ({ req: { user, payload }, data }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const workspaceId =
-    typeof data?.workspace === 'string' ? data.workspace : data?.workspace?.id
-  if (!workspaceId) return false
-  const members = await payload.find({
-    collection: 'workspace-members',
-    where: {
-      and: [
-        { workspace: { equals: workspaceId } },
-        { user: { equals: user.id } },
-        { role: { in: ['owner', 'admin'] } },
-        { status: { equals: 'active' } },
-      ],
-    },
-    limit: 1,
-    overrideAccess: true,
-  })
-  return members.docs.length > 0
-}
+/** Create gated on owner/admin of the target `data.workspace`. */
+export const workspaceScopedManageCreate: Access = manageCreate(['owner', 'admin'])
 
 /** Update/delete gated on owner/admin of the automation's workspace. */
-export const workspaceScopedManageMutate: Access = async ({ req: { user, payload }, id }) => {
-  if (!user || !id) return false
-  if (user.collection === 'users') return true
-  const doc = await payload.findByID({ collection: 'automations', id, overrideAccess: true })
-  const workspaceId = typeof doc.workspace === 'string' ? doc.workspace : doc.workspace?.id
-  if (!workspaceId) return false
-  const members = await payload.find({
-    collection: 'workspace-members',
-    where: {
-      and: [
-        { workspace: { equals: workspaceId } },
-        { user: { equals: user.id } },
-        { role: { in: ['owner', 'admin'] } },
-        { status: { equals: 'active' } },
-      ],
-    },
-    limit: 1,
-    overrideAccess: true,
-  })
-  return members.docs.length > 0
-}
+export const workspaceScopedManageMutate: Access = docWorkspaceMutate('automations', [
+  'owner',
+  'admin',
+])

--- a/orbit-www/src/collections/kafka/BifrostConfig.ts
+++ b/orbit-www/src/collections/kafka/BifrostConfig.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const BifrostConfig: CollectionConfig = {
   slug: 'bifrost-config',
@@ -8,20 +9,10 @@ export const BifrostConfig: CollectionConfig = {
     description: 'Bifrost gateway connection settings for Kafka clients',
   },
   access: {
-    // Only admins can read/write this singleton
-    read: ({ req: { user } }) => {
-      if (!user) return false
-      // System users (admins) have full access
-      return user.collection === 'users'
-    },
-    create: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    update: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
+    // Only platform admins can read/write this singleton
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
     delete: () => false, // Prevent deletion of singleton
   },
   fields: [

--- a/orbit-www/src/collections/kafka/KafkaApplicationQuotas.ts
+++ b/orbit-www/src/collections/kafka/KafkaApplicationQuotas.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 /**
  * KafkaApplicationQuotas - Workspace-level quota overrides
@@ -16,47 +17,13 @@ export const KafkaApplicationQuotas: CollectionConfig = {
     description: 'Workspace-level quota overrides for Kafka applications',
   },
   access: {
-    // Platform admins can read all quotas
-    // Workspace admins can read their own workspace quota
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Platform admins can see all
-      if (user.collection === 'users') return true
-
-      // Workspace admins can see their workspace quota
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-          role: { in: ['owner', 'admin'] },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      }
-    },
+    // Platform admins can read all quotas; workspace owner/admin can read
+    // their own workspace's quota.
+    read: workspaceScopedRead({ scope: 'manage' }),
     // Only platform admins can create/update/delete quotas
-    create: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    update: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    delete: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaApplicationRequests.ts
+++ b/orbit-www/src/collections/kafka/KafkaApplicationRequests.ts
@@ -1,5 +1,93 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
 import { afterChangeHook } from './hooks/applicationRequestHooks'
+import { memberCreate } from '@/lib/access/collection-access'
+import {
+  getAdminOrOwnerWorkspaceIds,
+  getMemberWorkspaceIds,
+  isPlatformAdmin,
+  isWorkspaceAdminOrOwner,
+} from '@/lib/access/workspace-access'
+
+// Read: users see (1) their own requests regardless of status, (2) requests
+// awaiting workspace-tier approval in workspaces they admin, and (3) all
+// requests (any status) in workspaces they're a member of, for audit.
+// `requestedBy` is a relationship to `users` (set from `req.user.id` in the
+// beforeChange hook below), so comparing against the Payload id is correct —
+// only the workspace-membership lookups needed the Better-Auth id fix.
+const readOwnOrWorkspaceRequests: Access = async ({ req: { user, payload } }) => {
+  if (!user) return false
+  if (isPlatformAdmin(user)) return true
+
+  const betterAuthId = typeof user.betterAuthId === 'string' ? user.betterAuthId : null
+  const [workspaceIds, adminWorkspaceIds] = betterAuthId
+    ? await Promise.all([
+        getMemberWorkspaceIds(payload, betterAuthId),
+        getAdminOrOwnerWorkspaceIds(payload, betterAuthId),
+      ])
+    : [[], []]
+
+  return {
+    or: [
+      { requestedBy: { equals: user.id } },
+      {
+        and: [
+          { workspace: { in: adminWorkspaceIds } },
+          { status: { equals: 'pending_workspace' } },
+        ],
+      },
+      { workspace: { in: workspaceIds } },
+    ],
+  } as Where
+}
+
+// Update: workspace owner/admin can act on a request only while it's still
+// awaiting workspace-tier approval; platform tier + terminal states are
+// handled elsewhere (server actions / hooks running with overrideAccess).
+const updateWhilePendingWorkspace: Access = async ({ req: { user, payload }, id }) => {
+  if (!user || !id) return false
+  if (isPlatformAdmin(user)) return true
+
+  const betterAuthId = typeof user.betterAuthId === 'string' ? user.betterAuthId : null
+  if (!betterAuthId) return false
+
+  const request = await payload.findByID({
+    collection: 'kafka-application-requests',
+    id: id as string,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (!request || request.status !== 'pending_workspace') return false
+
+  const workspaceId =
+    typeof request.workspace === 'string' ? request.workspace : (request.workspace as { id: string })?.id
+  if (!workspaceId) return false
+
+  return isWorkspaceAdminOrOwner(payload, betterAuthId, workspaceId)
+}
+
+// Delete: only the requester can cancel their own still-pending request.
+const deleteOwnPendingRequest: Access = async ({ req: { user, payload }, id }) => {
+  if (!user || !id) return false
+  if (isPlatformAdmin(user)) return true
+
+  const request = await payload.findByID({
+    collection: 'kafka-application-requests',
+    id: id as string,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (!request) return false
+
+  const requesterId =
+    typeof request.requestedBy === 'string'
+      ? request.requestedBy
+      : (request.requestedBy as { id: string })?.id
+
+  return (
+    requesterId === user.id &&
+    (request.status === 'pending_workspace' || request.status === 'pending_platform')
+  )
+}
 
 /**
  * KafkaApplicationRequests - Pending approval requests for Kafka applications
@@ -23,119 +111,13 @@ export const KafkaApplicationRequests: CollectionConfig = {
     // Users can see their own requests
     // Workspace admins can see workspace requests in pending_workspace
     // Platform admins can see all pending_platform requests
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Platform admins can see all
-      if (user.collection === 'users') return true
-
-      // Get user's workspace memberships
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      const adminWorkspaceIds = memberships.docs
-        .filter((m) => m.role === 'owner' || m.role === 'admin')
-        .map((m) => String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id))
-
-      // User can see:
-      // 1. Their own requests (any status)
-      // 2. Requests in workspaces they admin (pending_workspace status)
-      return {
-        or: [
-          { requestedBy: { equals: user.id } },
-          {
-            and: [
-              { workspace: { in: adminWorkspaceIds } },
-              { status: { equals: 'pending_workspace' } },
-            ],
-          },
-          // Also allow workspace admins to see approved/rejected for audit
-          {
-            and: [{ workspace: { in: workspaceIds } }],
-          },
-        ],
-      } as Where
-    },
-    // Any authenticated user can create a request
-    create: ({ req: { user } }) => !!user,
+    read: readOwnOrWorkspaceRequests,
+    // Any active member of the target workspace can create a request
+    create: memberCreate(),
     // Updates controlled by server actions - only allow through hooks
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Platform admins can update any
-      if (user.collection === 'users') return true
-
-      const request = await payload.findByID({
-        collection: 'kafka-application-requests',
-        id: id as string,
-        overrideAccess: true,
-      })
-
-      if (!request) return false
-
-      const workspaceId =
-        typeof request.workspace === 'string'
-          ? request.workspace
-          : (request.workspace as { id: string }).id
-
-      // Workspace admins can update requests in pending_workspace
-      if (request.status === 'pending_workspace') {
-        const members = await payload.find({
-          collection: 'workspace-members',
-          where: {
-            and: [
-              { workspace: { equals: workspaceId } },
-              { user: { equals: user.id } },
-              { role: { in: ['owner', 'admin'] } },
-              { status: { equals: 'active' } },
-            ],
-          },
-          limit: 1,
-          overrideAccess: true,
-        })
-
-        return members.docs.length > 0
-      }
-
-      return false
-    },
+    update: updateWhilePendingWorkspace,
     // Only requester can delete (cancel) their own pending request
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Platform admins can delete any
-      if (user.collection === 'users') return true
-
-      const request = await payload.findByID({
-        collection: 'kafka-application-requests',
-        id: id as string,
-        overrideAccess: true,
-      })
-
-      if (!request) return false
-
-      // Only requester can cancel, and only if still pending
-      const requesterId =
-        typeof request.requestedBy === 'string'
-          ? request.requestedBy
-          : (request.requestedBy as { id: string }).id
-
-      return (
-        requesterId === user.id &&
-        (request.status === 'pending_workspace' || request.status === 'pending_platform')
-      )
-    },
+    delete: deleteOwnPendingRequest,
   },
   fields: [
     // Application details (same as normal creation)

--- a/orbit-www/src/collections/kafka/KafkaApplications.ts
+++ b/orbit-www/src/collections/kafka/KafkaApplications.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { docWorkspaceMutate, memberCreate, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaApplications: CollectionConfig = {
   slug: 'kafka-applications',
@@ -9,98 +10,14 @@ export const KafkaApplications: CollectionConfig = {
     description: 'Kafka applications for self-service virtual clusters',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Admins can see all
-      if (user.collection === 'users') return true
-
-      // Regular users see only their workspace applications
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => !!user,
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Admins can update any
-      if (user.collection === 'users') return true
-
-      const app = await payload.findByID({
-        collection: 'kafka-applications',
-        id: id as string,
-        overrideAccess: true,
-      })
-
-      if (!app) return false
-
-      const workspaceId =
-        typeof app.workspace === 'string' ? app.workspace : (app.workspace as { id: string }).id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        limit: 1,
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-
-      // Admins can delete any
-      if (user.collection === 'users') return true
-
-      const app = await payload.findByID({
-        collection: 'kafka-applications',
-        id: id as string,
-        overrideAccess: true,
-      })
-
-      if (!app) return false
-
-      const workspaceId =
-        typeof app.workspace === 'string' ? app.workspace : (app.workspace as { id: string }).id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        limit: 1,
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
+    // Regular users see only their workspace applications
+    read: workspaceScopedRead(),
+    // Any active member of the target workspace may create an application
+    create: memberCreate(),
+    // Owner/admin of the app's workspace can update
+    update: docWorkspaceMutate('kafka-applications', ['owner', 'admin']),
+    // Owner/admin of the app's workspace can delete
+    delete: docWorkspaceMutate('kafka-applications', ['owner', 'admin']),
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaChargebackRates.ts
+++ b/orbit-www/src/collections/kafka/KafkaChargebackRates.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaChargebackRates: CollectionConfig = {
   slug: 'kafka-chargeback-rates',
@@ -10,10 +11,10 @@ export const KafkaChargebackRates: CollectionConfig = {
   },
   access: {
     // Only platform admins can manage rates
-    read: ({ req: { user } }) => user?.collection === 'users',
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaClientActivity.ts
+++ b/orbit-www/src/collections/kafka/KafkaClientActivity.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaClientActivity: CollectionConfig = {
   slug: 'kafka-client-activity',
@@ -10,32 +11,11 @@ export const KafkaClientActivity: CollectionConfig = {
   },
   access: {
     // Read: Users can see activity for topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
+    read: workspaceScopedRead(),
     // Activity is system-generated
-    create: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
     update: () => false, // Activity logs are immutable
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaClusters.ts
+++ b/orbit-www/src/collections/kafka/KafkaClusters.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaClusters: CollectionConfig = {
   slug: 'kafka-clusters',
@@ -9,11 +10,11 @@ export const KafkaClusters: CollectionConfig = {
     description: 'Registered Kafka clusters managed by platform team',
   },
   access: {
-    // Only admins can see cluster details (contains sensitive config)
-    read: ({ req: { user } }) => user?.collection === 'users',
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    // Only platform admins can see cluster details (contains sensitive config)
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaConsumerGroupLagHistory.ts
+++ b/orbit-www/src/collections/kafka/KafkaConsumerGroupLagHistory.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaConsumerGroupLagHistory: CollectionConfig = {
   slug: 'kafka-consumer-group-lag-history',
@@ -9,31 +10,10 @@ export const KafkaConsumerGroupLagHistory: CollectionConfig = {
     description: 'Historical lag snapshots for consumer groups',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    read: workspaceScopedRead(),
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaConsumerGroups.ts
+++ b/orbit-www/src/collections/kafka/KafkaConsumerGroups.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaConsumerGroups: CollectionConfig = {
   slug: 'kafka-consumer-groups',
@@ -10,32 +11,11 @@ export const KafkaConsumerGroups: CollectionConfig = {
   },
   access: {
     // Read: Users can see consumer groups for topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
+    read: workspaceScopedRead(),
     // Consumer groups are discovered automatically
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaEnvironmentMappings.ts
+++ b/orbit-www/src/collections/kafka/KafkaEnvironmentMappings.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaEnvironmentMappings: CollectionConfig = {
   slug: 'kafka-environment-mappings',
@@ -9,11 +10,11 @@ export const KafkaEnvironmentMappings: CollectionConfig = {
     description: 'Maps environments to Kafka clusters',
   },
   access: {
-    // Only admins can manage environment mappings
-    read: ({ req: { user } }) => user?.collection === 'users',
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    // Only platform admins can manage environment mappings
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaLineageEdge.ts
+++ b/orbit-www/src/collections/kafka/KafkaLineageEdge.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaLineageEdge: CollectionConfig = {
   slug: 'kafka-lineage-edges',
@@ -9,38 +10,13 @@ export const KafkaLineageEdge: CollectionConfig = {
     description: 'Aggregated data flow relationships between applications and topics',
   },
   access: {
-    // Read: Users can see edges for topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // User can see edges where they own the topic (targetWorkspace)
-      // or where their application is the source (sourceWorkspace)
-      return {
-        or: [
-          { targetWorkspace: { in: workspaceIds } },
-          { sourceWorkspace: { in: workspaceIds } },
-        ],
-      } as Where
-    },
+    // Read: Users can see edges where they own the topic (targetWorkspace)
+    // or where their application is the source (sourceWorkspace)
+    read: workspaceScopedRead({ fields: ['sourceWorkspace', 'targetWorkspace'] }),
     // Lineage edges are system-generated only
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     // Source fields (who is producing/consuming)

--- a/orbit-www/src/collections/kafka/KafkaLineageSnapshot.ts
+++ b/orbit-www/src/collections/kafka/KafkaLineageSnapshot.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaLineageSnapshot: CollectionConfig = {
   slug: 'kafka-lineage-snapshots',
@@ -10,32 +11,11 @@ export const KafkaLineageSnapshot: CollectionConfig = {
   },
   access: {
     // Read: Users can see snapshots for topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
+    read: workspaceScopedRead(),
     // Snapshots are system-generated only
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaOffsetCheckpoints.ts
+++ b/orbit-www/src/collections/kafka/KafkaOffsetCheckpoints.ts
@@ -1,4 +1,46 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
+import { getMemberWorkspaceIds, isPlatformAdmin } from '@/lib/access/workspace-access'
+
+// No direct `workspace` relation on this collection — the workspace is
+// resolved indirectly via virtualCluster → application → workspace. The
+// shared `workspaceScopedRead()` factory only supports direct/OR fields, so
+// this two-hop resolution is hand-rolled here (flagged in the WP2 report).
+const readCheckpointsForMemberWorkspaces: Access = async ({ req: { user, payload } }) => {
+  if (!user) return false
+  if (isPlatformAdmin(user)) return true
+
+  const betterAuthId = typeof user.betterAuthId === 'string' ? user.betterAuthId : null
+  const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+
+  // Find applications in user's workspaces
+  const apps = await payload.find({
+    collection: 'kafka-applications',
+    where: {
+      workspace: { in: workspaceIds },
+    },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  const appIds = apps.docs.map((a) => a.id)
+
+  // Find virtual clusters for those applications
+  const virtualClusters = await payload.find({
+    collection: 'kafka-virtual-clusters',
+    where: {
+      application: { in: appIds },
+    },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  const virtualClusterIds = virtualClusters.docs.map((vc) => vc.id)
+
+  return {
+    virtualCluster: { in: virtualClusterIds },
+  } as Where
+}
 
 export const KafkaOffsetCheckpoints: CollectionConfig = {
   slug: 'kafka-offset-checkpoints',
@@ -10,59 +52,11 @@ export const KafkaOffsetCheckpoints: CollectionConfig = {
   },
   access: {
     // Read: Users can see checkpoints for consumer groups in their workspace's virtual clusters
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Admin users can see all
-      if (user.collection === 'users') return true
-
-      // Regular users see only checkpoints for consumer groups in their workspace's virtual clusters
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Find applications in user's workspaces
-      const apps = await payload.find({
-        collection: 'kafka-applications',
-        where: {
-          workspace: { in: workspaceIds },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const appIds = apps.docs.map((a) => a.id)
-
-      // Find virtual clusters for those applications
-      const virtualClusters = await payload.find({
-        collection: 'kafka-virtual-clusters',
-        where: {
-          application: { in: appIds },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const virtualClusterIds = virtualClusters.docs.map((vc) => vc.id)
-
-      return {
-        virtualCluster: { in: virtualClusterIds },
-      } as Where
-    },
+    read: readCheckpointsForMemberWorkspaces,
     // Offset checkpoints are system/workflow-driven only
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaProviders.ts
+++ b/orbit-www/src/collections/kafka/KafkaProviders.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaProviders: CollectionConfig = {
   slug: 'kafka-providers',
@@ -9,12 +10,15 @@ export const KafkaProviders: CollectionConfig = {
     description: 'System-managed Kafka provider definitions',
   },
   access: {
-    // Everyone can read provider definitions
-    read: () => true,
-    // Only admins can manage providers
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    // Any authenticated user can read provider definitions — non-sensitive,
+    // enum-like reference data (adapter names/capabilities), not
+    // workspace-scoped, so no membership check is needed. Not public: an
+    // internal IDP has no legitimate anonymous consumer (UAC-4).
+    read: ({ req: { user } }) => !!user,
+    // Only platform admins can manage providers
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaSchemaVersions.ts
+++ b/orbit-www/src/collections/kafka/KafkaSchemaVersions.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaSchemaVersions: CollectionConfig = {
   slug: 'kafka-schema-versions',
@@ -9,31 +10,10 @@ export const KafkaSchemaVersions: CollectionConfig = {
     description: 'Historical versions of Kafka schemas',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => user?.collection === 'users',
-    update: ({ req: { user } }) => user?.collection === 'users',
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    read: workspaceScopedRead(),
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaSchemas.ts
+++ b/orbit-www/src/collections/kafka/KafkaSchemas.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { docWorkspaceMutate, memberCreate, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaSchemas: CollectionConfig = {
   slug: 'kafka-schemas',
@@ -10,83 +11,11 @@ export const KafkaSchemas: CollectionConfig = {
   },
   access: {
     // Read: Users can see schemas in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => !!user,
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const schema = await payload.findByID({
-        collection: 'kafka-schemas',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof schema.workspace === 'string' ? schema.workspace : schema.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const schema = await payload.findByID({
-        collection: 'kafka-schemas',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof schema.workspace === 'string' ? schema.workspace : schema.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
+    read: workspaceScopedRead(),
+    // Any active member of the target workspace may register a schema
+    create: memberCreate(),
+    update: docWorkspaceMutate('kafka-schemas', ['owner', 'admin', 'member']),
+    delete: docWorkspaceMutate('kafka-schemas', ['owner', 'admin']),
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaServiceAccounts.ts
+++ b/orbit-www/src/collections/kafka/KafkaServiceAccounts.ts
@@ -1,5 +1,63 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
 import crypto from 'crypto'
+import { docWorkspaceMutate, manageCreate } from '@/lib/access/collection-access'
+import { getMemberWorkspaceIds, isPlatformAdmin } from '@/lib/access/workspace-access'
+
+/** Normalize a relationship value (`string` id or populated `{ id }`) to its id. */
+function relationId(value: unknown): string | null {
+  if (!value) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && 'id' in (value as Record<string, unknown>)) {
+    const id = (value as { id?: unknown }).id
+    return typeof id === 'string' ? id : null
+  }
+  return null
+}
+
+// Read: no direct workspace relation — resolved indirectly via the parent
+// `application`. Users see service accounts belonging to applications in
+// their member workspaces.
+const readServiceAccountsForMemberWorkspaces: Access = async ({ req: { user, payload } }) => {
+  if (!user) return false
+  if (isPlatformAdmin(user)) return true
+
+  const betterAuthId = typeof user.betterAuthId === 'string' ? user.betterAuthId : null
+  const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+
+  // Find applications in user's workspaces
+  const apps = await payload.find({
+    collection: 'kafka-applications',
+    where: {
+      workspace: { in: workspaceIds },
+    },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  const appIds = apps.docs.map((a) => a.id)
+
+  return {
+    application: { in: appIds },
+  } as Where
+}
+
+// Resolves the workspace owning the `application` (or `virtualCluster`)
+// referenced on the incoming data/doc, for create/update gating.
+async function resolveServiceAccountWorkspace(
+  payload: import('payload').Payload,
+  appOrClusterRef: unknown,
+): Promise<string | null> {
+  const appId = relationId(appOrClusterRef)
+  if (!appId) return null
+  const app = await payload.findByID({
+    collection: 'kafka-applications',
+    id: appId,
+    depth: 0,
+    overrideAccess: true,
+  })
+  if (!app) return null
+  return relationId(app.workspace)
+}
 
 export const KafkaServiceAccounts: CollectionConfig = {
   slug: 'kafka-service-accounts',
@@ -10,87 +68,21 @@ export const KafkaServiceAccounts: CollectionConfig = {
     description: 'Service accounts for Kafka authentication',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection !== 'users') return false
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Find applications in user's workspaces
-      const apps = await payload.find({
-        collection: 'kafka-applications',
-        where: {
-          workspace: { in: workspaceIds },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const appIds = apps.docs.map((a) => a.id)
-
-      return {
-        application: { in: appIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => !!user && user.collection === 'users',
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id || user.collection !== 'users') return false
-
-      const serviceAccount = await payload.findByID({
-        collection: 'kafka-service-accounts',
-        id: id as string,
-        overrideAccess: true,
-      })
-
-      if (!serviceAccount) return false
-
-      const appId = typeof serviceAccount.application === 'string'
-        ? serviceAccount.application
-        : serviceAccount.application.id
-
-      const app = await payload.findByID({
-        collection: 'kafka-applications',
-        id: appId,
-        overrideAccess: true,
-      })
-
-      if (!app) return false
-
-      const workspaceId = typeof app.workspace === 'string' ? app.workspace : app.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        limit: 1,
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    delete: async ({ req: { user } }) => {
-      // Soft delete via revoke instead of hard delete
-      if (!user || user.collection !== 'users') return false
-      return false
-    },
+    read: readServiceAccountsForMemberWorkspaces,
+    // Owner/admin of the workspace that owns the referenced application
+    create: manageCreate(['owner', 'admin'], {
+      field: 'application',
+      resolveWorkspace: ({ data, payload }) =>
+        resolveServiceAccountWorkspace(payload, (data as Record<string, unknown> | undefined)?.application),
+    }),
+    // Owner/admin of the workspace that owns the service account's application
+    update: docWorkspaceMutate('kafka-service-accounts', ['owner', 'admin'], {
+      field: 'application',
+      resolveWorkspace: ({ doc, payload }) =>
+        resolveServiceAccountWorkspace(payload, (doc as Record<string, unknown> | undefined)?.application),
+    }),
+    // Soft delete via revoke instead of hard delete
+    delete: () => false,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaTopicPolicies.ts
+++ b/orbit-www/src/collections/kafka/KafkaTopicPolicies.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaTopicPolicies: CollectionConfig = {
   slug: 'kafka-topic-policies',
@@ -9,23 +10,12 @@ export const KafkaTopicPolicies: CollectionConfig = {
     description: 'Guardrails and policies for topic creation',
   },
   access: {
-    // Platform admins manage policies
-    read: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    create: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    update: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    delete: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
+    // Platform admins manage policies. The `workspace` field is not yet used
+    // to scope access — workspace-scoping these policies is a follow-up.
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaTopicSharePolicies.ts
+++ b/orbit-www/src/collections/kafka/KafkaTopicSharePolicies.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
 
 export const KafkaTopicSharePolicies: CollectionConfig = {
   slug: 'kafka-topic-share-policies',
@@ -9,23 +10,12 @@ export const KafkaTopicSharePolicies: CollectionConfig = {
     description: 'Policies controlling topic sharing behavior',
   },
   access: {
-    // Platform admins manage policies (can be expanded for workspace-level)
-    read: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    create: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    update: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
-    delete: ({ req: { user } }) => {
-      if (!user) return false
-      return user.collection === 'users'
-    },
+    // Platform admins manage policies. The `workspace` field is not yet used
+    // to scope access — workspace-scoping these policies is a follow-up.
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaTopicShares.ts
+++ b/orbit-www/src/collections/kafka/KafkaTopicShares.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { docWorkspaceMutate, manageCreate, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaTopicShares: CollectionConfig = {
   slug: 'kafka-topic-shares',
@@ -10,108 +11,12 @@ export const KafkaTopicShares: CollectionConfig = {
   },
   access: {
     // Read: Users can see shares involving their workspaces (as owner or target)
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        or: [
-          { ownerWorkspace: { in: workspaceIds } },
-          { targetWorkspace: { in: workspaceIds } },
-        ],
-      } as Where
-    },
-    // Create: Only workspace admins can create shares (from owner workspace)
-    create: async ({ req: { user, payload }, data }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      if (!data?.ownerWorkspace) return false
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: data.ownerWorkspace } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    // Update: Only owner workspace admins can update shares
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const share = await payload.findByID({
-        collection: 'kafka-topic-shares',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof share.ownerWorkspace === 'string' ? share.ownerWorkspace : share.ownerWorkspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const share = await payload.findByID({
-        collection: 'kafka-topic-shares',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof share.ownerWorkspace === 'string' ? share.ownerWorkspace : share.ownerWorkspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
+    read: workspaceScopedRead({ fields: ['ownerWorkspace', 'targetWorkspace'] }),
+    // Create: Only owner-workspace admins can create shares (from owner workspace)
+    create: manageCreate(['owner', 'admin'], { field: 'ownerWorkspace' }),
+    // Update: Only owner-workspace admins can update shares
+    update: docWorkspaceMutate('kafka-topic-shares', ['owner', 'admin'], { field: 'ownerWorkspace' }),
+    delete: docWorkspaceMutate('kafka-topic-shares', ['owner', 'admin'], { field: 'ownerWorkspace' }),
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaTopics.ts
+++ b/orbit-www/src/collections/kafka/KafkaTopics.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { docWorkspaceMutate, memberCreate, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaTopics: CollectionConfig = {
   slug: 'kafka-topics',
@@ -10,83 +11,11 @@ export const KafkaTopics: CollectionConfig = {
   },
   access: {
     // Read: Users can see topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
-    create: ({ req: { user } }) => !!user,
-    update: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const topic = await payload.findByID({
-        collection: 'kafka-topics',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof topic.workspace === 'string' ? topic.workspace : topic.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin', 'member'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
-    delete: async ({ req: { user, payload }, id }) => {
-      if (!user || !id) return false
-      if (user.collection === 'users') return true
-
-      const topic = await payload.findByID({
-        collection: 'kafka-topics',
-        id,
-        overrideAccess: true,
-      })
-
-      const workspaceId = typeof topic.workspace === 'string' ? topic.workspace : topic.workspace.id
-
-      const members = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          and: [
-            { workspace: { equals: workspaceId } },
-            { user: { equals: user.id } },
-            { role: { in: ['owner', 'admin'] } },
-            { status: { equals: 'active' } },
-          ],
-        },
-        overrideAccess: true,
-      })
-
-      return members.docs.length > 0
-    },
+    read: workspaceScopedRead(),
+    // Any active member of the target workspace may create a topic
+    create: memberCreate(),
+    update: docWorkspaceMutate('kafka-topics', ['owner', 'admin', 'member']),
+    delete: docWorkspaceMutate('kafka-topics', ['owner', 'admin']),
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaUsageMetrics.ts
+++ b/orbit-www/src/collections/kafka/KafkaUsageMetrics.ts
@@ -1,4 +1,5 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { CollectionConfig } from 'payload'
+import { adminOnly, workspaceScopedRead } from '@/lib/access/collection-access'
 
 export const KafkaUsageMetrics: CollectionConfig = {
   slug: 'kafka-usage-metrics',
@@ -10,32 +11,11 @@ export const KafkaUsageMetrics: CollectionConfig = {
   },
   access: {
     // Read: Users can see metrics for topics in their workspaces
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-      if (user.collection === 'users') return true
-
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map(m =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      return {
-        workspace: { in: workspaceIds },
-      } as Where
-    },
+    read: workspaceScopedRead(),
     // Metrics are system-generated
-    create: ({ req: { user } }) => user?.collection === 'users',
+    create: adminOnly,
     update: () => false, // Metrics are immutable
-    delete: ({ req: { user } }) => user?.collection === 'users',
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/kafka/KafkaVirtualClusters.ts
+++ b/orbit-www/src/collections/kafka/KafkaVirtualClusters.ts
@@ -1,4 +1,40 @@
-import type { CollectionConfig, Where } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
+import { adminOnly } from '@/lib/access/collection-access'
+import { getMemberWorkspaceIds, isPlatformAdmin } from '@/lib/access/workspace-access'
+
+// Read: direct workspace ownership, OR (legacy) an application owned by one
+// of the caller's workspaces. Some older virtual-cluster docs only set
+// `application`, not `workspace` — preserved via a 2-hop lookup so those
+// stay visible to their workspace members (identity fixed to betterAuthId).
+const readOwnedOrLegacyApplicationClusters: Access = async ({ req: { user, payload } }) => {
+  if (!user) return false
+  if (isPlatformAdmin(user)) return true
+
+  const betterAuthId = typeof user.betterAuthId === 'string' ? user.betterAuthId : null
+  const workspaceIds = betterAuthId ? await getMemberWorkspaceIds(payload, betterAuthId) : []
+
+  // Find applications in user's workspaces (for backward compat)
+  const apps = await payload.find({
+    collection: 'kafka-applications',
+    where: {
+      workspace: { in: workspaceIds },
+    },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  const appIds = apps.docs.map((a) => a.id)
+
+  // Return clusters that either:
+  // 1. Have direct workspace ownership, OR
+  // 2. Belong to an application in user's workspaces (legacy)
+  return {
+    or: [
+      { workspace: { in: workspaceIds } },
+      { application: { in: appIds } },
+    ],
+  } as Where
+}
 
 export const KafkaVirtualClusters: CollectionConfig = {
   slug: 'kafka-virtual-clusters',
@@ -9,59 +45,11 @@ export const KafkaVirtualClusters: CollectionConfig = {
     description: 'Virtual clusters for Kafka applications (one per environment)',
   },
   access: {
-    read: async ({ req: { user, payload } }) => {
-      if (!user) return false
-
-      // Admins can see all
-      if (user.collection === 'users') return true
-
-      // Regular users see only virtual clusters for their workspaces
-      const memberships = await payload.find({
-        collection: 'workspace-members',
-        where: {
-          user: { equals: user.id },
-          status: { equals: 'active' },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const workspaceIds = memberships.docs.map((m) =>
-        String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id)
-      )
-
-      // Find applications in user's workspaces (for backward compat)
-      const apps = await payload.find({
-        collection: 'kafka-applications',
-        where: {
-          workspace: { in: workspaceIds },
-        },
-        limit: 1000,
-        overrideAccess: true,
-      })
-
-      const appIds = apps.docs.map((a) => a.id)
-
-      // Return clusters that either:
-      // 1. Have direct workspace ownership, OR
-      // 2. Belong to an application in user's workspaces (legacy)
-      return {
-        or: [
-          { workspace: { in: workspaceIds } },
-          { application: { in: appIds } },
-        ],
-      } as Where
-    },
-    create: ({ req: { user } }) => {
-      // Only system/workflows can create virtual clusters
-      return user?.collection === 'users'
-    },
-    update: ({ req: { user } }) => {
-      return user?.collection === 'users'
-    },
-    delete: ({ req: { user } }) => {
-      return user?.collection === 'users'
-    },
+    read: readOwnedOrLegacyApplicationClusters,
+    // Only system/workflows can create virtual clusters
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
   },
   fields: [
     {

--- a/orbit-www/src/collections/scorecards/access.ts
+++ b/orbit-www/src/collections/scorecards/access.ts
@@ -1,85 +1,27 @@
-import type { Access, Where } from 'payload'
+import type { Access } from 'payload'
+import {
+  workspaceScopedRead as scopedRead,
+  memberCreate,
+  manageCreate,
+  docWorkspaceMutate,
+} from '@/lib/access/collection-access'
 
 /**
- * Shared workspace-scoped access for the scorecards collections (IDP refocus P2).
- *
- * Same security model as apps/catalog-entities (the tenant boundary is the
- * caller's active workspace memberships), factored into one place because all
- * five scorecard collections carry a `workspace` relationship and use the
- * identical pattern. Payload admin users (user.collection === 'users') see/do
- * everything; the Temporal/eval writebacks run with overrideAccess.
+ * Workspace-scoped access for the scorecards collections — thin adapters over
+ * the shared `@/lib/access/collection-access` factories (issue #63). The tenant
+ * boundary is the caller's active workspace memberships, keyed on the
+ * Better-Auth id. The only bypass is a platform admin (role super_admin/admin);
+ * Temporal/eval writebacks run with overrideAccess and bypass these rules.
  */
 
-export const workspaceScopedRead: Access = async ({ req: { user, payload } }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const memberships = await payload.find({
-    collection: 'workspace-members',
-    where: { user: { equals: user.id }, status: { equals: 'active' } },
-    limit: 1000,
-    overrideAccess: true,
-  })
-  const workspaceIds = memberships.docs.map((m) =>
-    String(typeof m.workspace === 'string' ? m.workspace : m.workspace.id),
-  )
-  return { workspace: { in: workspaceIds } } as Where
-}
+export const workspaceScopedRead: Access = scopedRead()
 
-export const workspaceScopedCreate: Access = ({ req: { user } }) => !!user
+/** Create allowed for any active member of the target `data.workspace`. */
+export const workspaceScopedCreate: Access = memberCreate()
 
-/**
- * Create access for standards-authoring collections (scorecards, rules): the
- * caller must be an active owner/admin of the workspace named in the incoming
- * `data.workspace`. Payload admins and overrideAccess (eval runner / seed)
- * bypass. Mirrors the `canManageScorecards` policy at the collection layer.
- */
-export const workspaceScopedManageCreate: Access = async ({ req: { user, payload }, data }) => {
-  if (!user) return false
-  if (user.collection === 'users') return true
-  const workspaceId =
-    typeof data?.workspace === 'string' ? data.workspace : data?.workspace?.id
-  if (!workspaceId) return false
-  const members = await payload.find({
-    collection: 'workspace-members',
-    where: {
-      and: [
-        { workspace: { equals: workspaceId } },
-        { user: { equals: user.id } },
-        { role: { in: ['owner', 'admin'] } },
-        { status: { equals: 'active' } },
-      ],
-    },
-    limit: 1,
-    overrideAccess: true,
-  })
-  return members.docs.length > 0
-}
+/** Create for standards-authoring collections: owner/admin of `data.workspace`. */
+export const workspaceScopedManageCreate: Access = manageCreate(['owner', 'admin'])
 
-/**
- * Factory for update/delete: caller must be an active member of the doc's
- * workspace with one of `roles`.
- */
-export const workspaceScopedMutate =
-  (slug: string, roles: string[]): Access =>
-  async ({ req: { user, payload }, id }) => {
-    if (!user || !id) return false
-    if (user.collection === 'users') return true
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = await payload.findByID({ collection: slug as any, id, overrideAccess: true })
-    const workspaceId =
-      typeof doc.workspace === 'string' ? doc.workspace : doc.workspace?.id
-    if (!workspaceId) return false
-    const members = await payload.find({
-      collection: 'workspace-members',
-      where: {
-        and: [
-          { workspace: { equals: workspaceId } },
-          { user: { equals: user.id } },
-          { role: { in: roles } },
-          { status: { equals: 'active' } },
-        ],
-      },
-      overrideAccess: true,
-    })
-    return members.docs.length > 0
-  }
+/** Update/delete: active member of the doc's workspace holding one of `roles`. */
+export const workspaceScopedMutate = (slug: string, roles: string[]): Access =>
+  docWorkspaceMutate(slug, roles)

--- a/orbit-www/src/lib/access/__tests__/collection-access.test.ts
+++ b/orbit-www/src/lib/access/__tests__/collection-access.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Access, Payload } from 'payload'
+import {
+  adminOnly,
+  workspaceScopedRead,
+  memberCreate,
+  manageCreate,
+  docWorkspaceMutate,
+  type DocWorkspaceResolver,
+} from '../collection-access'
+import * as scorecards from '@/collections/scorecards/access'
+import * as actions from '@/collections/actions/access'
+import * as automations from '@/collections/automations/access'
+
+/**
+ * Hand-rolled payload mock (mirrors src/lib/catalog/entity-authz.test.ts). `members`
+ * is the workspace-member fixture the `workspace-members` collection returns; the
+ * mock filters it against the `where.and` clauses the shared helpers build. `byId`
+ * backs `findByID` for the doc-mutate factory and its indirect resolvers.
+ */
+type MemberDoc = { workspace: string; user: string; role: string; status: string }
+
+function makePayload(members: MemberDoc[], byId: Record<string, unknown> = {}) {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const find = vi.fn(async (args: any) => {
+    if (args.collection !== 'workspace-members') return { docs: [] }
+    const and: any[] = args.where?.and ?? []
+    const filtered = members.filter((m) =>
+      and.every((cond) => {
+        if (cond.workspace) return m.workspace === cond.workspace.equals
+        if (cond.user) return m.user === cond.user.equals
+        if (cond.status) return m.status === cond.status.equals
+        if (cond.role?.equals) return m.role === cond.role.equals
+        if (cond.role?.in) return cond.role.in.includes(m.role)
+        return true
+      }),
+    )
+    return { docs: filtered }
+  })
+  const findByID = vi.fn(async (args: any) => {
+    const doc = byId[args.id]
+    if (!doc) throw new Error('not found')
+    return doc
+  })
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  return { payload: { find, findByID } as unknown as Payload, find, findByID }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const invoke = (
+  access: Access,
+  ctx: { user?: unknown; payload?: Payload; data?: unknown; id?: unknown },
+) => access({ req: { user: ctx.user, payload: ctx.payload }, data: ctx.data, id: ctx.id } as any)
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const member = (role: string, workspace = 'ws-1', user = 'ba-1'): MemberDoc => ({
+  workspace,
+  user,
+  role,
+  status: 'active',
+})
+
+// id and betterAuthId deliberately differ: membership queries MUST key on
+// betterAuthId, never the Payload doc id (bug-2 regression guard).
+const plainUser = { id: 'payload-1', betterAuthId: 'ba-1', role: 'user', collection: 'users' }
+const superAdmin = { id: 'payload-9', betterAuthId: 'ba-9', role: 'super_admin', collection: 'users' }
+const adminUser = { id: 'payload-8', betterAuthId: 'ba-8', role: 'admin', collection: 'users' }
+
+describe('adminOnly', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('grants platform admins (super_admin, admin)', () => {
+    expect(invoke(adminOnly, { user: superAdmin })).toBe(true)
+    expect(invoke(adminOnly, { user: adminUser })).toBe(true)
+  })
+
+  it('denies role:user (bug-1 regression guard: no bypass for a plain users-collection account)', () => {
+    expect(invoke(adminOnly, { user: plainUser })).toBe(false)
+  })
+
+  it('denies anonymous', () => {
+    expect(invoke(adminOnly, { user: null })).toBe(false)
+  })
+})
+
+describe('workspaceScopedRead', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('denies anonymous', async () => {
+    const { payload, find } = makePayload([])
+    expect(await invoke(workspaceScopedRead(), { user: null, payload })).toBe(false)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('returns true for a platform admin without a membership query', async () => {
+    const { payload, find } = makePayload([])
+    expect(await invoke(workspaceScopedRead(), { user: superAdmin, payload })).toBe(true)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('role:user gets a workspace filter, never true (bug-1 regression guard)', async () => {
+    const { payload } = makePayload([member('member')])
+    const result = await invoke(workspaceScopedRead(), { user: plainUser, payload })
+    expect(result).toEqual({ workspace: { in: ['ws-1'] } })
+  })
+
+  it('keys the membership query on betterAuthId, not the Payload doc id (bug-2 regression guard)', async () => {
+    const { payload, find } = makePayload([member('member')])
+    await invoke(workspaceScopedRead(), { user: plainUser, payload })
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'workspace-members',
+        where: expect.objectContaining({
+          and: expect.arrayContaining([{ user: { equals: 'ba-1' } }]),
+        }),
+      }),
+    )
+  })
+
+  it('filters a non-member to an empty set', async () => {
+    const { payload } = makePayload([member('member', 'ws-1', 'ba-OTHER')])
+    expect(await invoke(workspaceScopedRead(), { user: plainUser, payload })).toEqual({
+      workspace: { in: [] },
+    })
+  })
+
+  it('supports a custom field name', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(workspaceScopedRead({ field: 'ownerWorkspace' }), { user: plainUser, payload }),
+    ).toEqual({ ownerWorkspace: { in: ['ws-1'] } })
+  })
+
+  it('ORs a multi-field filter (KafkaLineageEdge / KafkaTopicShares shape)', async () => {
+    const { payload } = makePayload([member('member', 'ws-1'), member('member', 'ws-2')])
+    expect(
+      await invoke(workspaceScopedRead({ fields: ['sourceWorkspace', 'targetWorkspace'] }), {
+        user: plainUser,
+        payload,
+      }),
+    ).toEqual({
+      or: [{ sourceWorkspace: { in: ['ws-1', 'ws-2'] } }, { targetWorkspace: { in: ['ws-1', 'ws-2'] } }],
+    })
+  })
+
+  it('role-restricted variant reads only owner/admin workspaces (KafkaApplicationQuotas)', async () => {
+    const { payload } = makePayload([member('member', 'ws-1'), member('owner', 'ws-2')])
+    expect(await invoke(workspaceScopedRead({ scope: 'manage' }), { user: plainUser, payload })).toEqual({
+      workspace: { in: ['ws-2'] },
+    })
+  })
+
+  it('missing betterAuthId yields an empty filter without querying', async () => {
+    const { payload, find } = makePayload([member('member')])
+    expect(
+      await invoke(workspaceScopedRead(), { user: { ...plainUser, betterAuthId: undefined }, payload }),
+    ).toEqual({ workspace: { in: [] } })
+    expect(find).not.toHaveBeenCalled()
+  })
+})
+
+describe('memberCreate', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('denies anonymous', async () => {
+    const { payload } = makePayload([])
+    expect(await invoke(memberCreate(), { user: null, payload, data: { workspace: 'ws-1' } })).toBe(false)
+  })
+
+  it('grants a platform admin without a query', async () => {
+    const { payload, find } = makePayload([])
+    expect(await invoke(memberCreate(), { user: superAdmin, payload, data: { workspace: 'ws-1' } })).toBe(
+      true,
+    )
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('grants an active member (any role) of data.workspace', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(await invoke(memberCreate(), { user: plainUser, payload, data: { workspace: 'ws-1' } })).toBe(
+      true,
+    )
+  })
+
+  it('denies a non-member of data.workspace', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(await invoke(memberCreate(), { user: plainUser, payload, data: { workspace: 'ws-2' } })).toBe(
+      false,
+    )
+  })
+
+  it('denies a non-admin when data.workspace is missing/null', async () => {
+    const { payload } = makePayload([member('owner')])
+    expect(await invoke(memberCreate(), { user: plainUser, payload, data: {} })).toBe(false)
+    expect(await invoke(memberCreate(), { user: plainUser, payload, data: { workspace: null } })).toBe(
+      false,
+    )
+  })
+
+  it('keys the membership query on betterAuthId (bug-2 regression guard)', async () => {
+    const { payload, find } = makePayload([member('member')])
+    await invoke(memberCreate(), { user: plainUser, payload, data: { workspace: 'ws-1' } })
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          and: expect.arrayContaining([{ user: { equals: 'ba-1' } }]),
+        }),
+      }),
+    )
+  })
+
+  it('supports a custom workspace field (ownerWorkspace)', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(memberCreate({ field: 'ownerWorkspace' }), {
+        user: plainUser,
+        payload,
+        data: { ownerWorkspace: 'ws-1' },
+      }),
+    ).toBe(true)
+  })
+
+  it('missing betterAuthId is treated as non-member (deny, no throw)', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(memberCreate(), {
+        user: { ...plainUser, betterAuthId: undefined },
+        payload,
+        data: { workspace: 'ws-1' },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('manageCreate', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('grants an owner/admin of data.workspace', async () => {
+    const { payload } = makePayload([member('admin')])
+    expect(
+      await invoke(manageCreate(['owner', 'admin']), { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(true)
+  })
+
+  it('denies a plain member (role gating: manage-create needs owner/admin)', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(manageCreate(['owner', 'admin']), { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(false)
+  })
+
+  it('grants a platform admin without a query', async () => {
+    const { payload, find } = makePayload([])
+    expect(
+      await invoke(manageCreate(['owner', 'admin']), { user: adminUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(true)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('denies a non-admin with missing data.workspace', async () => {
+    const { payload } = makePayload([member('owner')])
+    expect(await invoke(manageCreate(['owner', 'admin']), { user: plainUser, payload, data: {} })).toBe(false)
+  })
+})
+
+describe('docWorkspaceMutate', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('denies anonymous and missing id', async () => {
+    const { payload } = makePayload([])
+    expect(await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: null, payload, id: 'd1' })).toBe(
+      false,
+    )
+    expect(
+      await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: plainUser, payload }),
+    ).toBe(false)
+  })
+
+  it('grants a platform admin without loading the doc', async () => {
+    const { payload, findByID } = makePayload([])
+    expect(
+      await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: superAdmin, payload, id: 'd1' }),
+    ).toBe(true)
+    expect(findByID).not.toHaveBeenCalled()
+  })
+
+  it('grants an owner/admin of the doc workspace (direct field default)', async () => {
+    const { payload } = makePayload([member('admin')], { d1: { id: 'd1', workspace: 'ws-1' } })
+    expect(
+      await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: plainUser, payload, id: 'd1' }),
+    ).toBe(true)
+  })
+
+  it('denies a plain member when roles require owner/admin', async () => {
+    const { payload } = makePayload([member('member')], { d1: { id: 'd1', workspace: 'ws-1' } })
+    expect(
+      await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: plainUser, payload, id: 'd1' }),
+    ).toBe(false)
+  })
+
+  it('denies when the doc has no workspace', async () => {
+    const { payload } = makePayload([member('owner')], { d1: { id: 'd1' } })
+    expect(
+      await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: plainUser, payload, id: 'd1' }),
+    ).toBe(false)
+  })
+
+  it('resolves an indirect workspace via a custom resolver (KafkaOffsetCheckpoints shape)', async () => {
+    // doc -> virtualCluster -> application -> workspace
+    const byId = {
+      chk1: { id: 'chk1', virtualCluster: 'vc1' },
+      vc1: { id: 'vc1', application: 'app1' },
+      app1: { id: 'app1', workspace: 'ws-1' },
+    }
+    const { payload, findByID } = makePayload([member('owner')], byId)
+    const load = (id: string) =>
+      payload.findByID({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        collection: 'kafka' as any,
+        id,
+        overrideAccess: true,
+      }) as Promise<Record<string, string>>
+    const resolveWorkspace: DocWorkspaceResolver = async ({ doc }) => {
+      const vc = await load((doc as Record<string, string>).virtualCluster)
+      const app = await load(vc.application)
+      return app.workspace
+    }
+    expect(
+      await invoke(docWorkspaceMutate('kafka-offset-checkpoints', ['owner', 'admin'], { resolveWorkspace }), {
+        user: plainUser,
+        payload,
+        id: 'chk1',
+      }),
+    ).toBe(true)
+    expect(findByID).toHaveBeenCalled()
+  })
+
+  it('keys the membership query on betterAuthId (bug-2 regression guard)', async () => {
+    const { payload, find } = makePayload([member('admin')], { d1: { id: 'd1', workspace: 'ws-1' } })
+    await invoke(docWorkspaceMutate('scorecards', ['owner', 'admin']), { user: plainUser, payload, id: 'd1' })
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          and: expect.arrayContaining([{ user: { equals: 'ba-1' } }]),
+        }),
+      }),
+    )
+  })
+})
+
+describe('scorecards/access adapter', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('workspaceScopedRead scopes to member workspaces', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(await invoke(scorecards.workspaceScopedRead, { user: plainUser, payload })).toEqual({
+      workspace: { in: ['ws-1'] },
+    })
+  })
+
+  it('workspaceScopedCreate now denies a non-member (policy change from !!user)', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(scorecards.workspaceScopedCreate, { user: plainUser, payload, data: { workspace: 'ws-2' } }),
+    ).toBe(false)
+    expect(
+      await invoke(scorecards.workspaceScopedCreate, { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(true)
+  })
+
+  it('workspaceScopedManageCreate requires owner/admin', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(scorecards.workspaceScopedManageCreate, { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(false)
+  })
+
+  it('workspaceScopedMutate(slug, roles) gates on the doc workspace', async () => {
+    const { payload } = makePayload([member('admin')], { d1: { id: 'd1', workspace: 'ws-1' } })
+    expect(
+      await invoke(scorecards.workspaceScopedMutate('scorecards', ['owner', 'admin']), {
+        user: plainUser,
+        payload,
+        id: 'd1',
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('actions/access adapter', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('workspaceScopedMemberCreate grants an active member', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(actions.workspaceScopedMemberCreate, { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(true)
+  })
+
+  it('workspaceScopedManageCreate denies a plain member', async () => {
+    const { payload } = makePayload([member('member')])
+    expect(
+      await invoke(actions.workspaceScopedManageCreate, { user: plainUser, payload, data: { workspace: 'ws-1' } }),
+    ).toBe(false)
+  })
+})
+
+describe('automations/access adapter', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('workspaceScopedManageMutate gates on owner/admin of the automation workspace', async () => {
+    const { payload } = makePayload([member('admin')], { a1: { id: 'a1', workspace: 'ws-1' } })
+    expect(
+      await invoke(automations.workspaceScopedManageMutate, { user: plainUser, payload, id: 'a1' }),
+    ).toBe(true)
+  })
+
+  it('workspaceScopedManageMutate denies a plain member', async () => {
+    const { payload } = makePayload([member('member')], { a1: { id: 'a1', workspace: 'ws-1' } })
+    expect(
+      await invoke(automations.workspaceScopedManageMutate, { user: plainUser, payload, id: 'a1' }),
+    ).toBe(false)
+  })
+
+  it('workspaceScopedManageMutate denies anonymous', async () => {
+    const { payload } = makePayload([])
+    expect(await invoke(automations.workspaceScopedManageMutate, { user: null, payload, id: 'a1' })).toBe(false)
+  })
+})

--- a/orbit-www/src/lib/access/collection-access.ts
+++ b/orbit-www/src/lib/access/collection-access.ts
@@ -1,0 +1,205 @@
+import type { Access, Payload, Where } from 'payload'
+import {
+  isPlatformAdmin,
+  isWorkspaceMember,
+  getWorkspaceMembership,
+  getMemberWorkspaceIds,
+  getAdminOrOwnerWorkspaceIds,
+} from './workspace-access'
+
+/**
+ * Composable Payload `Access` factories — the SINGLE source of truth for
+ * workspace-scoped collection access (Collection Access-Control Remediation,
+ * docs/plans/2026-07-02-collection-access-control-remediation.md, issue #63).
+ * Built on the membership helpers in `./workspace-access`, all of which key on
+ * the caller's **Better-Auth** id.
+ *
+ * Security model (cross-cutting, non-negotiable):
+ *  - `!user` ⇒ `false`, always, first line.
+ *  - The ONLY privilege bypass is `isPlatformAdmin(user)` (role ∈
+ *    super_admin/admin). A `users`-collection account with `role: 'user'` gets
+ *    NO bypass — the `user.collection === 'users'` short-circuit was the bug.
+ *  - Every `workspace-members` lookup passes `user.betterAuthId` (a TEXT field
+ *    holding the Better-Auth id), NEVER the Payload `user.id`. A missing
+ *    `betterAuthId` (pre-first-login edge) is treated as a non-member and never
+ *    throws.
+ *  - Read factories return `Where` filters (never fetch-all-then-filter); admin
+ *    returns `true`. Create/mutate resolve the target workspace and deny when it
+ *    is missing/null for non-admins.
+ *
+ * Internal writeback paths (server actions, `/api/internal/**`, Temporal) run
+ * with `overrideAccess: true` and bypass every factory here.
+ */
+
+/** The Better-Auth id a membership query must key on; null when unavailable. */
+function betterAuthIdOf(user: unknown): string | null {
+  const id = (user as { betterAuthId?: unknown } | null | undefined)?.betterAuthId
+  return typeof id === 'string' && id.length > 0 ? id : null
+}
+
+/** Normalize a relationship value (`string` id or populated `{ id }`) to its id. */
+function relationId(value: unknown): string | null {
+  if (!value) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && 'id' in (value as Record<string, unknown>)) {
+    const id = (value as { id?: unknown }).id
+    return typeof id === 'string' ? id : null
+  }
+  return null
+}
+
+/** True if `betterAuthId` is an active member of `workspaceId` with one of `roles`. */
+async function hasWorkspaceRole(
+  payload: Payload,
+  betterAuthId: string,
+  workspaceId: string,
+  roles: string[],
+): Promise<boolean> {
+  const membership = await getWorkspaceMembership(payload, betterAuthId, workspaceId)
+  if (!membership) return false
+  return roles.includes(membership.role as string)
+}
+
+/**
+ * Resolves the workspace id a create is bound to from the incoming `data`.
+ * Defaults to reading a direct relationship field; pass a custom resolver for
+ * indirect relations (resolve via a parent record with `payload`).
+ */
+export type DataWorkspaceResolver = (args: {
+  data: unknown
+  payload: Payload
+}) => string | null | Promise<string | null>
+
+/**
+ * Resolves the workspace id an existing doc belongs to. Defaults to a direct
+ * `workspace` field; pass a custom resolver for indirect relations (e.g.
+ * KafkaOffsetCheckpoints: virtualCluster → application → workspace).
+ */
+export type DocWorkspaceResolver = (args: {
+  doc: unknown
+  payload: Payload
+}) => string | null | Promise<string | null>
+
+/** Platform admin or deny. Use for system/global collections and system rows. */
+export const adminOnly: Access = ({ req: { user } }) => isPlatformAdmin(user)
+
+export interface WorkspaceScopedReadOptions {
+  /** Single workspace relationship field (default `'workspace'`). */
+  field?: string
+  /** OR the filter across several workspace fields (overrides `field`). */
+  fields?: string[]
+  /**
+   * Which membership set the caller reads: `'member'` (any active role,
+   * default) or `'manage'` (owner/admin workspaces only).
+   */
+  scope?: 'member' | 'manage'
+}
+
+/**
+ * Read filter: platform admin ⇒ `true`; otherwise a `Where` limiting results to
+ * the caller's workspaces. Supports a custom field, an OR over multiple fields,
+ * and a role-restricted (`manage`) variant.
+ */
+export function workspaceScopedRead(options: WorkspaceScopedReadOptions = {}): Access {
+  const { field = 'workspace', fields, scope = 'member' } = options
+  const targetFields = fields && fields.length > 0 ? fields : [field]
+  return async ({ req: { user, payload } }) => {
+    if (!user) return false
+    if (isPlatformAdmin(user)) return true
+    const betterAuthId = betterAuthIdOf(user)
+    const ids = betterAuthId
+      ? scope === 'manage'
+        ? await getAdminOrOwnerWorkspaceIds(payload, betterAuthId)
+        : await getMemberWorkspaceIds(payload, betterAuthId)
+      : []
+    if (targetFields.length === 1) {
+      return { [targetFields[0]]: { in: ids } } as Where
+    }
+    return { or: targetFields.map((f) => ({ [f]: { in: ids } })) } as Where
+  }
+}
+
+export interface CreateAccessOptions {
+  /** Workspace relationship field on the incoming doc (default `'workspace'`). */
+  field?: string
+  /** Resolve the target workspace from `data` (indirect relations). */
+  resolveWorkspace?: DataWorkspaceResolver
+}
+
+function createAccess(roles: string[] | null, options: CreateAccessOptions): Access {
+  const { field = 'workspace', resolveWorkspace } = options
+  return async ({ req: { user, payload }, data }) => {
+    if (!user) return false
+    if (isPlatformAdmin(user)) return true
+    const betterAuthId = betterAuthIdOf(user)
+    if (!betterAuthId) return false
+    const workspaceId = resolveWorkspace
+      ? await resolveWorkspace({ data, payload })
+      : relationId((data as Record<string, unknown> | undefined)?.[field])
+    if (!workspaceId) return false
+    return roles === null
+      ? isWorkspaceMember(payload, betterAuthId, workspaceId)
+      : hasWorkspaceRole(payload, betterAuthId, workspaceId, roles)
+  }
+}
+
+/**
+ * Create allowed for any active member (any role) of the target workspace named
+ * in `data`. Missing/null workspace ⇒ deny unless platform admin.
+ */
+export function memberCreate(options: CreateAccessOptions = {}): Access {
+  return createAccess(null, options)
+}
+
+/**
+ * Create allowed only for an active member of the target workspace holding one
+ * of `roles` (e.g. `['owner', 'admin']`). Missing/null workspace ⇒ deny unless
+ * platform admin.
+ */
+export function manageCreate(roles: string[], options: CreateAccessOptions = {}): Access {
+  return createAccess(roles, options)
+}
+
+export interface DocMutateOptions {
+  /** Workspace relationship field on the loaded doc (default `'workspace'`). */
+  field?: string
+  /** Resolve the doc's workspace via a parent relation (indirect). */
+  resolveWorkspace?: DocWorkspaceResolver
+}
+
+/**
+ * Update/delete gate: platform admin ⇒ allow; otherwise load the doc (depth 0,
+ * overrideAccess), resolve its workspace, and require active membership with one
+ * of `roles`. Supply `resolveWorkspace` for docs whose workspace lives on a
+ * parent record. A missing doc/workspace ⇒ deny.
+ */
+export function docWorkspaceMutate(
+  slug: string,
+  roles: string[],
+  options: DocMutateOptions = {},
+): Access {
+  const { field = 'workspace', resolveWorkspace } = options
+  return async ({ req: { user, payload }, id }) => {
+    if (!user || !id) return false
+    if (isPlatformAdmin(user)) return true
+    const betterAuthId = betterAuthIdOf(user)
+    if (!betterAuthId) return false
+    let doc: Record<string, unknown>
+    try {
+      doc = (await payload.findByID({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        collection: slug as any,
+        id: id as string,
+        depth: 0,
+        overrideAccess: true,
+      })) as Record<string, unknown>
+    } catch {
+      return false
+    }
+    const workspaceId = resolveWorkspace
+      ? await resolveWorkspace({ doc, payload })
+      : relationId(doc[field])
+    if (!workspaceId) return false
+    return hasWorkspaceRole(payload, betterAuthId, workspaceId, roles)
+  }
+}


### PR DESCRIPTION
## Problem (issue #63)

PR #62 fixed a broken access pattern on two catalog collections; this PR eradicates the same two bugs from the rest of the collection layer:

1. **Universal admin bypass** — `if (user.collection === 'users') return true` was intended as a Payload-admin check, but `users` is the only auth collection, so **every authenticated user** short-circuited to full read/update/delete. `KafkaServiceAccounts` had the guard *inverted* (`!== 'users'`) — a no-op that never denied, letting any user create service accounts.
2. **Wrong identity** — membership fallbacks queried `workspace-members.user` with the Payload doc id, but that field stores the **Better-Auth id**; the queries matched nothing. Ten collections had this bug alone and were broken *closed* (legitimate members locked out of the direct API).

Net effect: the direct Payload REST/GraphQL API was **tenant-unbounded for any logged-in user** across apps, API schemas, Kafka, scorecards, actions, and automations. (UI paths were safe — server actions do their own scoping and run with `overrideAccess`.)

### Escalated finding: full privilege-escalation chain (beyond original #63 scope)

The audit found `Roles`, `Permissions`, and `UserWorkspaceRoles` all accepted **writes from any authenticated user**, while `loadUserPermissions` grants platform-scoped permissions directly from those rows — i.e. any user could define a platform role with arbitrary permissions and assign it to themselves. All three are now platform-admin-only writes (reads tightened to authenticated; `Roles.delete` keeps the `isSystem` guard even for admins).

## The fix

One shared library, **`src/lib/access/collection-access.ts`**: composable `Access` factories (`adminOnly`, `workspaceScopedRead` with single/multi-field + member/manage scope, `memberCreate`/`manageCreate` validating the incoming `data.workspace` membership, `docWorkspaceMutate` with indirect workspace resolvers), built on the betterAuthId-keyed helpers in `workspace-access.ts`. The three duplicated `access.ts` modules (scorecards/actions/automations — covering 11 collections) are now thin adapters over it. 47 files changed, net **−950 lines**.

Notable per-collection decisions (full policy matrix in `docs/plans/2026-07-02-collection-access-control-remediation.md`):
- `!!user` **creates** on workspace-bound collections now validate membership of the target workspace (was: any user could create into any tenant).
- `AgentToolVersions` read was a latent **cross-tenant leak** (an `and: []` match-all reachable once identity was fixed) — now properly joined through `agent-tools.workspace`. This is a security fix, not a refactor.
- `PageLinks` read queried a nonexistent field path (always-deny); rewritten to the real workspace→space→page chain, and its formerly unscoped create/delete are membership-gated.
- `KafkaProviders` read tightened from public to authenticated; system/config collections (`BifrostConfig`, topic policies, clusters, chargeback, env mappings, quotas writes) are platform-admin-only.
- `KafkaVirtualClusters` keeps its legacy application→workspace read fallback (identity fixed) so legacy docs stay visible to their members.

## Verification

- **Tests**: branch **1179 passed / 100 failed** vs main **1139 / 100** — the 100 failures are byte-identical pre-existing ones needing live Mongo/env (verified by running the full suite on both). The +40 are the new `collection-access` suite, including the two regression guards: a `role: 'user'` account gets **no** bypass, and membership where-clauses carry the Better-Auth id (asserted on mock call shapes).
- **tsc --noEmit**: 111 errors on main, 111 on branch — zero introduced, none touching changed files.
- **eslint** on changed files: clean.
- **Grep audits**: zero `user.collection ===/!==` checks remain under `src/collections/`; every `workspace-members` query keys on `betterAuthId`; the three surviving `equals: user.id` comparisons are verified `relationship`-to-`users` fields (correct semantics).
- **QA**: independent adversarial pass — all 13 acceptance criteria PASS, 5-collection × 5-principal × 4-operation access matrix traced against the policy matrix, zero must-fix findings.
- **UI**: no UI code changed; all frontend reads/writes flow through server actions with their own scoping + `overrideAccess` (confirmed untouched), so no browser-level behavior change is expected.

## Out of scope (follow-up issue incoming)

Same-root-cause bugs *outside* the collection access layer, all broken-closed (functional, not security): 3 server-component `user.id` call sites, the agent SSE stream route's membership gate, and dedicated unit tests for the rewritten PageLinks/AgentToolVersions reads. Go-layer #50 unchanged. Workspace-scoping the two kafka policy collections is a product decision deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXSqSAnnGq79CETXQNWHgW