### PR TITLE
fix(security): gate Kafka ClusterHandler RPCs behind platform-admin svcauth claim

### DIFF
--- a/docs/plans/2026-07-06-kafka-cluster-admin-gate.md
+++ b/docs/plans/2026-07-06-kafka-cluster-admin-gate.md
@@ -1,0 +1,100 @@
+# Kafka ClusterHandler platform-admin gate (GitHub issue #50)
+
+**Date:** 2026-07-06
+**Status:** In progress on `fix/50-kafka-cluster-admin-gate`
+**Owner:** PM session (Claude) directing engineer + QA agents
+**Refs:** issue #50, PR #49 review record, `docs/plans/2026-06-10-grpc-auth-interceptor-design.md`
+
+## Problem
+
+PR #49 authenticated the Kafka gRPC service (svcauth HS256 JWT interceptor), but
+ClusterHandler RPCs remained the accepted residual: clusters are global in the
+domain model (no `WorkspaceID`), so all 11 cluster-level RPCs in
+`services/kafka/internal/grpc/cluster_handler.go` perform **no authorization** —
+any authenticated tenant can register/delete global clusters, run
+`ValidateClusterConnection` with attacker-supplied connection config, and
+create/delete topics directly against brokers.
+
+Chosen fix = issue option 1: **platform-admin claim in the svcauth token,
+enforced on every ClusterHandler RPC.** Cluster management is already
+platform-admin-only on the www side (`requireAdmin()` in
+`src/app/actions/kafka-admin.ts:249`), so this closes the direct-gRPC bypass
+without a domain-model migration.
+
+Caller analysis (recon, 2026-07-06): the ONLY live gRPC caller of any cluster
+RPC is `validateClusterConnection` from the admin-gated `validateCluster`
+server action (`kafka-admin.ts:860`). `CreateTopicDirect`/`DeleteTopicByName`
+have **no callers anywhere** (Temporal hits brokers via its own adapter, not
+this service). No Go service-to-service callers. Net regression risk: zero.
+
+## Design
+
+1. **Claims** (`proto/pkg/svcauth/claims.go:12`): add
+   `PlatformAdmin bool \`json:"adm,omitempty"\``. Absent claim ⇒ `false`
+   (old tokens are non-admin — fail closed).
+2. **Identity** (`claims.go:30`): add `PlatformAdmin bool`; thread it in BOTH
+   `grpc.go:62` and `connect.go:42`.
+3. **New helper** beside `EnforceWorkspace` (`claims.go:65`):
+   `EnforcePlatformAdmin(ctx) error` — no identity ⇒ `codes.Unauthenticated`;
+   `!PlatformAdmin` ⇒ `codes.PermissionDenied` ("platform admin required").
+4. **ClusterHandler**: first line of ALL 11 RPCs calls `EnforcePlatformAdmin`:
+   ListProviders, RegisterCluster, ValidateCluster, ValidateClusterConnection,
+   DeleteTopicByName, CreateTopicDirect, ListClusters, DeleteCluster,
+   CreateEnvironmentMapping, ListEnvironmentMappings, DeleteEnvironmentMapping.
+5. **www minting** (`orbit-www/src/lib/grpc/svc-auth-token.ts:53`):
+   `mintServiceToken(subject, workspaceId, opts?: { platformAdmin?: boolean })`
+   → sets `adm: true` only when true (omit otherwise).
+6. **www interceptor** (`orbit-www/src/lib/grpc/auth-interceptor.ts`): resolve
+   the session user's role (it currently only uses the id) and pass
+   `platformAdmin: isPlatformAdmin(user)` (from
+   `src/lib/access/workspace-access.ts:137`). Role must come from the server
+   session/Payload user — never from request input.
+7. **No workspace-RPC changes**: topic/share/service-account handlers and their
+   `EnforceWorkspace` scoping are untouched.
+8. Deployment-skew note: if kafka-service deploys before orbit-www, admin
+   "Validate connection" returns PermissionDenied until www ships the `adm`
+   claim. Acceptable in dev-stage; both land in one PR here.
+
+## UAC
+
+- **UAC-1** All 11 ClusterHandler RPCs reject: missing token ⇒ Unauthenticated;
+  valid token without `adm` ⇒ PermissionDenied; valid token `adm:true` ⇒
+  proceeds to handler logic. Table-driven test covers every RPC name.
+- **UAC-2** `adm` absent ⇒ non-admin (fail closed); claim cannot be injected
+  via request metadata/fields — only from the signed JWT.
+- **UAC-3** Topic/share/service-account RPC authz behavior byte-for-byte
+  unchanged (existing auth tests still green, no edits to their assertions).
+- **UAC-4** www: `mintServiceToken` emits `adm` iff `isPlatformAdmin(user)`;
+  interceptor derives it from the server-side session user role.
+- **UAC-5** `connect.go` (repository service path) compiles and threads the new
+  Identity field; repository behavior unchanged.
+- **UAC-6** Tests: svcauth unit tests for claim roundtrip + `EnforcePlatformAdmin`;
+  new `cluster_handler_auth_test.go` following the
+  `share_handler_auth_test.go` pattern (`mintKafkaToken` gains an admin arg);
+  TS tests for svc-auth-token/auth-interceptor updated.
+- **UAC-7** `cd services/kafka && go test -race ./...` green;
+  `cd proto && go test -race ./pkg/svcauth/...` green;
+  `cd orbit-www && bunx vitest run src/lib/grpc` green; golangci-lint clean on
+  touched Go packages.
+- **UAC-8** Browser QA: admin "Validate connection" flow on `/platform/kafka`
+  works end-to-end against a rebuilt kafka-service container (full token path
+  www → gRPC); all four admin Kafka tabs render regression-free.
+
+## Work packages
+
+- **WP1 (Opus engineer)** — the full change (Go svcauth + kafka handlers + www
+  TS minting/interceptor + all tests). Single package: the change is contained
+  and cross-language coordination is the risky part; splitting it would add
+  hand-off risk, not remove it. TDD on the new helper + handler gates.
+- **QA (agent-browser)** — rebuild kafka-service container from the branch,
+  run www dev server from this worktree on :3001, validate UAC-8 as the seeded
+  platform-admin user; capture screenshots; check kafka-service logs for the
+  denied/allowed audit lines.
+
+## Verification
+
+1. Go: `cd services/kafka && go test -race ./...`; `cd proto && go test -race ./pkg/svcauth/...`
+2. TS: `cd orbit-www && bunx vitest run src/lib/grpc`
+3. Lint: `golangci-lint run` in services/kafka (and proto if configured); eslint on touched TS.
+4. QA browser pass per UAC-8.
+5. PR closes #50.

