### PR TITLE
feat(auth): self-service password reset flow

### DIFF
--- a/docs/plans/2026-07-06-password-reset.md
+++ b/docs/plans/2026-07-06-password-reset.md
@@ -1,0 +1,70 @@
+# Password reset (forgot password) flow
+
+**Date:** 2026-07-06
+**Status:** In progress on `feat/password-reset`
+**Owner:** PM session (Claude) directing engineer + QA agents
+**Context:** Prod lockout incident — Drew's password stopped working and the only
+recovery was a manual scrypt-hash injection into the prod Mongo. There is no
+self-service reset. Direct follow-on to PR #75 (verification/resend).
+
+## Design (Better-Auth native)
+
+1. **`orbit-www/src/lib/auth.ts`** — add to `emailAndPassword`:
+   `sendResetPassword: async ({ user, url }) => { ... }` using the exact same
+   pattern as `emailVerification.sendVerificationEmail` post-#75: dev-mode
+   console block (📧 PASSWORD RESET + URL), loud
+   `console.error('[password-reset] RESEND_API_KEY not configured …')` in
+   production when the key is missing, Resend send with an Orbit-styled HTML
+   template ("Reset your Orbit password", same visual language/orange button,
+   "link expires in 1 hour; if you didn't request this, ignore").
+   Keep default `resetPasswordTokenExpiresIn` (1h).
+2. **Login page** (`src/app/(auth)/login/page.tsx`) — a small "Forgot password?"
+   link near the password field → `/forgot-password`.
+3. **NEW `/forgot-password` page** (`src/app/(auth)/forgot-password/page.tsx`) —
+   email input + submit calling the Better-Auth client
+   `requestPasswordReset({ email, redirectTo: '/reset-password' })`.
+   ALWAYS render the same success state ("If an account exists for that email,
+   a reset link is on its way") regardless of whether the account exists — no
+   account enumeration. Match login-page styling.
+4. **NEW `/reset-password` page** (`src/app/(auth)/reset-password/page.tsx`) —
+   reads `token` from the query string (Better-Auth appends it to `redirectTo`);
+   new password + confirm fields (min 8 chars, must match), submit calls client
+   `resetPassword({ newPassword, token })`; success → redirect to `/login` with
+   a "password updated" notice; invalid/expired token (`error=INVALID_TOKEN` in
+   query or API error) → clear error state with a link back to `/forgot-password`.
+5. No schema changes, no collection access changes, no new dependencies.
+
+## UAC
+
+- **UAC-1** Full journey: "Forgot password?" from login → submit email →
+  always-success state → reset URL (dev-logged) opens the reset form → new
+  password accepted → redirected to login → OLD password rejected, NEW password
+  logs in.
+- **UAC-2** Unknown email submits to the identical success state (no
+  enumeration), and no reset URL is emitted for it.
+- **UAC-3** Invalid/expired/missing token on `/reset-password` shows the error
+  state with a path back to `/forgot-password`; no crash.
+- **UAC-4** Password rules enforced client-side (min 8, confirm matches) and
+  server errors surfaced inline.
+- **UAC-5** Missing `RESEND_API_KEY`: dev logs the URL and continues; prod path
+  logs the loud `[password-reset]` error (unit-testable branch mirror of #75).
+- **UAC-6** Verification gate and all PR #75 behaviors unchanged (resend button
+  etc. still work — regression check).
+- **UAC-7** `bunx vitest run` on touched suites green; tsc at main baseline
+  (zero new errors in touched files); eslint clean on touched files.
+- **UAC-8** Browser QA: full UAC-1 journey live on the dev server as a real
+  user (use a qa-verify-* account or a fresh @example.invalid signup +
+  approval), plus UAC-2/3 spot checks and screenshots.
+
+## Work packages
+
+- **Engineer (Opus)** — all of Design; TDD for the two new pages' components
+  and the auth-config branch where testable.
+- **QA (agent-browser)** — UAC-8 with screenshots; verdict gates merge.
+
+## Verification
+
+1. `cd orbit-www && bunx vitest run src/app/\(auth\)` (+ any touched suites)
+2. `bunx tsc --noEmit` baseline; eslint touched files
+3. agent-browser QA per UAC-8
+4. PR; deploy notes: no new env needed (reuses RESEND_*)

--- a/docs/plans/2026-07-06-password-reset.md
+++ b/docs/plans/2026-07-06-password-reset.md
@@ -1,7 +1,7 @@
 # Password reset (forgot password) flow
 
 **Date:** 2026-07-06
-**Status:** In progress on `feat/password-reset`
+**Status:** Implemented on `feat/password-reset` — QA validated live (full reset journey incl. old-password-rejected/new-accepted, no-enumeration, bad/missing/expired token states, inline validation, #75 regression check). Verdict: ship.
 **Owner:** PM session (Claude) directing engineer + QA agents
 **Context:** Prod lockout incident — Drew's password stopped working and the only
 recovery was a manual scrypt-hash injection into the prod Mongo. There is no

--- a/orbit-www/src/app/(auth)/forgot-password/page.test.tsx
+++ b/orbit-www/src/app/(auth)/forgot-password/page.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockRequestPasswordReset = vi.fn()
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+  },
+}))
+
+import ForgotPasswordPage from './page'
+
+async function fillAndSubmit(email = 'u@test.com') {
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText('Email address'), email)
+  await user.click(screen.getByRole('button', { name: /send reset link/i }))
+  return user
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ForgotPasswordPage', () => {
+  it('renders the email form and a back-to-login link', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /send reset link/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to login/i })).toHaveAttribute('href', '/login')
+  })
+
+  it('calls requestPasswordReset with the entered email and redirectTo, then shows the neutral success state', async () => {
+    mockRequestPasswordReset.mockResolvedValue({ data: { status: true }, error: null })
+
+    render(<ForgotPasswordPage />)
+    await fillAndSubmit('known@test.com')
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+        email: 'known@test.com',
+        redirectTo: '/reset-password',
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/if an account exists/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows the identical neutral success state even when the API returns an error (no account enumeration)', async () => {
+    mockRequestPasswordReset.mockResolvedValue({ data: null, error: { message: 'boom' } })
+
+    render(<ForgotPasswordPage />)
+    await fillAndSubmit('unknown@test.com')
+
+    await waitFor(() => {
+      expect(screen.getByText(/if an account exists/i)).toBeInTheDocument()
+    })
+    // The email form is gone; the success state does not reveal whether the account exists.
+    expect(screen.queryByLabelText('Email address')).not.toBeInTheDocument()
+  })
+})

