### PR TITLE
fix(auth): working email verification, unbroken signup, super_admin first user

### DIFF
--- a/docs/plans/2026-07-06-email-verification-fix.md
+++ b/docs/plans/2026-07-06-email-verification-fix.md
@@ -1,0 +1,97 @@
+# Email verification flow fix
+
+**Date:** 2026-07-06
+**Status:** In progress on `fix/email-verification-flow`
+**Owner:** PM session (Claude) directing engineer + QA agents
+**Context:** Drew locked out of the deployed site — "verify your email" on a
+6-month-old approved account, no email ever delivered.
+
+## Problems (verified on main, 2026-07-06)
+
+1. **Invalid tokens.** `src/collections/hooks/userApprovalHook.ts` hand-rolls a
+   verification token (random hex inserted into the `verification` collection)
+   and links to `/api/auth/verify-email?token=...`. Better-Auth's verify-email
+   endpoint expects its own signed token — the emailed link does not verify.
+   Never validated end-to-end.
+2. **Silent production no-op.** Both send paths (`auth.ts`
+   `emailVerification.sendVerificationEmail` and the approval hook) skip sending
+   with no log at all when `RESEND_API_KEY` is unset outside development; send
+   errors are swallowed.
+3. **No resend path.** Login error says "check your inbox" but nothing can
+   regenerate the email: `auth.ts` sender is unreachable (`sendOnSignUp: false`,
+   zero client call sites), hook tokens expire in 24h, login page has no action.
+4. **Gate exemptions too narrow / checkbox not retroactive.** Session-create
+   gate (`auth.ts:117`) exempts only `super_admin`. The `skipEmailVerification`
+   checkbox only takes effect if checked before the status flip (hook fires
+   only on status *change*).
+
+## Design
+
+1. **Single sender, valid tokens.** The approval hook stops minting tokens and
+   calls Better-Auth's server API instead:
+   `auth.api.sendVerificationEmail({ body: { email, callbackURL: '/login' } })`.
+   That routes through `auth.ts`'s `emailVerification.sendVerificationEmail`
+   with a token Better-Auth itself validates. Delete the hook's duplicated
+   HTML template and hand-rolled `verification` insert.
+2. **Loud failures.** In `auth.ts` sender: if `RESEND_API_KEY` is missing and
+   `NODE_ENV === 'production'`, `console.error` a `[email-verification]`-tagged
+   line (unmissable in pod logs) — keep dev behavior (log the URL to console,
+   skip send). In the approval hook, catch + `console.error` send failures and
+   continue (approval itself must not roll back), but include the email + error.
+3. **Resend action.** On the login page, when sign-in fails with the
+   verify-your-email FORBIDDEN message, render a "Resend verification email"
+   button that calls the Better-Auth client `sendVerificationEmail({ email,
+   callbackURL: '/login' })` with the entered email. Show success/failure
+   feedback. (Better-Auth no-ops for unknown emails — no enumeration issue.)
+4. **Policy** (PM decision): exempt `admin` alongside `super_admin` in the
+   session gate (admins are hand-vetted; today they're approved via the panel
+   where email delivery may not even be configured). Keep the gate for `user`.
+   Make `skipEmailVerification` retroactive: hook also fires when the checkbox
+   flips true on an already-approved user → set `emailVerified: true` on the
+   Better-Auth doc (no email sent).
+5. **No schema changes**; no collection access changes.
+
+## Files
+
+- `orbit-www/src/collections/hooks/userApprovalHook.ts` — rewrite send path
+  (auth.api call), add retroactive-skip branch, keep status sync + metadata.
+- `orbit-www/src/lib/auth.ts` — sender: loud prod failure; gate: exempt
+  `admin` + `super_admin` (line ~117).
+- `orbit-www/src/app/(auth)/login/page.tsx` (or its client component) — resend
+  button on the verification error state.
+- Tests: hook unit tests (mock auth.api + mongo), auth-gate test if a harness
+  exists, login-page component test for the resend state.
+
+## UAC
+
+- **UAC-1** Approving a user (status → approved, skip unchecked) triggers exactly
+  one Better-Auth-issued verification email; clicking the emailed link verifies
+  the account and login then succeeds. Proven live in dev via the console-logged
+  URL (dev mode logs it; QA follows it in the browser).
+- **UAC-2** `skipEmailVerification` checked at approval time ⇒ `emailVerified:
+  true`, no email. Checking it AFTER approval (separate save) also sets
+  `emailVerified: true` (retroactive).
+- **UAC-3** Login blocked by the gate shows the message AND a working "Resend
+  verification email" action; resent link verifies successfully.
+- **UAC-4** `role: admin` and `super_admin` are exempt from the gate; `user` is
+  not. Legacy docs without `status` still pass.
+- **UAC-5** With `RESEND_API_KEY` unset: dev logs the URL and continues;
+  production path logs a loud `[email-verification]` error (unit-tested via
+  NODE_ENV stub) — never a silent skip.
+- **UAC-6** No hand-rolled `verification` inserts remain; single email template
+  lives in `auth.ts`.
+- **UAC-7** `bunx vitest run` on touched areas green; `bunx tsc --noEmit` at the
+  ~111 main baseline (zero new); eslint clean on touched files.
+- **UAC-8** Browser QA (dev server): full signup → admin-approve → verify-link →
+  login journey; resend journey; skip-checkbox journey. Existing seeded admin
+  login unaffected.
+
+## Verification
+
+1. `cd orbit-www && bunx vitest run src/collections src/app` (touched suites)
+2. `bunx tsc --noEmit` baseline check; eslint on touched files
+3. agent-browser QA per UAC-8 with screenshots
+4. PR references the deployed-site incident; deployment notes: requires
+   `ORBIT_RESEND_API_KEY`/`ORBIT_RESEND_FROM_EMAIL` in Doppler (and the
+   already-missing `ORBIT_SVC_AUTH_SECRET` for the stuck rollout — separate
+   infra action, not this PR).