--- a/docs/plans/2026-07-06-kafka-cluster-admin-gate.md
+++ b/docs/plans/2026-07-06-kafka-cluster-admin-gate.md
@@ -1,7 +1,7 @@
 # Kafka ClusterHandler platform-admin gate (GitHub issue #50)
 
 **Date:** 2026-07-06
-**Status:** In progress on `fix/50-kafka-cluster-admin-gate`
+**Status:** Implemented on `fix/50-kafka-cluster-admin-gate` — QA validated (all UAC PASS incl. wire-level denial proof: no-token ⇒ Unauthenticated, non-admin JWT ⇒ PermissionDenied "platform admin required", admin JWT ⇒ OK; admin Validate-Connection browser flow green against rebuilt kafka-service)
 **Owner:** PM session (Claude) directing engineer + QA agents
 **Refs:** issue #50, PR #49 review record, `docs/plans/2026-06-10-grpc-auth-interceptor-design.md`
 

--- a/orbit-www/src/lib/grpc/auth-interceptor.test.ts
+++ b/orbit-www/src/lib/grpc/auth-interceptor.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// server-only throws if imported outside an RSC bundle; stub it for the test.
+vi.mock('server-only', () => ({}))
+
+const getCurrentUser = vi.fn()
+vi.mock('@/lib/auth/session', () => ({ getCurrentUser }))
+
+// Capture what the interceptor asks the minter to sign.
+const mintServiceToken = vi.fn(async () => 'signed-token')
+vi.mock('./svc-auth-token', () => ({ mintServiceToken }))
+
+// Avoid pulling the real Payload config/runtime into the node test env. These
+// are only reached on the workspace-scoped path, which these tests do not take.
+vi.mock('payload', () => ({ getPayload: vi.fn() }))
+vi.mock('@payload-config', () => ({ default: {} }))
+
+async function runInterceptor(user: unknown, message: unknown = {}) {
+  getCurrentUser.mockResolvedValue(user)
+  const { authInterceptor } = await import('./auth-interceptor')
+  const next = vi.fn(async () => 'response')
+  const req = { message, header: new Headers() }
+  // Interceptor shape: (next) => async (req) => ...
+  await authInterceptor(next as never)(req as never)
+  return { next, req }
+}
+
+describe('authInterceptor platform-admin derivation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('signs adm:true for a super_admin session user', async () => {
+    await runInterceptor({ id: 'u1', role: 'super_admin' })
+    expect(mintServiceToken).toHaveBeenCalledWith('u1', '', { platformAdmin: true })
+  })
+
+  it('signs adm:true for an admin session user', async () => {
+    await runInterceptor({ id: 'u1', role: 'admin' })
+    expect(mintServiceToken).toHaveBeenCalledWith('u1', '', { platformAdmin: true })
+  })
+
+  it('does not elevate a plain user', async () => {
+    await runInterceptor({ id: 'u1', role: 'user' })
+    expect(mintServiceToken).toHaveBeenCalledWith('u1', '', { platformAdmin: false })
+  })
+
+  it('ignores an admin role smuggled in the request message (no self-elevation)', async () => {
+    await runInterceptor({ id: 'u1', role: 'user' }, { role: 'super_admin', adm: true })
+    expect(mintServiceToken).toHaveBeenCalledWith('u1', '', { platformAdmin: false })
+  })
+
+  it('throws when there is no authenticated user', async () => {
+    getCurrentUser.mockResolvedValue(null)
+    const { authInterceptor } = await import('./auth-interceptor')
+    const next = vi.fn(async () => 'response')
+    const req = { message: {}, header: new Headers() }
+    await expect(authInterceptor(next as never)(req as never)).rejects.toThrow(/no authenticated user/)
+    expect(mintServiceToken).not.toHaveBeenCalled()
+  })
+})