--- a/orbit-www/src/app/(auth)/forgot-password/page.tsx
+++ b/orbit-www/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { authClient } from '@/lib/auth-client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+
+    try {
+      // Better-Auth returns the same neutral response whether or not the account
+      // exists, and only emits a reset email for real accounts. We ignore the
+      // result entirely and always show the same state — no account enumeration.
+      await authClient.requestPasswordReset({
+        email,
+        redirectTo: '/reset-password',
+      })
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+      setSubmitted(true)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md text-center">
+        <div className="mb-4">
+          <div className="mx-auto w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center">
+            <svg className="w-6 h-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          </div>
+        </div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          Check your email
+        </h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          If an account exists for that email, a password reset link is on its way. The link expires in 1 hour.
+        </p>
+        <Link
+          href="/login"
+          className="text-sm font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400"
+        >
+          Back to login
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md">
+      <div className="text-center mb-8">
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">
+          Reset your password
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          Enter your email address and we&apos;ll send you a link to reset your password.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <Label htmlFor="email">Email address</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1"
+          />
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={loading}
+        >
+          {loading ? 'Sending...' : 'Send reset link'}
+        </Button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
+        <Link
+          href="/login"
+          className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400"
+        >
+          Back to login
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/orbit-www/src/app/(auth)/login/page.test.tsx
+++ b/orbit-www/src/app/(auth)/login/page.test.tsx
@@ -3,8 +3,10 @@ import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const mockPush = vi.fn()
+let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
 }))
 
 const mockSignInEmail = vi.fn()
