### PR TITLE
fix(auth): self-heal missing Payload user docs from Better-Auth sessions

### DIFF
--- a/orbit-www/src/lib/auth/ensure-payload-user.test.ts
+++ b/orbit-www/src/lib/auth/ensure-payload-user.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ensurePayloadUser, type BridgeSessionUser } from './ensure-payload-user'
+
+function makePayloadMock() {
+  return {
+    find: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  }
+}
+
+const sessionUser: BridgeSessionUser = {
+  id: 'ba-user-id-123',
+  email: 'drew.payment@gmail.com',
+  name: 'Drew Payment',
+  role: 'super_admin',
+  status: 'approved',
+}
+
+describe('ensurePayloadUser', () => {
+  let payload: ReturnType<typeof makePayloadMock>
+
+  beforeEach(() => {
+    payload = makePayloadMock()
+  })
+
+  it('returns the existing Payload user without creating one', async () => {
+    const existing = { id: 'p1', email: sessionUser.email, role: 'super_admin', betterAuthId: 'ba-user-id-123' }
+    payload.find.mockResolvedValue({ docs: [existing] })
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(result).toMatchObject({ id: 'p1' })
+    expect(payload.create).not.toHaveBeenCalled()
+    expect(payload.update).not.toHaveBeenCalled()
+  })
+
+  it('lazy-populates betterAuthId on an existing user that lacks it', async () => {
+    const existing = { id: 'p1', email: sessionUser.email, role: 'super_admin' }
+    payload.find.mockResolvedValue({ docs: [existing] })
+    payload.update.mockResolvedValue({ ...existing, betterAuthId: 'ba-user-id-123' })
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'users',
+        id: 'p1',
+        data: { betterAuthId: 'ba-user-id-123' },
+        context: { skipApprovalHook: true },
+      }),
+    )
+    expect(result?.betterAuthId).toBe('ba-user-id-123')
+  })
+
+  it('still returns the user when the betterAuthId backfill update fails', async () => {
+    const existing = { id: 'p1', email: sessionUser.email, role: 'super_admin' }
+    payload.find.mockResolvedValue({ docs: [existing] })
+    payload.update.mockRejectedValue(new Error('update failed'))
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(result).toMatchObject({ id: 'p1' })
+  })
+
+  it('self-heals a missing Payload user from the Better-Auth session', async () => {
+    payload.find.mockResolvedValue({ docs: [] })
+    const created = {
+      id: 'p-new',
+      email: sessionUser.email,
+      role: 'super_admin',
+      status: 'approved',
+      betterAuthId: 'ba-user-id-123',
+    }
+    payload.create.mockResolvedValue(created)
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'users',
+        data: expect.objectContaining({
+          email: 'drew.payment@gmail.com',
+          name: 'Drew Payment',
+          role: 'super_admin',
+          status: 'approved',
+          betterAuthId: 'ba-user-id-123',
+        }),
+        overrideAccess: true,
+        // Must skip the approval hook: the doc is created already-approved and
+        // the hook would otherwise fire approval side effects (emails, workflows).
+        context: { skipApprovalHook: true },
+      }),
+    )
+    expect(result).toMatchObject({ id: 'p-new' })
+  })
+
+  it('defaults role to user and status to approved when the session omits them', async () => {
+    payload.find.mockResolvedValue({ docs: [] })
+    payload.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ id: 'p-new', ...data }))
+
+    // Legacy Better-Auth users predate the status/role additionalFields; a live
+    // session proves the login gate passed, so approved is the safe default.
+    await ensurePayloadUser(payload as never, { id: 'ba-2', email: 'legacy@example.com' })
+
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'user', status: 'approved' }),
+      }),
+    )
+  })
+
+  it('coerces unknown role/status values to safe defaults', async () => {
+    payload.find.mockResolvedValue({ docs: [] })
+    payload.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ id: 'p-new', ...data }))
+
+    await ensurePayloadUser(payload as never, {
+      id: 'ba-3',
+      email: 'weird@example.com',
+      role: 'owner-of-everything',
+      status: 'super-approved',
+    })
+
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'user', status: 'approved' }),
+      }),
+    )
+  })
+
+  it('recovers from a create race by re-finding the user', async () => {
+    const racedDoc = { id: 'p-raced', email: sessionUser.email, betterAuthId: 'ba-user-id-123' }
+    payload.find
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [racedDoc] })
+    payload.create.mockRejectedValue(new Error('E11000 duplicate key'))
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(result).toMatchObject({ id: 'p-raced' })
+    expect(payload.find).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when create fails and the re-find comes back empty', async () => {
+    payload.find.mockResolvedValue({ docs: [] })
+    payload.create.mockRejectedValue(new Error('validation failed'))
+
+    const result = await ensurePayloadUser(payload as never, sessionUser)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the session has no email', async () => {
+    const result = await ensurePayloadUser(payload as never, { id: 'ba-4', email: '' })
+
+    expect(result).toBeNull()
+    expect(payload.find).not.toHaveBeenCalled()
+  })
+})