--- a/orbit-www/src/lib/grpc/auth-interceptor.ts
+++ b/orbit-www/src/lib/grpc/auth-interceptor.ts
@@ -22,7 +22,7 @@ import type { Interceptor } from '@connectrpc/connect'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import { getCurrentUser } from '@/lib/auth/session'
-import { isWorkspaceMember } from '@/lib/access/workspace-access'
+import { isWorkspaceMember, isPlatformAdmin } from '@/lib/access/workspace-access'
 import { mintServiceToken } from './svc-auth-token'
 
 /**
@@ -59,7 +59,13 @@ export const authInterceptor: Interceptor = (next) => async (req) => {
     workspaceId = requestedWorkspaceId
   }
 
-  const token = await mintServiceToken(user.id, workspaceId)
+  // Platform-admin status is derived from the server-side session user role
+  // (a server-set, input:false field) — never from the request message — so a
+  // client cannot self-elevate. It gates the Go services' platform-scoped RPCs
+  // (Kafka cluster management) via the `adm` claim.
+  const platformAdmin = isPlatformAdmin(user)
+
+  const token = await mintServiceToken(user.id, workspaceId, { platformAdmin })
   req.header.set('Authorization', `Bearer ${token}`)
 
   return next(req)

--- a/orbit-www/src/lib/grpc/svc-auth-token.test.ts
+++ b/orbit-www/src/lib/grpc/svc-auth-token.test.ts
@@ -40,6 +40,30 @@ describe('mintServiceToken', () => {
     expect((payload.exp as number) - (payload.iat as number)).toBe(120)
   })
 
+  it('sets the adm claim only when platformAdmin is true', async () => {
+    vi.stubEnv('ORBIT_SVC_AUTH_SECRET', MOCK_SECRET)
+    const { mintServiceToken } = await importFresh()
+    const secret = new TextEncoder().encode(MOCK_SECRET)
+
+    const adminToken = await mintServiceToken('user-abc', 'ws', { platformAdmin: true })
+    const { payload: adminPayload } = await jose.jwtVerify(adminToken, secret)
+    expect(adminPayload.adm).toBe(true)
+  })
+
+  it('omits the adm claim when platformAdmin is false or unset (fail closed)', async () => {
+    vi.stubEnv('ORBIT_SVC_AUTH_SECRET', MOCK_SECRET)
+    const { mintServiceToken } = await importFresh()
+    const secret = new TextEncoder().encode(MOCK_SECRET)
+
+    const falseToken = await mintServiceToken('user-abc', 'ws', { platformAdmin: false })
+    const { payload: falsePayload } = await jose.jwtVerify(falseToken, secret)
+    expect(falsePayload.adm).toBeUndefined()
+
+    const defaultToken = await mintServiceToken('user-abc', 'ws')
+    const { payload: defaultPayload } = await jose.jwtVerify(defaultToken, secret)
+    expect(defaultPayload.adm).toBeUndefined()
+  })
+
   it('allows an empty workspace for RPCs with no workspace scope', async () => {
     vi.stubEnv('ORBIT_SVC_AUTH_SECRET', MOCK_SECRET)
     const { mintServiceToken } = await importFresh()

--- a/orbit-www/src/lib/grpc/svc-auth-token.ts
+++ b/orbit-www/src/lib/grpc/svc-auth-token.ts
@@ -42,6 +42,20 @@ function loadSecret(): Uint8Array {
 }
 
 /**
+ * Options for minting a service-auth token.
+ */
+export interface MintServiceTokenOptions {
+  /**
+   * When true, sign the `adm: true` platform-admin claim so the services'
+   * EnforcePlatformAdmin gate (e.g. Kafka cluster management) admits the call.
+   * MUST be derived from the server-side session user role, never from request
+   * input. Omitted from the token when false so non-admin (and legacy) tokens
+   * fail closed.
+   */
+  platformAdmin?: boolean
+}
+
+/**
  * Mint a service-auth JWT for a single outbound call.
  *
  * @param subject     betterAuthId of the acting user (session.user.id).
@@ -49,8 +63,13 @@ function loadSecret(): Uint8Array {
  *                    request; signed into `wid` and enforced by the services
  *                    against the request body's workspace_id. May be empty for
  *                    RPCs that carry no workspace scope.
+ * @param opts        optional claims; see MintServiceTokenOptions.
  */
