### PR TITLE
fix: unconditional hook order in GitHubInstallationsClient (unbreak main image build)

### DIFF
--- a/orbit-www/src/components/features/github-installations/GitHubInstallationsClient.tsx
+++ b/orbit-www/src/components/features/github-installations/GitHubInstallationsClient.tsx
@@ -171,6 +171,10 @@ export function GitHubInstallationsClient({ installations: initial }: GitHubInst
     [applyState, setPhase],
   )
 
+  const onRemoved = useCallback((docId: string) => {
+    setInstallations((prev) => prev.filter((inst) => inst.id !== docId))
+  }, [])
+
   if (installations.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed py-16 text-center">
@@ -188,10 +192,6 @@ export function GitHubInstallationsClient({ installations: initial }: GitHubInst
       </div>
     )
   }
-
-  const onRemoved = useCallback((docId: string) => {
-    setInstallations((prev) => prev.filter((inst) => inst.id !== docId))
-  }, [])
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
The post-merge "Build and Push Images" run on main failed in the orbit-www image build: `next build` lints, and `onRemoved`'s `useCallback` in `GitHubInstallationsClient.tsx` was declared after the empty-state early return — a conditional hook call (`react-hooks/rules-of-hooks`, the build's only hard error). Moved the hook above the return.

Verified: eslint clean on the file, `tsc --noEmit` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)