--- a/orbit-www/src/lib/auth/ensure-payload-user.ts
+++ b/orbit-www/src/lib/auth/ensure-payload-user.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto'
+import type { Payload } from 'payload'
+import type { User } from '@/payload-types'
+
+/** Shape of the Better-Auth session user the bridge needs. */
+export interface BridgeSessionUser {
+  id: string
+  email: string
+  name?: string | null
+  role?: string | null
+  status?: string | null
+}
+
+const VALID_ROLES = new Set(['super_admin', 'admin', 'user'])
+const VALID_STATUSES = new Set(['pending', 'approved', 'rejected'])
+
+async function findByEmail(payload: Payload, email: string): Promise<User | undefined> {
+  const result = await payload.find({
+    collection: 'users',
+    where: { email: { equals: email } },
+    limit: 1,
+    overrideAccess: true,
+  })
+  return result.docs[0]
+}
+
+/**
+ * Resolve the Payload user for a Better-Auth session, creating it when missing.
+ *
+ * Better-Auth and Payload keep separate user records; registration is supposed
+ * to create both, but historically failed between the two writes and left
+ * Better-Auth-only accounts that could sign in yet had no identity anywhere
+ * Payload-backed (/platform guards, /admin). A valid session is proof the
+ * login gate passed, so a missing Payload doc is repaired here from the
+ * session's own fields rather than treated as unauthenticated.
+ */
+export async function ensurePayloadUser(
+  payload: Payload,
+  sessionUser: BridgeSessionUser,
+): Promise<User | null> {
+  if (!sessionUser.email) return null
+
+  let payloadUser = await findByEmail(payload, sessionUser.email)
+
+  if (!payloadUser) {
+    const role = sessionUser.role && VALID_ROLES.has(sessionUser.role) ? sessionUser.role : 'user'
+    // A live session means the session-create gate passed, so 'approved' is
+    // the safe default for legacy Better-Auth users that predate the status field.
+    const status =
+      sessionUser.status && VALID_STATUSES.has(sessionUser.status) ? sessionUser.status : 'approved'
+
+    try {
+      payloadUser = await payload.create({
+        collection: 'users',
+        data: {
+          email: sessionUser.email,
+          name: sessionUser.name || '',
+          role: role as User['role'],
+          status: status as User['status'],
+          betterAuthId: sessionUser.id,
+          // Local strategy is disabled; this password is never usable for login
+          // but satisfies the auth-collection field kept by enableFields.
+          password: crypto.randomBytes(32).toString('hex'),
+        },
+        overrideAccess: true,
+        context: { skipApprovalHook: true },
+      })
+      console.warn(
+        `[better-auth-bridge] Self-healed missing Payload user for ${sessionUser.email} (role: ${role})`,
+      )
+      return payloadUser
+    } catch (error) {
+      // Most likely a concurrent request created it first (unique email) — re-find.
+      payloadUser = await findByEmail(payload, sessionUser.email)
+      if (!payloadUser) {
+        console.error(
+          `[better-auth-bridge] Failed to self-heal Payload user for ${sessionUser.email}:`,
+          error,
+        )
+        return null
+      }
+    }
+  }
+
+  // Lazy-populate betterAuthId on users created before the bridge stored it.
+  if (!payloadUser.betterAuthId && sessionUser.id) {
+    try {
+      payloadUser = await payload.update({
+        collection: 'users',
+        id: payloadUser.id,
+        data: { betterAuthId: sessionUser.id },
+        overrideAccess: true,
+        context: { skipApprovalHook: true },
+      })
+    } catch (error) {
+      // Non-fatal — will retry on the next request.
+      console.error('[better-auth-bridge] Failed to populate betterAuthId:', error)
+    }
+  }
+
+  return payloadUser
+}

--- a/orbit-www/src/lib/auth/session.ts
+++ b/orbit-www/src/lib/auth/session.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { getPayload } from 'payload'
 import config from '@payload-config'