-export async function mintServiceToken(subject: string, workspaceId: string): Promise<string> {
+export async function mintServiceToken(
+  subject: string,
+  workspaceId: string,
+  opts?: MintServiceTokenOptions,
+): Promise<string> {
   if (!subject) {
     throw new Error('mintServiceToken: subject (betterAuthId) is required')
   }
@@ -58,7 +77,14 @@ export async function mintServiceToken(subject: string, workspaceId: string): Pr
   const secret = loadSecret()
   const now = Math.floor(Date.now() / 1000)
 
-  return new jose.SignJWT({ wid: workspaceId })
+  const claims: Record<string, unknown> = { wid: workspaceId }
+  // Only set `adm` when true — omitting it keeps the token shape identical to
+  // the pre-admin-claim tokens, which the Go side parses as non-admin.
+  if (opts?.platformAdmin) {
+    claims.adm = true
+  }
+
+  return new jose.SignJWT(claims)
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuer(ISSUER)
     .setAudience(AUDIENCE)

--- a/proto/pkg/svcauth/claims.go
+++ b/proto/pkg/svcauth/claims.go
@@ -34,6 +34,11 @@ type Identity struct {
 	// request (the JWT "wid" claim). orbit-www only ever signs a workspace the
 	// session user is a verified member of.
 	WorkspaceID string
+	// PlatformAdmin is true when the caller is a verified platform admin (the JWT
+	// "adm" claim). orbit-www only sets it from the server-side session user role,
+	// never from request input. Gate platform-scoped RPCs on this via
+	// EnforcePlatformAdmin.
+	PlatformAdmin bool
 }
 
 // ctxKey is an unexported type so the identity value cannot collide with or be
@@ -75,6 +80,26 @@ func EnforceWorkspace(ctx context.Context, bodyWorkspaceID string) error {
 	}
 	if bodyWorkspaceID != id.WorkspaceID {
 		return status.Error(codes.PermissionDenied, "workspace_id does not match authorized workspace")
+	}
+	return nil
+}
+
+// EnforcePlatformAdmin gates platform-scoped RPCs (e.g. Kafka cluster
+// management) that have no workspace boundary in the domain model. It requires a
+// verified identity whose token carried adm=true.
+//
+//   - identity missing   : not authenticated; Unauthenticated.
+//   - !PlatformAdmin      : authenticated but not an admin; PermissionDenied.
+//
+// A token minted without the "adm" claim yields PlatformAdmin=false, so such a
+// token is rejected (fail closed).
+func EnforcePlatformAdmin(ctx context.Context) error {
+	id, ok := IdentityFromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no verified identity in context")
+	}
+	if !id.PlatformAdmin {
+		return status.Error(codes.PermissionDenied, "platform admin required")
 	}
 	return nil
 }

--- a/proto/pkg/svcauth/claims_test.go
+++ b/proto/pkg/svcauth/claims_test.go
@@ -44,6 +44,26 @@ func TestEnforceWorkspace(t *testing.T) {
 	})
 }
 
