### PR TITLE
chore(dev): trim dev-local to core services; add dev-local-full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Orbit Development Makefile
 
-.PHONY: help dev dev-docker dev-local test test-go test-frontend lint lint-go lint-frontend build clean
+.PHONY: help dev dev-docker dev-local dev-local-full test test-go test-frontend lint lint-go lint-frontend build clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -10,19 +10,17 @@ dev: dev-docker ## Start complete development environment in Docker
 dev-docker: ## Start all services in Docker (recommended)
 	@./scripts/dev-start.sh
 
-dev-local: ## Start infrastructure in Docker, run orbit-www locally
-	@echo "🚀 Starting infrastructure and application services..."
+dev-local: ## Start core infrastructure in Docker, run orbit-www locally
+	@echo "🚀 Starting core infrastructure and application services..."
 	docker compose up -d \
 		mongo postgres redis \
 		temporal-postgresql temporal-elasticsearch temporal-server temporal-ui temporal-worker \
 		redpanda redpanda-console \
-		minio minio-init orbit-registry \
 		bifrost traefik \
-		repository-service kafka-service build-service buildkit \
-		launches-worker-azure orbit-automations-worker \
-		prometheus
+		repository-service kafka-service \
+		orbit-automations-worker
 	@echo ""
-	@echo "✅ All services started!"
+	@echo "✅ Core services started!"
 	@echo ""
 	@echo "📝 To start orbit-www locally:"
 	@echo "  cd orbit-www && bun run dev"
@@ -31,6 +29,20 @@ dev-local: ## Start infrastructure in Docker, run orbit-www locally
 	@echo "  Frontend:          http://localhost:3000  (run locally)"
 	@echo "  Temporal UI:       http://localhost:8080"
 	@echo "  Redpanda Console:  http://localhost:8083"
+	@echo ""
+	@echo "ℹ️  Launches/build stack (MinIO, registry, BuildKit, build-service,"
+	@echo "   launches-worker-azure) and Prometheus are not started."
+	@echo "   Testing launches or image builds? Run: make dev-local-full"
+	@echo ""
+
+dev-local-full: dev-local ## dev-local plus the launches/build stack and Prometheus
+	@echo "🚀 Starting launches/build stack..."
+	docker compose up -d \
+		minio minio-init orbit-registry \
+		buildkit build-service launches-worker-azure \
+		prometheus
+	@echo ""
+	@echo "✅ Launches/build stack started!"
 	@echo "  MinIO Console:     http://localhost:9001"
 	@echo "  Prometheus:        http://localhost:9090"
 	@echo ""


### PR DESCRIPTION
## What

`make dev-local` still started the full launches/build pipeline (7 extra containers) on every run, even after the product-focus strip ([2026-06-09 strategy](docs/plans/2026-06-09-product-focus-strategy.md)). This trims it to the core stack and adds `make dev-local-full` for when the launches/build path is actually being tested.

## Why each service was cut from the default

| Service | Reason |
|---|---|
| `prometheus` | Nothing queries it — it only scrapes Bifrost metrics; pure observability |
| `minio` + `minio-init` | Payload media uses local disk (no storage adapter configured); MinIO only backs Pulumi state + registry storage |
| `orbit-registry` | Frozen capability; only consumed by build-service |
| `buildkit` + `build-service` | Only called from Temporal build activities (`temporal-workflows/internal/activities/build_activities.go`) — the launches/deploy pipeline |
| `launches-worker-azure` | Only needed when testing launches |

## What stays (and why)

mongo/postgres/redis, full Temporal stack (elasticsearch is temporal-server's visibility store; `postgres` is a kafka-service dependency), Redpanda + Bifrost + traefik + kafka-service (flagship), repository-service (catalog), orbit-automations-worker, temporal-worker (agent — healthcheck depends on Bifrost).

`make dev-local-full` = dev-local + the launches/build stack + Prometheus.

## Verification

- `make -n dev-local` and `make -n dev-local-full` dry-run clean
- All service names validated against `docker compose config --services`

## Note (out of scope)

`scripts/dev-start.sh` (the `make dev` path) references an `orbit-www` compose service that is commented out in `docker-compose.yml` — that target likely errors today and could use a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)