+import { ensurePayloadUser } from '@/lib/auth/ensure-payload-user'
 
 /**
  * Get the current user from the session on the server side.
@@ -25,6 +26,7 @@ export async function getSession() {
 /**
  * Get the authenticated Payload user from the current Better Auth session.
  * Returns the Payload user document with betterAuthId populated, or null.
+ * A missing Payload doc is self-healed from the session (see ensurePayloadUser).
  * Use this in server actions to pass `user` to Payload local API calls.
  */
 export async function getPayloadUserFromSession() {
@@ -35,31 +37,8 @@ export async function getPayloadUserFromSession() {
 
   const payload = await getPayload({ config })
 
-  const result = await payload.find({
-    collection: 'users',
-    where: { email: { equals: session.user.email } },
-    limit: 1,
-    overrideAccess: true,
-  })
-
-  let payloadUser = result.docs[0]
+  const payloadUser = await ensurePayloadUser(payload, session.user)
   if (!payloadUser) return null
-
-  // Lazy-populate betterAuthId if missing (mirrors strategy behavior)
-  const betterAuthId = session.user.id
-  if (!payloadUser.betterAuthId && betterAuthId) {
-    try {
-      payloadUser = await payload.update({
-        collection: 'users',
-        id: payloadUser.id,
-        data: { betterAuthId },
-        overrideAccess: true,
-        context: { skipApprovalHook: true },
-      })
-    } catch {
-      // Non-fatal — betterAuthId will be populated on next call
-    }
-  }
 
   return {
     ...payloadUser,

--- a/orbit-www/src/lib/payload-better-auth-strategy.ts
+++ b/orbit-www/src/lib/payload-better-auth-strategy.ts
@@ -1,9 +1,11 @@
 import type { AuthStrategy, AuthStrategyFunctionArgs, AuthStrategyResult } from 'payload'
 import { auth } from '@/lib/auth'
+import { ensurePayloadUser } from '@/lib/auth/ensure-payload-user'
 
 /**
  * Custom Payload AuthStrategy that validates Better Auth sessions.
- * All authenticated users get req.user populated.
+ * All authenticated users get req.user populated; a missing Payload user
+ * doc is self-healed from the session (see ensurePayloadUser).
  * Admin panel access is gated separately via Users.access.admin.
  */
 async function authenticate({ headers, payload }: AuthStrategyFunctionArgs): Promise<AuthStrategyResult> {
@@ -14,33 +16,9 @@ async function authenticate({ headers, payload }: AuthStrategyFunctionArgs): Pro
       return { user: null }
     }
 
-    const betterAuthId = session.user.id
-    const result = await payload.find({
-      collection: 'users',
-      where: { email: { equals: session.user.email } },
-      limit: 1,
-      overrideAccess: true,
-    })
-
-    let payloadUser = result.docs[0]
+    const payloadUser = await ensurePayloadUser(payload, session.user)
     if (!payloadUser) {
-      console.warn(`[better-auth-strategy] No Payload user found for email: ${session.user.email}`)
       return { user: null }
-    }
-
-    // Lazy-populate betterAuthId on first authentication
-    if (!payloadUser.betterAuthId && betterAuthId) {
-      try {
-        payloadUser = await payload.update({
-          collection: 'users',
-          id: payloadUser.id,
-          data: { betterAuthId },
-          overrideAccess: true,
-          context: { skipApprovalHook: true },
-        })
-      } catch (error) {
-        console.error('[better-auth-strategy] Failed to populate betterAuthId:', error)
-      }
     }
 
     return {


### PR DESCRIPTION
## Problem

Production incident: `drew.payment@gmail.com` (super_admin) is locked out of every `/platform/*` page (redirects to `/login`) and `/admin` hangs forever on the Payload splash screen — while regular sign-in and `/dashboard` work fine.

Root cause (verified live against prod): the Better-Auth account is healthy (`role: super_admin`, `status: approved`, `emailVerified: true`) but the matching **Payload `users` document does not exist**. The prod pod logs the smoking gun on every bridge lookup:

```
[better-auth-strategy] No Payload user found for email: drew.payment@gmail.com
```

The account was created 2026-07-01, while `/api/register` still 500'd between the Better-Auth write and the Payload write (fixed in #75), and was then promoted by hand in Mongo (the #76 recovery). Nothing backfills such orphans, and since `Users` sets `disableLocalStrategy`, `/admin/login` has no form to fall back to — a missing Payload doc is an unrecoverable dead end for the browser.

Not a regression from #75/#76: the bridge code was last touched in #36. Those PRs fixed sign-in going forward; this is leftover damage surfacing.

## Fix

A valid Better-Auth session proves the session-create gate passed, so treat a missing Payload doc as repairable data loss instead of "unauthenticated":

- New `ensurePayloadUser()` (`orbit-www/src/lib/auth/ensure-payload-user.ts`): finds the Payload user by session email; when absent, creates it from the session's own fields (email, name, role, status, betterAuthId) with `skipApprovalHook` so approval side effects (verification emails, provisioning workflows) don't re-fire. Unknown role/status coerce to `user`/`approved`; a create race recovers by re-finding; the doc gets an unusable random password purely to satisfy the auth-collection schema (local login stays disabled).
- Both bridge entry points — the Payload auth strategy and `getPayloadUserFromSession()` — now share it, deduping the copy-pasted betterAuthId lazy-backfill.

## Testing

- TDD: 9 new unit tests in `ensure-payload-user.test.ts` (existing-user passthrough, betterAuthId backfill + failure tolerance, self-heal field mapping, legacy/unknown role-status defaults, create-race recovery, hard-failure null, no-email guard). Watched fail, then pass.
- `tsc --noEmit` clean; eslint clean on touched files.
- Full `vitest run src`: failing set identical to `main` baseline (98 pre-existing env/flaky failures, zero new).

## Follow-ups (not in this PR)

- `api/register/route.ts` still swallows Payload-create failures (now self-healing makes those orphans recoverable on first login).
- `/admin/login` blank-page dead end for fully unauthenticated visitors could redirect to `/login?redirect=/admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5MWQjx9kVpheX3fUNBq4z