+func TestEnforcePlatformAdmin(t *testing.T) {
+	t.Run("admin identity is allowed", func(t *testing.T) {
+		ctx := WithIdentity(context.Background(), Identity{UserID: "u", PlatformAdmin: true})
+		require.NoError(t, EnforcePlatformAdmin(ctx))
+	})
+
+	t.Run("non-admin identity is PermissionDenied", func(t *testing.T) {
+		ctx := WithIdentity(context.Background(), Identity{UserID: "u", PlatformAdmin: false})
+		err := EnforcePlatformAdmin(ctx)
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	})
+
+	t.Run("missing identity is Unauthenticated", func(t *testing.T) {
+		err := EnforcePlatformAdmin(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+}
+
 func TestIdentityRoundTrip(t *testing.T) {
 	id := Identity{UserID: "user-123", WorkspaceID: "ws-456"}
 	got, ok := IdentityFromContext(WithIdentity(context.Background(), id))

--- a/proto/pkg/svcauth/connect.go
+++ b/proto/pkg/svcauth/connect.go
@@ -39,7 +39,7 @@ func (i *connectInterceptor) authenticateConnect(ctx context.Context, procedure 
 		}
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("invalid or missing service auth token"))
 	}
-	return WithIdentity(ctx, Identity{UserID: claims.Subject, WorkspaceID: claims.WorkspaceID}), nil
+	return WithIdentity(ctx, Identity{UserID: claims.Subject, WorkspaceID: claims.WorkspaceID, PlatformAdmin: claims.PlatformAdmin}), nil
 }
 
 func (i *connectInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {

--- a/proto/pkg/svcauth/grpc.go
+++ b/proto/pkg/svcauth/grpc.go
@@ -59,7 +59,7 @@ func authenticate(ctx context.Context, secret []byte, enforce bool) (context.Con
 		}
 		return nil, status.Error(codes.Unauthenticated, "invalid or missing service auth token")
 	}
-	return WithIdentity(ctx, Identity{UserID: claims.Subject, WorkspaceID: claims.WorkspaceID}), nil
+	return WithIdentity(ctx, Identity{UserID: claims.Subject, WorkspaceID: claims.WorkspaceID, PlatformAdmin: claims.PlatformAdmin}), nil
 }
 
 // identityStream overrides Context() so the wrapped handler observes the

--- a/proto/pkg/svcauth/verify.go
+++ b/proto/pkg/svcauth/verify.go
@@ -12,6 +12,10 @@ import (
 type Claims struct {
 	jwt.RegisteredClaims
 	WorkspaceID string `json:"wid"`
+	// PlatformAdmin is the platform-admin flag ("adm"). It is omitted when false,
+	// so a token minted before this claim existed (or for a non-admin user) parses
+	// as false — platform-admin RPCs fail closed for such tokens.
+	PlatformAdmin bool `json:"adm,omitempty"`
 }
 
 // LoadSecret validates a raw secret string and returns it as bytes. It is the

--- a/proto/pkg/svcauth/verify_test.go
+++ b/proto/pkg/svcauth/verify_test.go
@@ -51,6 +51,22 @@ func TestParseAndVerify(t *testing.T) {
 		assert.Equal(t, "ws-456", claims.WorkspaceID)
 	})
 
+	t.Run("adm claim true parses as PlatformAdmin", func(t *testing.T) {
+		tok := mintForTest(t, testSecret, jwt.SigningMethodHS256, func(c jwt.MapClaims) {
+			c["adm"] = true
+		})
+		claims, err := ParseAndVerify(tok, testSecret)
+		require.NoError(t, err)
+		assert.True(t, claims.PlatformAdmin)
+	})
+
+	t.Run("absent adm claim parses as non-admin (fail closed)", func(t *testing.T) {
+		tok := mintForTest(t, testSecret, jwt.SigningMethodHS256, nil)
+		claims, err := ParseAndVerify(tok, testSecret)
+		require.NoError(t, err)
+		assert.False(t, claims.PlatformAdmin, "old token without adm must be non-admin")
+	})
+
 	t.Run("expired token is rejected", func(t *testing.T) {
 		tok := mintForTest(t, testSecret, jwt.SigningMethodHS256, func(c jwt.MapClaims) {
 			c["iat"] = time.Now().Add(-10 * time.Minute).Unix()

--- a/services/kafka/internal/grpc/cluster_handler.go
+++ b/services/kafka/internal/grpc/cluster_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	kafkav1 "github.com/drewpayment/orbit/proto/gen/go/idp/kafka/v1"
+	"github.com/drewpayment/orbit/proto/pkg/svcauth"
 	"github.com/drewpayment/orbit/services/kafka/internal/domain"
 	"github.com/drewpayment/orbit/services/kafka/internal/service"
 	"github.com/google/uuid"
@@ -26,6 +27,9 @@ func NewClusterHandler(clusterService *service.ClusterService) *ClusterHandler {
 
 // ListProviders returns all available Kafka providers
 func (h *ClusterHandler) ListProviders(ctx context.Context, req *kafkav1.ListProvidersRequest) (*kafkav1.ListProvidersResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	providers, err := h.clusterService.ListProviders(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list providers: %v", err)
@@ -43,6 +47,9 @@ func (h *ClusterHandler) ListProviders(ctx context.Context, req *kafkav1.ListPro
 
 // RegisterCluster registers a new Kafka cluster
 func (h *ClusterHandler) RegisterCluster(ctx context.Context, req *kafkav1.RegisterClusterRequest) (*kafkav1.RegisterClusterResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	cluster, err := h.clusterService.RegisterCluster(ctx, service.RegisterClusterRequest{
 		Name:             req.Name,
 		ProviderID:       req.ProviderId,
@@ -63,6 +70,9 @@ func (h *ClusterHandler) RegisterCluster(ctx context.Context, req *kafkav1.Regis
 
 // ValidateCluster validates a cluster connection (cluster stored in Go service)
 func (h *ClusterHandler) ValidateCluster(ctx context.Context, req *kafkav1.ValidateClusterRequest) (*kafkav1.ValidateClusterResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	clusterID, err := uuid.Parse(req.ClusterId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid cluster ID: %v", err)
@@ -84,6 +94,9 @@ func (h *ClusterHandler) ValidateCluster(ctx context.Context, req *kafkav1.Valid
 // ValidateClusterConnection validates a Kafka connection using provided config
 // This is used when cluster config is stored externally (e.g., Payload CMS)
 func (h *ClusterHandler) ValidateClusterConnection(ctx context.Context, req *kafkav1.ValidateClusterConnectionRequest) (*kafkav1.ValidateClusterConnectionResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	valid, err := h.clusterService.ValidateClusterConnection(ctx, req.ConnectionConfig, req.Credentials)
 	if err != nil {
 		return &kafkav1.ValidateClusterConnectionResponse{
@@ -101,6 +114,9 @@ func (h *ClusterHandler) ValidateClusterConnection(ctx context.Context, req *kaf
 // This is used when topic metadata is stored externally (e.g., Payload CMS)
 // and we only need to remove the topic from Kafka without looking up internal IDs.
 func (h *ClusterHandler) DeleteTopicByName(ctx context.Context, req *kafkav1.DeleteTopicByNameRequest) (*kafkav1.DeleteTopicByNameResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.TopicName == "" {
 		return &kafkav1.DeleteTopicByNameResponse{
 			Success: false,
@@ -125,6 +141,9 @@ func (h *ClusterHandler) DeleteTopicByName(ctx context.Context, req *kafkav1.Del
 // This is used when topic metadata is stored externally (e.g., Payload CMS)
 // and we only need to create the topic on Kafka without storing in Go service.
 func (h *ClusterHandler) CreateTopicDirect(ctx context.Context, req *kafkav1.CreateTopicDirectRequest) (*kafkav1.CreateTopicDirectResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.TopicName == "" {
 		return &kafkav1.CreateTopicDirectResponse{
 			Success: false,
@@ -154,6 +173,9 @@ func (h *ClusterHandler) CreateTopicDirect(ctx context.Context, req *kafkav1.Cre
 
 // ListClusters returns all registered clusters
 func (h *ClusterHandler) ListClusters(ctx context.Context, req *kafkav1.ListClustersRequest) (*kafkav1.ListClustersResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	clusters, err := h.clusterService.ListClusters(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list clusters: %v", err)
@@ -171,6 +193,9 @@ func (h *ClusterHandler) ListClusters(ctx context.Context, req *kafkav1.ListClus
 
 // DeleteCluster deletes a cluster
 func (h *ClusterHandler) DeleteCluster(ctx context.Context, req *kafkav1.DeleteClusterRequest) (*kafkav1.DeleteClusterResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	clusterID, err := uuid.Parse(req.ClusterId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid cluster ID: %v", err)
@@ -190,6 +215,9 @@ func (h *ClusterHandler) DeleteCluster(ctx context.Context, req *kafkav1.DeleteC
 
 // CreateEnvironmentMapping creates an environment to cluster mapping
 func (h *ClusterHandler) CreateEnvironmentMapping(ctx context.Context, req *kafkav1.CreateEnvironmentMappingRequest) (*kafkav1.CreateEnvironmentMappingResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	clusterID, err := uuid.Parse(req.ClusterId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid cluster ID: %v", err)
@@ -216,6 +244,9 @@ func (h *ClusterHandler) CreateEnvironmentMapping(ctx context.Context, req *kafk
 
 // ListEnvironmentMappings returns environment mappings
 func (h *ClusterHandler) ListEnvironmentMappings(ctx context.Context, req *kafkav1.ListEnvironmentMappingsRequest) (*kafkav1.ListEnvironmentMappingsResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	mappings, err := h.clusterService.ListEnvironmentMappings(ctx, req.Environment)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list mappings: %v", err)
@@ -233,6 +264,9 @@ func (h *ClusterHandler) ListEnvironmentMappings(ctx context.Context, req *kafka
 
 // DeleteEnvironmentMapping deletes an environment mapping
 func (h *ClusterHandler) DeleteEnvironmentMapping(ctx context.Context, req *kafkav1.DeleteEnvironmentMappingRequest) (*kafkav1.DeleteEnvironmentMappingResponse, error) {
+	if err := svcauth.EnforcePlatformAdmin(ctx); err != nil {
+		return nil, err
+	}
 	mappingID, err := uuid.Parse(req.MappingId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid mapping ID: %v", err)

--- a/services/kafka/internal/grpc/cluster_handler_auth_test.go
+++ b/services/kafka/internal/grpc/cluster_handler_auth_test.go
@@ -1,0 +1,231 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	kafkav1 "github.com/drewpayment/orbit/proto/gen/go/idp/kafka/v1"
+	"github.com/drewpayment/orbit/proto/pkg/svcauth"
+	"github.com/drewpayment/orbit/services/kafka/internal/adapters"
+	"github.com/drewpayment/orbit/services/kafka/internal/domain"
+	"github.com/drewpayment/orbit/services/kafka/internal/service"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// mintKafkaAdminToken is the platform-admin counterpart of mintKafkaToken (in
+// share_handler_auth_test.go): it sets adm=true so the token satisfies
+// EnforcePlatformAdmin. Kept as a separate helper so the existing non-admin
+// minter and its call sites stay untouched.
+func mintKafkaAdminToken(t *testing.T, sub, wid string) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": "orbit-www",
+		"aud": "orbit-services",
+		"sub": sub,
+		"wid": wid,
+		"adm": true,
+		"iat": now.Unix(),
+		"exp": now.Add(120 * time.Second).Unix(),
+		"jti": uuid.NewString(),
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(testAuthSecret))
+	require.NoError(t, err)
+	return signed
+}
+
+// The fakes below are minimal in-memory stand-ins for the ClusterService's
+// dependencies. They return "not found" / empty / adapter-unavailable results so
+// that once a request passes the platform-admin gate the handler runs to
+// completion and returns a nil top-level gRPC error (domain failures are folded
+// into the response's Error field). That lets the admin-case assertion be a
+// clean require.NoError, proving the gate was passed without depending on a real
+// broker or database.
+
+type fakeClusterRepo struct{}
+
+func (fakeClusterRepo) Create(context.Context, *domain.KafkaCluster) error { return nil }
+func (fakeClusterRepo) GetByID(context.Context, uuid.UUID) (*domain.KafkaCluster, error) {
+	return nil, nil
+}
+func (fakeClusterRepo) List(context.Context) ([]*domain.KafkaCluster, error) { return nil, nil }
+func (fakeClusterRepo) Update(context.Context, *domain.KafkaCluster) error   { return nil }
+func (fakeClusterRepo) Delete(context.Context, uuid.UUID) error              { return nil }
+
+type fakeProviderRepo struct{}
+
+func (fakeProviderRepo) GetByID(context.Context, string) (*domain.KafkaProvider, error) {
+	return nil, nil
+}
+func (fakeProviderRepo) List(context.Context) ([]*domain.KafkaProvider, error) { return nil, nil }
+
+type fakeEnvMappingRepo struct{}
+
+func (fakeEnvMappingRepo) Create(context.Context, *domain.KafkaEnvironmentMapping) error { return nil }
+func (fakeEnvMappingRepo) GetByID(context.Context, uuid.UUID) (*domain.KafkaEnvironmentMapping, error) {
+	return nil, nil
+}
+func (fakeEnvMappingRepo) List(context.Context, string) ([]*domain.KafkaEnvironmentMapping, error) {
+	return nil, nil
+}
+func (fakeEnvMappingRepo) Delete(context.Context, uuid.UUID) error { return nil }
+func (fakeEnvMappingRepo) GetDefaultForEnvironment(context.Context, string) (*domain.KafkaEnvironmentMapping, error) {
+	return nil, nil
+}
+
+// fakeAdapterFactory fails to create an adapter, so the connection/topic RPCs
+// return a folded domain error rather than dialing a real broker.
+type fakeAdapterFactory struct{}
+
+func (fakeAdapterFactory) CreateKafkaAdapter(*domain.KafkaCluster, map[string]string) (adapters.KafkaAdapter, error) {
+	return nil, errors.New("no broker available in test")
+}
+func (fakeAdapterFactory) CreateSchemaRegistryAdapter(*domain.SchemaRegistry, map[string]string) (adapters.SchemaRegistryAdapter, error) {
+	return nil, errors.New("no schema registry available in test")
+}
+
+// newAuthedClusterServer wires the real auth interceptor in front of a
+// KafkaServer whose ClusterService is backed by the fakes above.
+func newAuthedClusterServer() (grpc.UnaryServerInterceptor, *KafkaServer) {
+	clusterService := service.NewClusterService(
+		fakeClusterRepo{}, fakeProviderRepo{}, fakeEnvMappingRepo{}, fakeAdapterFactory{},
+	)
+	srv := NewKafkaServer(clusterService, nil, nil, nil)
+	interceptor := svcauth.UnaryServerInterceptor([]byte(testAuthSecret), true)
+	return interceptor, srv
+}
+
+// TestClusterHandler_PlatformAdminGate is the UAC-1 table: every ClusterHandler
+// RPC must reject a missing token (Unauthenticated) and a valid non-admin token
+// (PermissionDenied), and let an adm=true token through to handler logic.
+func TestClusterHandler_PlatformAdminGate(t *testing.T) {
+	interceptor, srv := newAuthedClusterServer()
+
+	// A single valid UUID reused for the ID-bearing requests; the gate runs
+	// before any ID parsing, and in the admin case these resolve to a folded
+	// "not found" response (nil top-level error).
+	validID := uuid.NewString()
+
+	cases := []struct {
+		name    string
+		method  string
+		req     any
+		handler grpc.UnaryHandler
+	}{
+		{
+			"ListProviders", "/idp.kafka.v1.KafkaService/ListProviders",
+			&kafkav1.ListProvidersRequest{},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.ListProviders(ctx, req.(*kafkav1.ListProvidersRequest))
+			},
+		},
+		{
+			"RegisterCluster", "/idp.kafka.v1.KafkaService/RegisterCluster",
+			&kafkav1.RegisterClusterRequest{Name: "c", ProviderId: "p"},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.RegisterCluster(ctx, req.(*kafkav1.RegisterClusterRequest))
+			},
+		},
+		{
+			"ValidateCluster", "/idp.kafka.v1.KafkaService/ValidateCluster",
+			&kafkav1.ValidateClusterRequest{ClusterId: validID},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.ValidateCluster(ctx, req.(*kafkav1.ValidateClusterRequest))
+			},
+		},
+		{
+			"ValidateClusterConnection", "/idp.kafka.v1.KafkaService/ValidateClusterConnection",
+			&kafkav1.ValidateClusterConnectionRequest{ConnectionConfig: map[string]string{"brokers": "x"}},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.ValidateClusterConnection(ctx, req.(*kafkav1.ValidateClusterConnectionRequest))
+			},
+		},
+		{
+			"DeleteTopicByName", "/idp.kafka.v1.KafkaService/DeleteTopicByName",
+			&kafkav1.DeleteTopicByNameRequest{TopicName: "t", ConnectionConfig: map[string]string{"brokers": "x"}},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.DeleteTopicByName(ctx, req.(*kafkav1.DeleteTopicByNameRequest))
+			},
+		},
+		{
+			"CreateTopicDirect", "/idp.kafka.v1.KafkaService/CreateTopicDirect",
+			&kafkav1.CreateTopicDirectRequest{TopicName: "t", ConnectionConfig: map[string]string{"brokers": "x"}},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.CreateTopicDirect(ctx, req.(*kafkav1.CreateTopicDirectRequest))
+			},
+		},
+		{
+			"ListClusters", "/idp.kafka.v1.KafkaService/ListClusters",
+			&kafkav1.ListClustersRequest{},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.ListClusters(ctx, req.(*kafkav1.ListClustersRequest))
+			},
+		},
+		{
+			"DeleteCluster", "/idp.kafka.v1.KafkaService/DeleteCluster",
+			&kafkav1.DeleteClusterRequest{ClusterId: validID},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.DeleteCluster(ctx, req.(*kafkav1.DeleteClusterRequest))
+			},
+		},
+		{
+			"CreateEnvironmentMapping", "/idp.kafka.v1.KafkaService/CreateEnvironmentMapping",
+			&kafkav1.CreateEnvironmentMappingRequest{ClusterId: validID, Environment: "prod"},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.CreateEnvironmentMapping(ctx, req.(*kafkav1.CreateEnvironmentMappingRequest))
+			},
+		},
+		{
+			"ListEnvironmentMappings", "/idp.kafka.v1.KafkaService/ListEnvironmentMappings",
+			&kafkav1.ListEnvironmentMappingsRequest{},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.ListEnvironmentMappings(ctx, req.(*kafkav1.ListEnvironmentMappingsRequest))
+			},
+		},
+		{
+			"DeleteEnvironmentMapping", "/idp.kafka.v1.KafkaService/DeleteEnvironmentMapping",
+			&kafkav1.DeleteEnvironmentMappingRequest{MappingId: validID},
+			func(ctx context.Context, req any) (any, error) {
+				return srv.DeleteEnvironmentMapping(ctx, req.(*kafkav1.DeleteEnvironmentMappingRequest))
+			},
+		},
+	}
+
+	require.Len(t, cases, 11, "every ClusterHandler RPC must be covered")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("no token is Unauthenticated", func(t *testing.T) {
+				_, err := invoke(interceptor, context.Background(), tc.method, tc.req, tc.handler)
+				require.Error(t, err)
+				assert.Equal(t, codes.Unauthenticated, status.Code(err))
+			})
+
+			t.Run("non-admin token is PermissionDenied", func(t *testing.T) {
+				token := mintKafkaToken(t, uuid.NewString(), "")
+				ctx := metadata.NewIncomingContext(context.Background(),
+					metadata.Pairs("authorization", "Bearer "+token))
+				_, err := invoke(interceptor, ctx, tc.method, tc.req, tc.handler)
+				require.Error(t, err)
+				assert.Equal(t, codes.PermissionDenied, status.Code(err))
+			})
+
+			t.Run("admin token reaches handler", func(t *testing.T) {
+				token := mintKafkaAdminToken(t, uuid.NewString(), "")
+				ctx := metadata.NewIncomingContext(context.Background(),
+					metadata.Pairs("authorization", "Bearer "+token))
+				_, err := invoke(interceptor, ctx, tc.method, tc.req, tc.handler)
+				require.NoError(t, err, "adm=true token must pass the gate and reach handler logic")
+			})
+		})
+	}
+}


### PR DESCRIPTION
Closes #50 (the PR #49 accepted residual: cluster-level RPCs were authenticated but not authorized — any tenant could register/delete global clusters and run direct topic ops with attacker-supplied broker config).

## What

- **svcauth** (`proto/pkg/svcauth`): `Claims` gains `adm` (`PlatformAdmin bool, json:"adm,omitempty"`) — **fail closed**: absent claim parses as non-admin, so pre-existing tokens get no elevation. Threaded through `Identity` on both the grpc (kafka) and connect (repository) paths. New `EnforcePlatformAdmin(ctx)`: no identity ⇒ `Unauthenticated`, non-admin ⇒ `PermissionDenied "platform admin required"`.
- **kafka-service**: `EnforcePlatformAdmin` is the first statement of all 11 ClusterHandler RPCs (ListProviders, RegisterCluster, ValidateCluster, ValidateClusterConnection, DeleteTopicByName, CreateTopicDirect, ListClusters, DeleteCluster, Create/List/DeleteEnvironmentMapping). Topic/share/service-account handlers untouched.
- **orbit-www**: `mintServiceToken` sets `adm` iff the server-side session user passes `isPlatformAdmin` (Better-Auth `role` additionalField, `input: false`). Request input cannot elevate — covered by a test that smuggles an admin role in the message and asserts no `adm` claim.

Caller analysis: the only live gRPC caller of any cluster RPC is `validateClusterConnection` from the already-`requireAdmin()`-gated server action, so nothing regresses. `CreateTopicDirect`/`DeleteTopicByName` have no callers (Temporal uses its own broker adapter) — now dead attack surface behind the gate.

## Verification

- Go: `go test -race` green in both modules; new table-driven gate test = 11 RPCs × {no token ⇒ Unauthenticated, non-admin ⇒ PermissionDenied, admin ⇒ reaches handler} (44 subtests). svcauth roundtrip tests prove absent-`adm` fails closed. `go vet` clean (golangci-lint not installed locally).
- TS: `bunx vitest run src/lib/grpc` — 23 passed; tsc at the 111-error main baseline (zero new); eslint clean.
- **Live QA against a rebuilt kafka-service container + browser (agent-browser)**: admin "Validate Connection" on /platform/kafka succeeds end-to-end (real 164ms broker round-trip in service logs); wire-level proof via grpcurl — no token ⇒ `Unauthenticated`, minted non-admin JWT ⇒ `PermissionDenied: platform admin required` (the exact #50 attack), admin JWT ⇒ OK cluster list. Member workspace Kafka UI regression-free.

Deployment note: if kafka-service ships before orbit-www, admin Validate-Connection returns PermissionDenied until www ships the claim — both land together here.

Plan: docs/plans/2026-07-06-kafka-cluster-admin-gate.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5MWQjx9kVpheX3fUNBq4z