--- a/docs/plans/2026-07-06-email-verification-fix.md
+++ b/docs/plans/2026-07-06-email-verification-fix.md
@@ -1,7 +1,7 @@
 # Email verification flow fix
 
 **Date:** 2026-07-06
-**Status:** In progress on `fix/email-verification-flow`
+**Status:** Implemented on `fix/email-verification-flow` — QA validated live across two passes (full verify journey with a real Better-Auth token, resend→verify→login, retroactive skip, register-500 fix with auto-created Payload user, error classification, admin-gate exemption). Scope grew: + register-route 500 fix (autoSignIn:false), + first-setup-user is super_admin in all three role stores.
 **Owner:** PM session (Claude) directing engineer + QA agents
 **Context:** Drew locked out of the deployed site — "verify your email" on a
 6-month-old approved account, no email ever delivered.

--- a/orbit-www/src/app/(auth)/login/page.test.tsx
+++ b/orbit-www/src/app/(auth)/login/page.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockSignInEmail = vi.fn()
+const mockSendVerificationEmail = vi.fn()
+vi.mock('@/lib/auth-client', () => ({
+  signIn: { email: (...args: unknown[]) => mockSignInEmail(...args) },
+  authClient: {
+    sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+  },
+}))
+
+import LoginPage from './page'
+
+async function fillAndSubmit() {
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText('Email address'), 'u@test.com')
+  await user.type(screen.getByLabelText('Password'), 'Password1234')
+  await user.click(screen.getByRole('button', { name: /sign in/i }))
+  return user
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LoginPage — verification error resend', () => {
+  it('shows a Resend verification email button when sign-in fails with the verify-email error', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Please verify your email before logging in. Check your inbox.' },
+    })
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /resend verification email/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('does NOT show the resend button for an invalid-credentials error', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Invalid email or password' },
+    })
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email or password/i)).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('button', { name: /resend verification email/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('resends via the Better Auth client with the entered email and shows sent feedback', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Please verify your email before logging in. Check your inbox.' },
+    })
+    mockSendVerificationEmail.mockResolvedValue({ data: {}, error: null })
+
+    render(<LoginPage />)
+    const user = await fillAndSubmit()
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend verification email/i,
+    })
+    await user.click(resendBtn)
+
+    await waitFor(() => {
+      expect(mockSendVerificationEmail).toHaveBeenCalledWith({
+        email: 'u@test.com',
+        callbackURL: '/login',
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/verification email sent/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows failure feedback when the resend call errors', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: 'Please verify your email before logging in. Check your inbox.' },
+    })
+    mockSendVerificationEmail.mockResolvedValue({ data: null, error: { message: 'boom' } })
+
+    render(<LoginPage />)
+    const user = await fillAndSubmit()
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend verification email/i,
+    })
+    await user.click(resendBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not send/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/orbit-www/src/app/(auth)/login/page.tsx
+++ b/orbit-www/src/app/(auth)/login/page.tsx
@@ -3,10 +3,17 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { signIn } from '@/lib/auth-client'
+import { signIn, authClient } from '@/lib/auth-client'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+
+// The session gate throws a FORBIDDEN whose message contains this phrase when an
+// approved-but-unverified user tries to sign in. Match on the specific phrase so
+// unrelated errors that merely mention "email" don't offer a resend action.
+function isVerificationError(error: { message?: string } | null | undefined): boolean {
+  return (error?.message || '').includes('verify your email')
+}
 
 function getErrorDisplay(error: any): { message: string; type: 'error' | 'info' | 'warning' } {
   const message = error?.message || ''
@@ -23,7 +30,7 @@ function getErrorDisplay(error: any): { message: string; type: 'error' | 'info' 
       type: 'error',
     }
   }
-  if (message.includes('verify your email') || message.includes('email')) {
+  if (message.includes('verify your email')) {
     return {
       message: 'Please verify your email before logging in. Check your inbox for a verification link.',
       type: 'warning',
@@ -48,10 +55,14 @@ export default function LoginPage() {
   const [password, setPassword] = useState('')
   const [errorDisplay, setErrorDisplay] = useState<{ message: string; type: 'error' | 'info' | 'warning' } | null>(null)
   const [loading, setLoading] = useState(false)
+  const [showResend, setShowResend] = useState(false)
+  const [resendStatus, setResendStatus] = useState<'idle' | 'pending' | 'sent' | 'error'>('idle')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setErrorDisplay(null)
+    setShowResend(false)
+    setResendStatus('idle')
     setLoading(true)
 
     try {
@@ -62,6 +73,7 @@ export default function LoginPage() {
 
       if (result.error) {
         setErrorDisplay(getErrorDisplay(result.error))
+        setShowResend(isVerificationError(result.error))
       } else {
         router.push('/dashboard')
       }
@@ -70,6 +82,20 @@ export default function LoginPage() {
       console.error(err)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleResend = async () => {
+    setResendStatus('pending')
+    try {
+      const result = await authClient.sendVerificationEmail({
+        email,
+        callbackURL: '/login',
+      })
+      setResendStatus(result?.error ? 'error' : 'sent')
+    } catch (err) {
+      console.error(err)
+      setResendStatus('error')
     }
   }
 
@@ -94,6 +120,30 @@ export default function LoginPage() {
         {errorDisplay && (
           <div className={`border px-4 py-3 rounded ${alertStyles[errorDisplay.type]}`}>
             {errorDisplay.message}
+          </div>
+        )}
+
+        {showResend && (
+          <div className="space-y-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleResend}
+              disabled={resendStatus === 'pending'}
+            >
+              {resendStatus === 'pending' ? 'Sending...' : 'Resend verification email'}
+            </Button>
+            {resendStatus === 'sent' && (
+              <p className="text-sm text-green-600 dark:text-green-400">
+                Verification email sent. Check your inbox for the link.
+              </p>
+            )}
+            {resendStatus === 'error' && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                Could not send the verification email. Please try again.
+              </p>
+            )}
           </div>
         )}
 

--- a/orbit-www/src/app/api/register/route.ts
+++ b/orbit-www/src/app/api/register/route.ts
@@ -15,13 +15,25 @@ export async function POST(request: NextRequest) {
     }
 
     // 1. Create Better Auth user with status: pending (set by defaultValue)
-    const signUpResponse = await auth.api.signUpEmail({
-      body: {
-        email,
-        password,
-        name: name || '',
-      },
-    })
+    let signUpResponse
+    try {
+      signUpResponse = await auth.api.signUpEmail({
+        body: {
+          email,
+          password,
+          name: name || '',
+        },
+      })
+    } catch (signUpError: any) {
+      // The session.create gate rejects pending users. With autoSignIn: false
+      // this shouldn't fire at signup anymore, but if it does the user WAS
+      // created and only the session was denied — registration succeeded.
+      if (signUpError?.message?.includes('pending admin approval')) {
+        signUpResponse = true
+      } else {
+        throw signUpError
+      }
+    }
 
     if (!signUpResponse) {
       return NextResponse.json(

--- a/orbit-www/src/app/api/setup/route.ts
+++ b/orbit-www/src/app/api/setup/route.ts
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
       await setupClient.connect()
       await setupClient.db().collection('user').updateOne(
         { _id: new ObjectId(authUserId) },
-        { $set: { status: 'approved', role: 'admin', emailVerified: true } }
+        { $set: { status: 'approved', role: 'super_admin', emailVerified: true } }
       )
     } finally {
       await setupClient.close()
@@ -99,7 +99,7 @@ export async function POST(request: Request) {
 
     const payloadUser = await payload.create({
       collection: 'users',
-      data: { email, name, password, status: 'approved' },
+      data: { email, name, password, status: 'approved', role: 'super_admin' },
       overrideAccess: true,
       context: { skipApprovalHook: true },
     })

--- a/orbit-www/src/collections/hooks/userApprovalHook.test.ts
+++ b/orbit-www/src/collections/hooks/userApprovalHook.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- mongodb mock -----------------------------------------------------------
+const mockFindOne = vi.fn()
+const mockUpdateOne = vi.fn()
+const mockInsertOne = vi.fn()
+const mockCollection = vi.fn(() => ({
+  findOne: mockFindOne,
+  updateOne: mockUpdateOne,
+  insertOne: mockInsertOne,
+}))
+vi.mock('@/lib/mongodb', () => ({
+  getMongoClient: vi.fn(async () => ({
+    db: () => ({ collection: mockCollection }),
+  })),
+}))
+
+// --- Better Auth server API mock (imported dynamically by the hook) ---------
+const mockSendVerificationEmail = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { sendVerificationEmail: mockSendVerificationEmail } },
+}))
+
+import { userApprovalAfterChangeHook } from './userApprovalHook'
+
+const mockPayloadUpdate = vi.fn()
+
+function runHook(args: {
+  operation?: 'create' | 'update'
+  doc: Record<string, unknown>
+  previousDoc?: Record<string, unknown>
+}) {
+  return (userApprovalAfterChangeHook as any)({
+    operation: args.operation ?? 'update',
+    doc: args.doc,
+    previousDoc: args.previousDoc ?? {},
+    req: { payload: { update: mockPayloadUpdate }, user: { id: 'admin-1' } },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindOne.mockResolvedValue({ _id: 'ba-1', email: 'u@test.com' })
+  mockSendVerificationEmail.mockResolvedValue({})
+  mockPayloadUpdate.mockResolvedValue({})
+})
+
+describe('userApprovalAfterChangeHook', () => {
+  it('UAC-1: approving (skip unchecked) requests exactly one Better-Auth verification email and no hand-rolled token', async () => {
+    await runHook({
+      doc: { id: 'p1', email: 'u@test.com', status: 'approved', skipEmailVerification: false },
+      previousDoc: { status: 'pending' },
+    })
+
+    expect(mockSendVerificationEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith({
+      body: { email: 'u@test.com', callbackURL: '/login' },
+    })
+    // Better Auth user marked approved, NOT force-verified
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'ba-1' },
+      { $set: { status: 'approved' } },
+    )
+    // No hand-rolled insert into the verification collection remains
+    expect(mockInsertOne).not.toHaveBeenCalled()
+  })
+
+  it('UAC-2a: approving with skip checked sets emailVerified and sends no email', async () => {
+    await runHook({
+      doc: { id: 'p1', email: 'u@test.com', status: 'approved', skipEmailVerification: true },
+      previousDoc: { status: 'pending' },
+    })
+
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'ba-1' },
+      { $set: { status: 'approved', emailVerified: true } },
+    )
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled()
+  })
+
+  it('UAC-2b: checking skip AFTER approval (status unchanged) retroactively sets emailVerified, no email', async () => {
+    await runHook({
+      doc: { id: 'p1', email: 'u@test.com', status: 'approved', skipEmailVerification: true },
+      previousDoc: { status: 'approved', skipEmailVerification: false },
+    })
+
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'ba-1' },
+      { $set: { emailVerified: true } },
+    )
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled()
+    // retroactive path does not rewrite approval metadata
+    expect(mockPayloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when status is unchanged and skip did not flip', async () => {
+    await runHook({
+      doc: { id: 'p1', email: 'u@test.com', status: 'approved', skipEmailVerification: false },
+      previousDoc: { status: 'approved', skipEmailVerification: false },
+    })
+
+    expect(mockFindOne).not.toHaveBeenCalled()
+    expect(mockUpdateOne).not.toHaveBeenCalled()
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on create', async () => {
+    await runHook({
+      operation: 'create',
+      doc: { id: 'p1', email: 'u@test.com', status: 'approved' },
+    })
+    expect(mockFindOne).not.toHaveBeenCalled()
+  })
+
+  it('marks Better Auth user rejected when status flips to rejected', async () => {
+    await runHook({
+      doc: { id: 'p1', email: 'u@test.com', status: 'rejected' },
+      previousDoc: { status: 'pending' },
+    })
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'ba-1' },
+      { $set: { status: 'rejected' } },
+    )
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled()
+  })
+
+  it('swallows send failures so approval is not rolled back', async () => {
+    mockSendVerificationEmail.mockRejectedValue(new Error('resend down'))
+    await expect(
+      runHook({
+        doc: { id: 'p1', email: 'u@test.com', status: 'approved', skipEmailVerification: false },
+        previousDoc: { status: 'pending' },
+      }),
+    ).resolves.toBeDefined()
+    // BA user still approved despite send failure
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'ba-1' },
+      { $set: { status: 'approved' } },
+    )
+  })
+
+  it('returns early when no Better Auth user exists for the email', async () => {
+    mockFindOne.mockResolvedValue(null)
+    await runHook({
+      doc: { id: 'p1', email: 'ghost@test.com', status: 'approved', skipEmailVerification: false },
+      previousDoc: { status: 'pending' },
+    })
+    expect(mockUpdateOne).not.toHaveBeenCalled()
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled()
+  })
+})