@@ -28,6 +30,7 @@ async function fillAndSubmit() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockSearchParams = new URLSearchParams()
 })
 
 afterEach(() => {
@@ -89,6 +92,25 @@ describe('LoginPage — verification error resend', () => {
     await waitFor(() => {
       expect(screen.getByText(/verification email sent/i)).toBeInTheDocument()
     })
+  })
+
+  it('shows a Forgot password link pointing at /forgot-password', () => {
+    render(<LoginPage />)
+    expect(screen.getByRole('link', { name: /forgot password/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    )
+  })
+
+  it('shows the password-updated notice when ?reset=success is present', () => {
+    mockSearchParams = new URLSearchParams('reset=success')
+    render(<LoginPage />)
+    expect(screen.getByText(/password updated/i)).toBeInTheDocument()
+  })
+
+  it('does not show the password-updated notice by default', () => {
+    render(<LoginPage />)
+    expect(screen.queryByText(/password updated/i)).not.toBeInTheDocument()
   })
 
   it('shows failure feedback when the resend call errors', async () => {

--- a/orbit-www/src/app/(auth)/login/page.tsx
+++ b/orbit-www/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { signIn, authClient } from '@/lib/auth-client'
 import { Button } from '@/components/ui/button'
@@ -49,8 +49,10 @@ const alertStyles = {
   info: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-600 dark:text-blue-400',
 }
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const resetSuccess = searchParams.get('reset') === 'success'
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errorDisplay, setErrorDisplay] = useState<{ message: string; type: 'error' | 'info' | 'warning' } | null>(null)
@@ -117,6 +119,12 @@ export default function LoginPage() {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
+        {resetSuccess && (
+          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400 px-4 py-3 rounded">
+            Password updated — sign in with your new password.
+          </div>
+        )}
+
         {errorDisplay && (
           <div className={`border px-4 py-3 rounded ${alertStyles[errorDisplay.type]}`}>
             {errorDisplay.message}
@@ -162,7 +170,15 @@ export default function LoginPage() {
         </div>
 
         <div>
-          <Label htmlFor="password">Password</Label>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="password">Password</Label>
+            <Link
+              href="/forgot-password"
+              className="text-sm font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400"
+            >
+              Forgot password?
+            </Link>
+          </div>
           <Input
             id="password"
             name="password"
@@ -184,5 +200,13 @@ export default function LoginPage() {
         </Button>
       </form>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
   )
 }

--- a/orbit-www/src/app/(auth)/reset-password/page.test.tsx
+++ b/orbit-www/src/app/(auth)/reset-password/page.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockPush = vi.fn()
+let mockSearchParams = new URLSearchParams()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
+}))
+
+const mockResetPassword = vi.fn()
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+  },
+}))
+
+import ResetPasswordPage from './page'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSearchParams = new URLSearchParams('token=valid-token')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ResetPasswordPage', () => {
+  it('renders the new-password form when a token is present', () => {
+    render(<ResetPasswordPage />)
+    expect(screen.getByLabelText('New password')).toBeInTheDocument()
+    expect(screen.getByLabelText('Confirm password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()
+  })
+
+  it('shows an error state with a link to /forgot-password when the token is missing', () => {
+    mockSearchParams = new URLSearchParams()
+    render(<ResetPasswordPage />)
+
+    expect(screen.queryByLabelText('New password')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /request a new/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    )
+  })
+
+  it('shows the error state when the query carries error=INVALID_TOKEN', () => {
+    mockSearchParams = new URLSearchParams('error=INVALID_TOKEN')
+    render(<ResetPasswordPage />)
+
+    expect(screen.queryByLabelText('New password')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /invalid or expired/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /request a new/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    )
+  })
+
+  it('rejects a password shorter than 8 characters without calling the API', async () => {
+    const user = userEvent.setup()
+    render(<ResetPasswordPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'short')
+    await user.type(screen.getByLabelText('Confirm password'), 'short')
+    await user.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(screen.getByText(/password must be at least 8 characters/i)).toBeInTheDocument()
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('rejects mismatched passwords without calling the API', async () => {
+    const user = userEvent.setup()
+    render(<ResetPasswordPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'Password1234')
+    await user.type(screen.getByLabelText('Confirm password'), 'Password9999')
+    await user.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument()
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('submits the new password with the token and redirects to login on success', async () => {
+    mockResetPassword.mockResolvedValue({ data: { status: true }, error: null })
+    const user = userEvent.setup()
+    render(<ResetPasswordPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'Password1234')
+    await user.type(screen.getByLabelText('Confirm password'), 'Password1234')
+    await user.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledWith({
+        newPassword: 'Password1234',
+        token: 'valid-token',
+      })
+    })
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/login?reset=success')
+    })
+  })
+
+  it('surfaces a server error inline and offers the forgot-password path', async () => {
+    mockResetPassword.mockResolvedValue({
+      data: null,
+      error: { message: 'invalid token' },
+    })
+    const user = userEvent.setup()
+    render(<ResetPasswordPage />)
+
+    await user.type(screen.getByLabelText('New password'), 'Password1234')
+    await user.type(screen.getByLabelText('Confirm password'), 'Password1234')
+    await user.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /request a new/i })).toHaveAttribute(
+        'href',
+        '/forgot-password',
+      )
+    })
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+})

