### PR TITLE
feat(ui): light/dark/system theme toggle in user menu

### DIFF
--- a/orbit-www/src/app/(auth)/layout.tsx
+++ b/orbit-www/src/app/(auth)/layout.tsx
@@ -21,7 +21,7 @@ export default function AuthLayout({
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"
-          enableSystem={false}
+          enableSystem
           disableTransitionOnChange
         >
           <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">

--- a/orbit-www/src/app/(frontend)/layout.tsx
+++ b/orbit-www/src/app/(frontend)/layout.tsx
@@ -32,7 +32,7 @@ export default function FrontendLayout({ children }: { children: React.ReactNode
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"
-          enableSystem={false}
+          enableSystem
           disableTransitionOnChange
         >
           <BreadcrumbProvider>

--- a/orbit-www/src/app/(marketing)/layout.tsx
+++ b/orbit-www/src/app/(marketing)/layout.tsx
@@ -50,7 +50,7 @@ export default function MarketingLayout({
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"
-          enableSystem={false}
+          enableSystem
           disableTransitionOnChange
         >
           {children}

--- a/orbit-www/src/app/(setup)/layout.tsx
+++ b/orbit-www/src/app/(setup)/layout.tsx
@@ -21,7 +21,7 @@ export default function SetupLayout({
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"
-          enableSystem={false}
+          enableSystem
           disableTransitionOnChange
         >
           <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">

--- a/orbit-www/src/components/nav-user.tsx
+++ b/orbit-www/src/components/nav-user.tsx
@@ -1,11 +1,16 @@
 "use client"
 
+import * as React from "react"
 import {
   Bell,
   LogOut,
+  Monitor,
+  Moon,
   Shield,
+  Sun,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { useTheme } from "next-themes"
 import { signOut } from "@/lib/auth-client"
 
 import {
@@ -19,7 +24,12 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -44,6 +54,13 @@ export function NavUser({
 }) {
   const { isMobile } = useSidebar()
   const router = useRouter()
+  const { theme, setTheme } = useTheme()
+
+  // next-themes resolves the active theme only on the client; guard the
+  // active-state indicators against a hydration mismatch.
+  const [mounted, setMounted] = React.useState(false)
+  React.useEffect(() => setMounted(true), [])
+  const activeTheme = mounted ? theme : undefined
 
   const handleLogout = async () => {
     await signOut()
@@ -114,6 +131,38 @@ export function NavUser({
                 </DropdownMenuGroup>
               </>
             )}
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                {activeTheme === "light" ? (
+                  <Sun />
+                ) : activeTheme === "dark" ? (
+                  <Moon />
+                ) : (
+                  <Monitor />
+                )}
+                Theme
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup
+                  value={activeTheme}
+                  onValueChange={setTheme}
+                >
+                  <DropdownMenuRadioItem value="light">
+                    <Sun />
+                    Light
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="dark">
+                    <Moon />
+                    Dark
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="system">
+                    <Monitor />
+                    System
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut />


### PR DESCRIPTION
## What

Adds a **Theme** submenu (Light / Dark / System) to the sidebar user dropdown — the menu in the bottom-left with Notifications / Admin Panel / Log out.

## Why

The app was hard-pinned to dark (`enableSystem={false}` in every route-group `ThemeProvider`) with no way for users to switch. All the tooling was already in place — `next-themes`, a Tailwind v4 `.dark` variant, and full light/dark CSS variable sets in `globals.css` — so this is purely wiring, no new dependencies.

## Changes

- **`nav-user.tsx`** — new `DropdownMenuSub` "Theme" with a radio group (Light / Dark / System) bound to `useTheme()`. The trigger icon and active radio are guarded behind a `mounted` flag to avoid a hydration mismatch (next-themes only resolves the theme client-side).
- **Four layouts** (`(frontend)`, `(auth)`, `(marketing)`, `(setup)`) — flipped `enableSystem={false}` → `enableSystem`. `defaultTheme` stays `"dark"`, so **nobody's current experience changes** until they pick a theme.

## Verification

- `tsc --noEmit` — clean (0 errors).
- agent-browser end-to-end on a local build:
  - **Light** → `<html class="light">`, full app palette switches (see screenshot), `localStorage.theme="light"`.
  - **Dark** → default, radio correctly pre-checked.
  - **System** → persists as `localStorage.theme="system"`, resolves via `prefers-color-scheme`.
  - Choice persists across a full page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGwpEuRZpxwJ69uFunn8SZ