--- a/orbit-www/src/collections/hooks/userApprovalHook.ts
+++ b/orbit-www/src/collections/hooks/userApprovalHook.ts
@@ -5,9 +5,13 @@ import { getMongoClient } from '@/lib/mongodb'
  * Syncs user approval status changes from Payload admin to Better Auth.
  *
  * When an admin changes a user's status in Payload:
- * - approved: Updates Better Auth user status, optionally sets emailVerified
- *   and triggers verification email via Resend
- * - rejected: Updates Better Auth user status
+ * - approved (skip unchecked): marks the Better Auth user approved and asks
+ *   Better Auth's server API to mint + send a valid verification email
+ * - approved (skip checked): marks the Better Auth user approved and verified,
+ *   no email
+ * - skip checked on an already-approved user (status unchanged): retroactively
+ *   marks the Better Auth user verified, no email
+ * - rejected: marks the Better Auth user rejected
  */
 export const userApprovalAfterChangeHook: CollectionAfterChangeHook = async ({
   operation,
@@ -20,9 +24,19 @@ export const userApprovalAfterChangeHook: CollectionAfterChangeHook = async ({
 
   const previousStatus = previousDoc?.status
   const newStatus = doc.status
+  const statusChanged = previousStatus !== newStatus
 
-  // Only act when status actually changed
-  if (previousStatus === newStatus) return doc
+  // Retroactive skip: the checkbox flipped true on an already-approved user
+  // whose status did not otherwise change. The hook normally only fires on a
+  // status change, so this branch handles "approve now, skip verification
+  // later" as a separate save.
+  const retroactiveSkip =
+    !statusChanged &&
+    newStatus === 'approved' &&
+    previousDoc?.skipEmailVerification !== true &&
+    doc.skipEmailVerification === true
+
+  if (!statusChanged && !retroactiveSkip) return doc
 
   const mongoClient = await getMongoClient()
   const db = mongoClient.db()
@@ -32,6 +46,15 @@ export const userApprovalAfterChangeHook: CollectionAfterChangeHook = async ({
   const baUser = await baUserCollection.findOne({ email: doc.email })
   if (!baUser) {
     console.warn(`[userApprovalHook] No Better Auth user found for email: ${doc.email}`)
+    return doc
+  }
+
+  if (retroactiveSkip) {
+    await baUserCollection.updateOne(
+      { _id: baUser._id },
+      { $set: { emailVerified: true } },
+    )
+    console.log(`[userApprovalHook] Email verification retroactively skipped for ${doc.email}`)
     return doc
   }
 
@@ -62,60 +85,17 @@ export const userApprovalAfterChangeHook: CollectionAfterChangeHook = async ({
     })
 
     if (!skipVerification) {
+      // Ask Better Auth to mint its OWN signed token and route it through the
+      // single sender in lib/auth.ts. Dynamic import avoids any config-load
+      // cycle (Users -> hook -> auth) and keeps this the sole email path.
       try {
-        const { Resend } = await import('resend')
-        const resend = new Resend(process.env.RESEND_API_KEY)
-        const fromEmail = process.env.RESEND_FROM_EMAIL || 'noreply@hoytlabs.app'
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-
-        // Create a verification token in Better Auth's verification collection
-        const crypto = await import('crypto')
-        const token = crypto.randomBytes(32).toString('hex')
-        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
-
-        await db.collection('verification').insertOne({
-          identifier: doc.email,
-          value: token,
-          expiresAt,
-          createdAt: new Date(),
-          updatedAt: new Date(),
+        const { auth } = await import('@/lib/auth')
+        await auth.api.sendVerificationEmail({
+          body: { email: doc.email, callbackURL: '/login' },
         })
-
-        const verificationUrl = `${appUrl}/api/auth/verify-email?token=${token}&callbackURL=${encodeURIComponent(appUrl + '/login')}`
-
-        if (process.env.NODE_ENV === 'development') {
-          console.log(`\n${'='.repeat(60)}`)
-          console.log(`📧 EMAIL VERIFICATION (dev mode)`)
-          console.log(`   To: ${doc.email}`)
-          console.log(`   URL: ${verificationUrl}`)
-          console.log(`${'='.repeat(60)}\n`)
-        }
-
-        if (!process.env.RESEND_API_KEY) {
-          if (process.env.NODE_ENV === 'development') {
-            console.log(`   (No RESEND_API_KEY — skipping email send in dev mode)`)
-          }
-        } else {
-          await resend.emails.send({
-            from: fromEmail,
-            to: doc.email,
-            subject: 'Verify your Orbit account',
-            html: `
-              <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 600px; margin: 0 auto;">
-                <h2 style="color: #1a1a1a;">Verify your email address</h2>
-                <p>Your Orbit account has been approved! Click the link below to verify your email and start using Orbit.</p>
-                <p style="margin: 24px 0;">
-                  <a href="${verificationUrl}" style="display: inline-block; background: #FF5C00; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 500;">
-                    Verify Email
-                  </a>
-                </p>
-                <p style="color: #666; font-size: 14px;">This link expires in 24 hours. If you didn't create an Orbit account, you can ignore this email.</p>
-              </div>
-            `,
-          })
-          console.log(`[userApprovalHook] Verification email sent to ${doc.email}`)
-        }
+        console.log(`[userApprovalHook] Verification email requested for ${doc.email}`)
       } catch (error) {
+        // Approval itself must not roll back if delivery fails.
         console.error(`[userApprovalHook] Failed to send verification email to ${doc.email}:`, error)
       }
     } else {

--- a/orbit-www/src/lib/auth.ts
+++ b/orbit-www/src/lib/auth.ts
@@ -15,6 +15,10 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false, // Handled manually in databaseHooks for gated users only
+    // Signups start as status:pending, and the session.create gate rejects
+    // pending users — creating a session at signup would make registration
+    // itself fail with FORBIDDEN. New users sign in after approval instead.
+    autoSignIn: false,
   },
   emailVerification: {
     sendVerificationEmail: async ({ user, url }) => {

--- a/orbit-www/src/lib/auth.ts
+++ b/orbit-www/src/lib/auth.ts
@@ -29,6 +29,10 @@ export const auth = betterAuth({
       if (!process.env.RESEND_API_KEY) {
         if (process.env.NODE_ENV === "development") {
           console.log(`   (No RESEND_API_KEY — skipping email send in dev mode)`)
+        } else if (process.env.NODE_ENV === "production") {
+          console.error(
+            `[email-verification] RESEND_API_KEY not configured — verification email NOT sent to ${user.email}`,
+          )
         }
         return
       }
@@ -114,7 +118,12 @@ export const auth = betterAuth({
               message: "Your registration was not approved. Contact an administrator.",
             })
           }
-          if (status === "approved" && !user.emailVerified && user.role !== "super_admin") {
+          if (
+            status === "approved" &&
+            !user.emailVerified &&
+            user.role !== "super_admin" &&
+            user.role !== "admin"
+          ) {
             throw new APIError("FORBIDDEN", {
               message: "Please verify your email before logging in. Check your inbox.",
             })


### PR DESCRIPTION
Fixes the deployed-site lockout class Drew hit ("verify your email" with no email ever arriving) plus two adjacent registration bugs found during QA.

## What

**Email verification actually works now**
- The approval hook sent links built from a hand-rolled hex token inserted into the `verification` collection — Better-Auth's verify-email endpoint expects its own signed token, so the emailed link could never verify. The hook now calls `auth.api.sendVerificationEmail` and Better-Auth mints/validates its own token. Single email template lives in `auth.ts`.
- Silent-failure fix: missing `RESEND_API_KEY` in production now logs a loud `[email-verification]` error instead of silently skipping the send.
- **Resend path**: the login form's verify-email error now offers "Resend verification email" (Better-Auth client, entered email). Previously the error said "check your inbox" with no way to ever get another email (tokens expire in 24h).
- Error classification: any error containing 'email' (including "Invalid email or password") previously rendered as the verify-email warning — now only genuine verification errors do.
- Session gate exempts `admin` alongside `super_admin`; `skipEmailVerification` checkbox now applies retroactively to already-approved users.

**Signup was returning 500 for every registration** (QA discovery)
- `signUpEmail` auto-created a session, the pending-status gate rejected it, the route treated that as failure, and the Payload user row was never created — admins had nobody to approve. Fixed with `autoSignIn: false` + route-level resilience.

**Self-hosted first user is now super_admin** (per Drew)
- `/setup` assigned `admin` on the Better-Auth doc and default `user` on the Payload row while RBAC assigned super-admin. All three stores now agree on `super_admin` (auto-approved + email-verified as before).

## Verification

- Unit: 12 new tests (approval hook w/ mocked auth.api + mongo; login resend states) — green. tsc: zero errors in touched files (baseline unchanged); eslint clean.
- **Live browser QA, two passes** (agent-browser, dev server): full journey — UI signup → 200 + Payload row auto-created → admin approve → dev-logged Better-Auth JWT link verifies → login succeeds. Resend journey end-to-end. Retroactive-skip journey end-to-end. Wrong-password shows invalid-credentials (no bogus resend). Admin-role gate exemption confirmed.

## Deploy notes

- Requires `ORBIT_RESEND_API_KEY` / `ORBIT_RESEND_FROM_EMAIL` in Doppler for real sends (missing key is now loud, not silent).
- Unrelated but blocking deploys: `ORBIT_SVC_AUTH_SECRET` missing in Doppler has the orbit-www rollout stuck in CreateContainerConfigError since 2026-07-02 — infra action, not this PR.
- Existing locked-out accounts (approved + unverified) can self-serve via the new resend button once deployed, or be unblocked directly: `db.getCollection('user').updateOne({email},{\$set:{emailVerified:true}})`.

Plan: docs/plans/2026-07-06-email-verification-fix.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5MWQjx9kVpheX3fUNBq4z