--- a/orbit-www/src/app/(auth)/reset-password/page.tsx
+++ b/orbit-www/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { Suspense, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { authClient } from '@/lib/auth-client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+function InvalidTokenState() {
+  return (
+    <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md text-center">
+      <div className="mb-4">
+        <div className="mx-auto w-12 h-12 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center">
+          <svg className="w-6 h-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+      </div>
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+        Reset link invalid or expired
+      </h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
+        This password reset link is invalid or expired. Reset links are valid for 1 hour.
+      </p>
+      <Link
+        href="/forgot-password"
+        className="text-sm font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400"
+      >
+        Request a new reset link
+      </Link>
+    </div>
+  )
+}
+
+function ResetPasswordForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token')
+  const tokenError = searchParams.get('error') === 'INVALID_TOKEN'
+
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [serverError, setServerError] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  // Better-Auth redirects here with ?error=INVALID_TOKEN for a bad/expired link,
+  // and a valid link arrives with ?token=... — both are handled up front.
+  if (tokenError || !token) {
+    return <InvalidTokenState />
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      const result = await authClient.resetPassword({
+        newPassword: password,
+        token,
+      })
+
+      if (result?.error) {
+        setServerError(true)
+      } else {
+        router.push('/login?reset=success')
+      }
+    } catch (err) {
+      console.error(err)
+      setServerError(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (serverError) {
+    return <InvalidTokenState />
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md">
+      <div className="text-center mb-8">
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">
+          Set a new password
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          Choose a new password for your Orbit account.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 px-4 py-3 rounded">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <Label htmlFor="password">New password</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Must be at least 8 characters
+          </p>
+        </div>
+
+        <div>
+          <Label htmlFor="confirmPassword">Confirm password</Label>
+          <Input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="mt-1"
+          />
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={loading}
+        >
+          {loading ? 'Resetting...' : 'Reset password'}
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordForm />
+    </Suspense>
+  )
+}

--- a/orbit-www/src/lib/auth.ts
+++ b/orbit-www/src/lib/auth.ts
@@ -19,6 +19,49 @@ export const auth = betterAuth({
     // pending users — creating a session at signup would make registration
     // itself fail with FORBIDDEN. New users sign in after approval instead.
     autoSignIn: false,
+    // Keep the default resetPasswordTokenExpiresIn (1 hour).
+    sendResetPassword: async ({ user, url }) => {
+      if (process.env.NODE_ENV === "development") {
+        console.log(`\n${"=".repeat(60)}`)
+        console.log(`📧 PASSWORD RESET (dev mode)`)
+        console.log(`   To: ${user.email}`)
+        console.log(`   URL: ${url}`)
+        console.log(`${"=".repeat(60)}\n`)
+      }
+
+      if (!process.env.RESEND_API_KEY) {
+        if (process.env.NODE_ENV === "development") {
+          console.log(`   (No RESEND_API_KEY — skipping email send in dev mode)`)
+        } else if (process.env.NODE_ENV === "production") {
+          console.error(
+            `[password-reset] RESEND_API_KEY not configured — password reset email NOT sent to ${user.email}`,
+          )
+        }
+        return
+      }
+
+      const { Resend } = await import("resend")
+      const resend = new Resend(process.env.RESEND_API_KEY)
+      const fromEmail = process.env.RESEND_FROM_EMAIL || "noreply@hoytlabs.app"
+
+      await resend.emails.send({
+        from: fromEmail,
+        to: user.email,
+        subject: "Reset your Orbit password",
+        html: `
+          <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2 style="color: #1a1a1a;">Reset your password</h2>
+            <p>We received a request to reset the password for your Orbit account. Click the link below to choose a new password.</p>
+            <p style="margin: 24px 0;">
+              <a href="${url}" style="display: inline-block; background: #FF5C00; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 500;">
+                Reset Password
+              </a>
+            </p>
+            <p style="color: #666; font-size: 14px;">This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.</p>
+          </div>
+        `,
+      })
+    },
   },
   emailVerification: {
     sendVerificationEmail: async ({ user, url }) => {


### PR DESCRIPTION
Adds the forgot/reset-password flow. Prompted by the prod lockout where the only recovery was manually injecting a scrypt hash into Mongo.

## What

- **`sendResetPassword`** in Better-Auth config, mirroring the hardened #75 email pattern: dev-mode logs the reset URL, loud `[password-reset]` console.error in production when `RESEND_API_KEY` is missing, Orbit-styled Resend email ("link expires in 1 hour").
- **"Forgot password?"** link on the login page + green "Password updated" notice after a successful reset.
- **`/forgot-password`** — enumeration-safe: identical neutral success state whether or not the account exists (verified server-side in better-auth 1.4.20 source: unknown emails return the same 200 and never invoke the sender).
- **`/reset-password`** — token from the redirect, min-8/confirm validation inline, clean invalid/expired/missing-token error state with a path back to `/forgot-password`.

## Verification

- 17/17 auth-page tests green (7 new-page tests written TDD; all 4 pre-existing #75 login tests still pass). tsc: zero errors in touched files (baseline unchanged). eslint clean.
- **Live browser QA (agent-browser)**: full journey — request → logged reset link → new password set → old password rejected, new one logs in → reset back. No-enumeration confirmed (no URL emitted for unknown email, identical UX). Bad/missing/expired token states all clean. Wrong-password shows invalid-credentials with no bogus resend (#75 regression check).

No new env vars (reuses `RESEND_*`), no schema or access changes, no new dependencies.

Plan: docs/plans/2026-07-06-password-reset.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5MWQjx9kVpheX3fUNBq4z