### PR TITLE
feat: ADO repo-import parity (Phase 2 of Connections Consolidation)

### DIFF
--- a/docs/plans/2026-07-09-ado-import-parity.md
+++ b/docs/plans/2026-07-09-ado-import-parity.md
@@ -1,0 +1,117 @@
+# ADO Repo-Import Parity — Phase 2 of Connections Consolidation
+
+**Status**: Approved 2026-07-09 (Drew) — follows `2026-07-09-connections-consolidation.md` (Phase 1, merged as PR #83 / c43744c)
+**Branch**: `feat/ado-import-parity`
+
+## Problem
+
+Azure DevOps connections (`git-connections`) can back catalog-discovery *scans*, but nothing else:
+
+- **Manual import is GitHub-only.** `ImportAppForm` loads only `github-installations`; `importRepository` (`app/actions/apps.ts`) parses URLs with a `github.com` regex and rejects everything else; `RepositoryBrowser` lists repos only via `listInstallationRepositories`.
+- **The `apps.repository` group can't represent an ADO repo.** Fields are `owner/name/url/installationId/branch` — no provider discriminator, no `git-connections` linkage, no slot for ADO's project (three-part org/project/repo coordinate).
+- **Discovery accept is provider-lossy.** `lib/discovery/import.ts` reads only `discovery.installation`; an accepted ADO entity becomes an `apps` row with no provider, no connection, and (because the scanner stores `RepoRef.Owner = project` and drops the org) no way to reconstruct its clone URL.
+- **The agent clone path hard-rejects non-GitHub.** `orbit_repo_clone_activity.go` `parseGitHubRepoURL` requires host `github.com` + two path segments, and the clone URL literal is `x-access-token:${token}@github.com/...`.
+
+## Goal
+
+An ADO connection is a first-class repo source: browse/import its repos from the import form, accepted discovery proposals keep their provider + connection, and the agent can clone an ADO-backed app using the connection's credentials.
+
+## Non-goals
+
+- Template *creation* into ADO (`UseTemplateForm`, `PrepareGitHubRemoteActivity`, `services/repository` git-provider client) — GitHub-only stays.
+- New providers beyond ADO; changes to scan/proposal flows (already provider-aware).
+- Backfilling provider fields on pre-existing `apps` rows (absent provider ⇒ treated as GitHub; document this invariant).
+
+## Canonical decisions
+
+- **Provider value**: `azure-devops` everywhere new (matches `git-connections.provider` and the catalog workflow input; do NOT introduce `azure_devops`).
+- **ADO coordinate**: never overload `owner` — new `apps` rows store `provider`, `organization` (in `owner`), `project` (new field), `name`, and full `url`; the `connection` relationship is the auth root.
+- **ADO repo listing** is served by TS server actions calling ADO REST directly (reusing `lib/connections/token-core.ts` `resolveConnectionToken` for basic-pat/bearer auth) — no new Go/gRPC surface for listing.
+- **Clone auth**: the Go agent activity resolves ADO credentials via the existing internal endpoint `POST /api/internal/git-connections/token` and builds `https://{user}:{PAT}@dev.azure.com/{org}/{project}/_git/{repo}` for `basic-pat`, or bearer via `http.extraheader` for `service-principal`.
+
+## Key files
+
+| Area | Path |
+|---|---|
+| Apps collection | `orbit-www/src/collections/Apps.ts` (`repository` group) |
+| Import action | `orbit-www/src/app/actions/apps.ts` (`importRepository`) |
+| GitHub listing actions (mirror) | `orbit-www/src/app/actions/github.ts` |
+| New ADO listing actions | `orbit-www/src/app/actions/azure-devops.ts` (new) |
+| ADO token core (reuse) | `orbit-www/src/lib/connections/token-core.ts` |
+| Import form | `orbit-www/src/components/features/apps/ImportAppForm.tsx` |
+| Repo browser | `orbit-www/src/components/features/apps/RepositoryBrowser.tsx` |
+| Discovery accept | `orbit-www/src/lib/discovery/import.ts` |
+| Discovered entities (read) | `orbit-www/src/collections/discovery/DiscoveredEntities.ts` |
+| Git connections (read) | `orbit-www/src/collections/connections/GitConnections.ts` |
+| Agent clone activity | `temporal-workflows/internal/activities/agent/orbit_repo_clone_activity.go` |
+| GitHub token client (pattern) | `temporal-workflows/internal/services/payload_github_client.go` |
+| ADO REST client (pattern) | `temporal-workflows/internal/activities/ado_scan_activities.go` |
+
+---
+
+## WI1 — `apps.repository` provider model
+
+**UAC**
+1. `repository` group gains: `provider` (select `github` | `azure-devops`, no default — absent means legacy GitHub), `connection` (relationship → `git-connections`, ADO rows only), `project` (text, ADO rows only). Existing fields unchanged; existing docs remain valid with no migration.
+2. Field-level admin descriptions state the invariant: GitHub rows use `installationId`, ADO rows use `connection` + `project`; `owner` holds the GitHub owner or the ADO organization.
+3. `orbit-www` payload types regenerated (`payload-types.ts`) and tsc stays at 0 errors.
+
+## WI2 — ADO repo listing server actions
+
+New `orbit-www/src/app/actions/azure-devops.ts`, mirroring `actions/github.ts` semantics:
+
+**UAC**
+1. `getWorkspaceGitConnections(workspaceId)` returns active `git-connections` where `allowedWorkspaces` contains the workspace — same shape/gating pattern as `getWorkspaceGitHubInstallations` (session required, membership checked), secrets never returned.
+2. `listConnectionRepositories(connectionId, page?)` lists repos via ADO REST `GET {base}/{org}/{project}/_apis/git/repositories?api-version=7.1` (all projects of the org when the connection has no project: enumerate `_apis/projects` then fan in). Returns the same `Repository` shape the browser consumes (`name`, `fullName` = display coordinate, `defaultBranch`, `private`, plus `project`), auth via `resolveConnectionToken` (works for both basic-pat and bearer).
+3. `searchConnectionRepositories(connectionId, query)` filters by name (client-side filter over the listing is acceptable — ADO has no repo-search API equivalent).
+4. Failures (bad PAT, 404 org, network) return `{ success: false, error }` — never throw to the client, never leak the token.
+5. Unit tests (TDD) cover: happy path with project-scoped connection, org-wide fan-in, auth header selection for basic-pat vs bearer, error mapping.
+
+## WI3 — Provider-aware import UI + action
+
+**UAC**
+1. `ImportAppForm` shows a source selector when the workspace has both providers available (GitHub installations AND ADO connections); with only one provider it preselects it without extra chrome. Empty-state alert links to `/settings/connections` (already does post-Phase 1).
+2. Selecting an ADO connection drives `RepositoryBrowser` through the WI2 actions (list + search + pagination), same UX as GitHub browsing.
+3. Selecting an ADO repo fills the URL field with `https://dev.azure.com/{org}/{project}/_git/{repo}` (or the connection's `baseUrl` for on-prem) and the name field with the repo name.
+4. `importRepository` accepts either `{installationId}` (GitHub, unchanged) or `{connectionId}` (ADO): validates the connection is allowed for the workspace, parses/derives org+project+repo, and writes the WI1 fields (`provider: 'azure-devops'`, `connection`, `owner`=org, `project`, `name`, `url`). GitHub behavior byte-for-byte unchanged.
+5. Manual URL entry accepts `dev.azure.com/{org}/{project}/_git/{repo}` URLs (and the connection's baseUrl host) with a validation message that names both accepted shapes; unparseable URLs still rejected.
+6. The imported app's detail view renders without regression for both providers (repo link points at the right host).
+7. Unit tests (TDD): URL parsing for both providers (incl. on-prem baseUrl + `_git` shape), workspace-authorization rejection, field mapping onto the created doc.
+
+## WI4 — Discovery accept keeps provider + connection
+
+**UAC**
+1. `importDiscoveredService` (and the api/global-entity variants where they store repo linkage) copies onto the created row: `provider` (from the discovered entity's source), `connection` (when present), and for ADO reconstructs `owner`=organization from the linked `git-connections` doc (the scanner stores project in `RepoRef.Owner` — do not trust it as org) plus `project`.
+2. Accepted GitHub proposals are unchanged (still `installationId`, no provider regression — absent-provider invariant OK, setting `provider: 'github'` preferred).
+3. An accepted ADO service yields an `apps` row from which a clone URL is reconstructable (org + project + name + url all present).
+4. Unit tests (TDD): ADO accept maps connection/org/project correctly; GitHub accept unchanged; entity with neither linkage fails soft (no crash, logged).
+
+## WI5 — Provider-aware agent clone (Go)
+
+`temporal-workflows/internal/activities/agent/orbit_repo_clone_activity.go`:
+
+**UAC**
+1. URL parsing generalized: `github.com/{owner}/{repo}` (existing behavior + tests preserved) and `{host}/{org}/{project}/_git/{repo}` (dev.azure.com or a configured on-prem host). Anything else rejected with today's clear error.
+2. Credential resolution branches by parsed provider: GitHub path unchanged (`token-for-repo`); ADO path calls `POST /api/internal/git-connections/token` (new small client method following `payload_github_client.go` conventions, X-API-Key auth) with the connection id carried on the app/workflow input — and must handle both `authMode: basic-pat` (clone URL `https://pat:{token}@{host}/...` — username arbitrary) and `bearer` (clone via `git -c http.extraheader="AUTHORIZATION: Bearer {token}" clone ...`; the token must NOT appear in the clone URL or logs).
+3. The activity input carries the provider/connection linkage (threaded from the app doc through the workflow input — find where the GitHub repo URL/installation currently enters the workflow and extend that seam; do not query Payload from inside the activity beyond the existing token endpoints).
+4. Tokens never logged; error messages name host/org/project/repo but never credentials.
+5. Table-driven unit tests (TDD, `go test -race`): URL parse matrix (github, dev.azure.com, on-prem base, garbage), auth-mode → clone-command construction (assert bearer never lands in URL), GitHub path regression.
+6. `temporal-workflows` builds (`go build ./...`) and existing tests pass.
+
+## WI6 — Quality gates (all engineers)
+
+1. TDD throughout; `cd orbit-www && bunx tsc --noEmit` → 0 errors; no new `as any` casts (Tech Debt Metrics gate counts them repo-wide, threshold +5 — aim for 0).
+2. `bunx vitest run <changed test files>` green; `cd temporal-workflows && go test -race ./...` green; `go build ./...` green.
+3. eslint/golangci-lint clean on touched files.
+
+## WI7 — QA validation (agent-browser)
+
+Full walkthrough on local dev. **Known limitation**: no real ADO org credentials exist in local dev, so ADO listing/clone are validated for UI wiring + graceful failure (clear error surfaced, no crash, no secret leak); the happy-path listing is covered by WI2 unit tests. A real-ADO smoke test needs Drew's credentials and is listed as a post-merge manual step.
+
+---
+
+## Sequencing
+
+1. **Engineer C** (frontend, WI1+WI2+WI3) and **Engineer E** (Go, WI5) in parallel — disjoint trees (`orbit-www` vs `temporal-workflows`); E's workflow-input threading may touch the TS side where the workflow is started — coordinate through the PM if so.
+2. **Engineer D** (WI4) after C lands (depends on WI1 fields).
+3. QA (WI7), then PR.

--- a/orbit-www/src/app/actions/__tests__/apps.test.ts
+++ b/orbit-www/src/app/actions/__tests__/apps.test.ts
@@ -109,6 +109,140 @@ describe('importRepository', () => {
   })
 })
 
+describe('importRepository — Azure DevOps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const session = { user: { id: 'user-1' }, session: {} }
+
+  function payloadWith(opts: {
+    membership?: boolean
+    connectionAllowed?: boolean
+    create?: ReturnType<typeof vi.fn>
+  }) {
+    const create = opts.create ?? vi.fn().mockResolvedValue({ id: 'app-1' })
+    const find = vi.fn((args: { collection: string }) => {
+      if (args.collection === 'workspace-members') {
+        return Promise.resolve({ docs: opts.membership === false ? [] : [{ id: 'm1' }] })
+      }
+      if (args.collection === 'git-connections') {
+        return Promise.resolve({
+          docs: opts.connectionAllowed === false ? [] : [{ id: 'conn-1', allowedWorkspaces: ['ws-1'] }],
+        })
+      }
+      return Promise.resolve({ docs: [] })
+    })
+    return { find, create }
+  }
+
+  it('creates an ADO row with provider, org, project, connection from a connectionId', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(session as never)
+    const create = vi.fn().mockResolvedValue({ id: 'app-ado' })
+    const mockPayload = payloadWith({ create })
+    vi.mocked(getPayload).mockResolvedValue(mockPayload as never)
+
+    const result = await importRepository({
+      workspaceId: 'ws-1',
+      repositoryUrl: 'https://dev.azure.com/acme/platform/_git/backend',
+      name: 'backend',
+      connectionId: 'conn-1',
+    })
+
+    expect(result).toEqual({ success: true, appId: 'app-ado' })
+    expect(create).toHaveBeenCalledWith({
+      collection: 'apps',
+      data: expect.objectContaining({
+        repository: expect.objectContaining({
+          provider: 'azure-devops',
+          owner: 'acme',
+          project: 'platform',
+          name: 'backend',
+          url: 'https://dev.azure.com/acme/platform/_git/backend',
+          connection: 'conn-1',
+        }),
+      }),
+    })
+  })
+
+  it('parses an on-prem _git URL into org/project/repo', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(session as never)
+    const create = vi.fn().mockResolvedValue({ id: 'app-ado' })
+    vi.mocked(getPayload).mockResolvedValue(payloadWith({ create }) as never)
+
+    await importRepository({
+      workspaceId: 'ws-1',
+      repositoryUrl: 'https://ado.acme.internal/tfs/DefaultCollection/platform/_git/backend',
+      name: 'backend',
+      connectionId: 'conn-1',
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      collection: 'apps',
+      data: expect.objectContaining({
+        repository: expect.objectContaining({
+          owner: 'DefaultCollection',
+          project: 'platform',
+          name: 'backend',
+        }),
+      }),
+    })
+  })
+
+  it('rejects when the connection is not allowed for the workspace', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(session as never)
+    const create = vi.fn()
+    vi.mocked(getPayload).mockResolvedValue(
+      payloadWith({ connectionAllowed: false, create }) as never,
+    )
+
+    const result = await importRepository({
+      workspaceId: 'ws-1',
+      repositoryUrl: 'https://dev.azure.com/acme/platform/_git/backend',
+      name: 'backend',
+      connectionId: 'conn-1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unparseable URL naming both accepted shapes', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(session as never)
+    const create = vi.fn()
+    vi.mocked(getPayload).mockResolvedValue(payloadWith({ create }) as never)
+
+    const result = await importRepository({
+      workspaceId: 'ws-1',
+      repositoryUrl: 'https://example.com/not/a/repo',
+      name: 'x',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/github/i)
+    expect(result.error).toMatch(/azure devops|dev\.azure\.com/i)
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('leaves GitHub imports on the unchanged github path (no provider field)', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(session as never)
+    const create = vi.fn().mockResolvedValue({ id: 'app-gh' })
+    vi.mocked(getPayload).mockResolvedValue(payloadWith({ create }) as never)
+
+    await importRepository({
+      workspaceId: 'ws-1',
+      repositoryUrl: 'https://github.com/acme/backend',
+      name: 'backend',
+      installationId: 'install-1',
+    })
+
+    const call = create.mock.calls[0][0]
+    expect(call.data.repository.owner).toBe('acme')
+    expect(call.data.repository.provider).toBeUndefined()
+    expect(call.data.repository.installationId).toBe('install-1')
+  })
+})
+
 describe('updateAppSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/orbit-www/src/app/actions/apps.ts
+++ b/orbit-www/src/app/actions/apps.ts
@@ -9,6 +9,7 @@ import { builtInGenerators } from '@/lib/seeds/deployment-generators'
 import { serializeAppManifest } from '@/lib/app-manifest'
 import { generateWebhookSecret, parseGitHubUrl } from '@/lib/github-manifest'
 import { getInstallationOctokit } from '@/lib/github/octokit'
+import { parseAdoRepoUrl } from '@/lib/connections/ado-url'
 
 interface CreateAppFromTemplateInput {
   name: string
@@ -85,7 +86,10 @@ interface ImportRepositoryInput {
   repositoryUrl: string
   name: string
   description?: string
+  /** GitHub source: the app installation backing the repo. */
   installationId?: string
+  /** Azure DevOps source: the git-connection backing the repo (auth root). */
+  connectionId?: string
 }
 
 export async function importRepository(input: ImportRepositoryInput) {
@@ -116,13 +120,58 @@ export async function importRepository(input: ImportRepositoryInput) {
     return { success: false, error: 'Not a member of this workspace' }
   }
 
-  // Parse repository URL
-  const match = input.repositoryUrl.match(/github\.com\/([^/]+)\/([^/]+)/)
-  if (!match) {
-    return { success: false, error: 'Invalid GitHub repository URL' }
-  }
+  // Classify the URL. GitHub keeps its exact existing behavior; anything that
+  // isn't a github.com URL is tried as an Azure DevOps `_git` URL.
+  const githubMatch = input.repositoryUrl.match(/github\.com\/([^/]+)\/([^/]+)/)
 
-  const [, owner, repoName] = match
+  let repositoryData: Record<string, unknown>
+  if (githubMatch) {
+    const [, owner, repoName] = githubMatch
+    repositoryData = {
+      owner,
+      name: repoName.replace(/\.git$/, ''),
+      url: input.repositoryUrl,
+      ...(input.installationId && { installationId: input.installationId }),
+    }
+  } else {
+    const ado = parseAdoRepoUrl(input.repositoryUrl)
+    if (!ado) {
+      return {
+        success: false,
+        error:
+          'Invalid repository URL — expected a GitHub (github.com/owner/repo) or ' +
+          'Azure DevOps (dev.azure.com/org/project/_git/repo) URL',
+      }
+    }
+
+    // When a connection is supplied it is the auth root — verify it is allowed
+    // for this workspace before linking it.
+    if (input.connectionId) {
+      const allowed = await payload.find({
+        collection: 'git-connections',
+        where: {
+          and: [
+            { id: { equals: input.connectionId } },
+            { allowedWorkspaces: { contains: input.workspaceId } },
+          ],
+        },
+        overrideAccess: true,
+        limit: 1,
+      })
+      if (allowed.docs.length === 0) {
+        return { success: false, error: 'Connection is not available for this workspace' }
+      }
+    }
+
+    repositoryData = {
+      provider: 'azure-devops',
+      owner: ado.organization,
+      project: ado.project,
+      name: ado.repo,
+      url: input.repositoryUrl,
+      ...(input.connectionId && { connection: input.connectionId }),
+    }
+  }
 
   try {
     const app = await payload.create({
@@ -131,12 +180,7 @@ export async function importRepository(input: ImportRepositoryInput) {
         name: input.name,
         description: input.description,
         workspace: input.workspaceId,
-        repository: {
-          owner,
-          name: repoName.replace(/\.git$/, ''),
-          url: input.repositoryUrl,
-          ...(input.installationId && { installationId: input.installationId }),
-        },
+        repository: repositoryData,
         origin: {
           type: 'imported',
         },

--- a/orbit-www/src/app/actions/azure-devops.ts
+++ b/orbit-www/src/app/actions/azure-devops.ts
@@ -1,0 +1,131 @@
+'use server'
+
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { listConnectionRepositoriesCore } from '@/lib/connections/ado-repos-core'
+import type { Repository } from './github'
+
+/**
+ * Azure DevOps repo-source server actions (WI2) — the git-connections analogue
+ * of `actions/github.ts`. Same gating (session + workspace membership) and the
+ * same PAT-less contract: the connection's decrypted credential never crosses
+ * back to the client; actions return only repo metadata or `{ success:false }`.
+ *
+ * git-connections access is platform-admin only, so every read here uses
+ * `overrideAccess: true` and is instead gated by the caller's workspace
+ * membership plus the connection's `allowedWorkspaces`.
+ */
+
+export interface GitConnectionSource {
+  id: string
+  name: string
+  organization: string
+  baseUrl: string
+}
+
+async function requireMember(workspaceId: string): Promise<{ ok: boolean }> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) return { ok: false }
+
+  const payload = await getPayload({ config })
+  const membership = await payload.find({
+    collection: 'workspace-members',
+    where: {
+      and: [
+        { workspace: { equals: workspaceId } },
+        { user: { equals: session.user.id } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    limit: 1,
+  })
+  return { ok: membership.docs.length > 0 }
+}
+
+/**
+ * Active ADO connections whose `allowedWorkspaces` includes this workspace.
+ * Mirrors `getWorkspaceGitHubInstallations`: session + membership gated, no
+ * secrets in the projection.
+ */
+export async function getWorkspaceGitConnections(workspaceId: string): Promise<{
+  success: boolean
+  error?: string
+  connections: GitConnectionSource[]
+}> {
+  const member = await requireMember(workspaceId)
+  if (!member.ok) return { success: false, error: 'Unauthorized', connections: [] }
+
+  const payload = await getPayload({ config })
+  const result = await payload.find({
+    collection: 'git-connections',
+    where: {
+      and: [
+        { allowedWorkspaces: { contains: workspaceId } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    overrideAccess: true,
+    limit: 200,
+    depth: 0,
+  })
+
+  return {
+    success: true,
+    connections: result.docs.map((doc) => {
+      const d = doc as unknown as Record<string, unknown>
+      return {
+        id: String(d.id),
+        name: typeof d.name === 'string' ? d.name : String(d.id),
+        organization: typeof d.organization === 'string' ? d.organization : '',
+        baseUrl:
+          typeof d.baseUrl === 'string' && d.baseUrl.length > 0
+            ? d.baseUrl
+            : 'https://dev.azure.com',
+      }
+    }),
+  }
+}
+
+/**
+ * List the repos backing an ADO connection. `page` is accepted for parity with
+ * the GitHub action but ADO listing is unpaginated (all projects/repos fetched
+ * in one pass), so `hasMore` is always false. Client-side search filters this
+ * full listing.
+ */
+export async function listConnectionRepositories(
+  connectionId: string,
+  _page: number = 1,
+): Promise<{ success: boolean; error?: string; repos: Repository[]; hasMore: boolean }> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) {
+    return { success: false, error: 'Unauthorized', repos: [], hasMore: false }
+  }
+
+  const payload = await getPayload({ config })
+  const result = await listConnectionRepositoriesCore(payload, connectionId, {
+    fetchFn: (url, init) => fetch(url, init),
+  })
+
+  if (!result.ok) {
+    return { success: false, error: result.error, repos: [], hasMore: false }
+  }
+  return { success: true, repos: result.repos, hasMore: false }
+}
+
+/**
+ * Search an ADO connection's repos by name. ADO has no repo-search API, so this
+ * lists the full set and filters client-side (WI2.3).
+ */
+export async function searchConnectionRepositories(
+  connectionId: string,
+  query: string,
+): Promise<{ success: boolean; error?: string; repos: Repository[]; hasMore: boolean }> {
+  const listed = await listConnectionRepositories(connectionId)
+  if (!listed.success) return listed
+
+  const q = query.trim().toLowerCase()
+  const repos = q.length === 0 ? listed.repos : listed.repos.filter((r) => r.name.toLowerCase().includes(q))
+  return { success: true, repos, hasMore: false }
+}

--- a/orbit-www/src/app/actions/github.ts
+++ b/orbit-www/src/app/actions/github.ts
@@ -57,6 +57,8 @@ export interface Repository {
   description: string | null
   private: boolean
   defaultBranch: string
+  /** Azure DevOps project coordinate; undefined for GitHub repos. */
+  project?: string
 }
 
 export async function listInstallationRepositories(

--- a/orbit-www/src/app/api/internal/workspaces/[id]/apps/[appId]/route.test.ts
+++ b/orbit-www/src/app/api/internal/workspaces/[id]/apps/[appId]/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import type { Payload } from 'payload'
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+vi.stubEnv('ORBIT_INTERNAL_API_KEY', 'test-api-key')
+
+import { getPayload } from 'payload'
+const { GET } = await import('./route')
+
+type Doc = Record<string, unknown> & { id: string }
+
+class FakePayload {
+  collections: Record<string, Doc[]> = { apps: [] }
+  async findByID({ collection, id }: { collection: string; id: string }) {
+    const doc = (this.collections[collection] ?? []).find((d) => d.id === id)
+    if (!doc) {
+      const err = new Error(`not found`) as Error & { status?: number }
+      err.status = 404
+      throw err
+    }
+    return doc
+  }
+}
+
+const p = (f: FakePayload) => f as unknown as Payload
+
+function req(apiKey: string | null) {
+  const headers: Record<string, string> = {}
+  if (apiKey) headers['X-API-Key'] = apiKey
+  return new NextRequest('http://localhost/api/internal/workspaces/ws-1/apps/app-1', { headers })
+}
+
+const ctx = (id: string, appId: string) => ({ params: Promise.resolve({ id, appId }) })
+
+describe('GET /api/internal/workspaces/[id]/apps/[appId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 without a valid API key', async () => {
+    const f = new FakePayload()
+    vi.mocked(getPayload).mockResolvedValue(p(f))
+    const res = await GET(req(null), ctx('ws-1', 'app-1'))
+    expect(res.status).toBe(401)
+  })
+
+  it('emits provider, connectionId and project for an Azure DevOps app', async () => {
+    const f = new FakePayload()
+    f.collections.apps = [
+      {
+        id: 'app-1',
+        name: 'backend',
+        workspace: 'ws-1',
+        repository: {
+          provider: 'azure-devops',
+          owner: 'acme',
+          project: 'platform',
+          name: 'backend',
+          url: 'https://dev.azure.com/acme/platform/_git/backend',
+          connection: 'conn-1',
+          branch: 'main',
+        },
+      },
+    ]
+    vi.mocked(getPayload).mockResolvedValue(p(f))
+
+    const res = await GET(req('test-api-key'), ctx('ws-1', 'app-1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.repository).toMatchObject({
+      provider: 'azure-devops',
+      owner: 'acme',
+      project: 'platform',
+      name: 'backend',
+      url: 'https://dev.azure.com/acme/platform/_git/backend',
+      connectionId: 'conn-1',
+      branch: 'main',
+    })
+  })
+
+  it('emits empty provider fields for a legacy GitHub app', async () => {
+    const f = new FakePayload()
+    f.collections.apps = [
+      {
+        id: 'app-1',
+        name: 'gh-app',
+        workspace: 'ws-1',
+        repository: {
+          owner: 'acme',
+          name: 'gh-app',
+          url: 'https://github.com/acme/gh-app',
+          installationId: 'install-1',
+          branch: 'main',
+        },
+      },
+    ]
+    vi.mocked(getPayload).mockResolvedValue(p(f))
+
+    const res = await GET(req('test-api-key'), ctx('ws-1', 'app-1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.repository.provider).toBe('')
+    expect(body.repository.connectionId).toBe('')
+    expect(body.repository.project).toBe('')
+    expect(body.repository.owner).toBe('acme')
+  })
+
+  it('returns 404 when the app belongs to another workspace', async () => {
+    const f = new FakePayload()
+    f.collections.apps = [
+      { id: 'app-1', name: 'x', workspace: 'ws-other', repository: { url: 'u' } },
+    ]
+    vi.mocked(getPayload).mockResolvedValue(p(f))
+
+    const res = await GET(req('test-api-key'), ctx('ws-1', 'app-1'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/orbit-www/src/app/api/internal/workspaces/[id]/apps/[appId]/route.ts
+++ b/orbit-www/src/app/api/internal/workspaces/[id]/apps/[appId]/route.ts
@@ -41,9 +41,24 @@ export async function GET(
       return NextResponse.json({ error: 'App not found in this workspace' }, { status: 404 })
     }
 
-    const repo = (app as { repository?: { url?: string; owner?: string; name?: string; branch?: string } }).repository
+    const repo = (app as {
+      repository?: {
+        url?: string
+        owner?: string
+        name?: string
+        branch?: string
+        provider?: string
+        // depth:0 read → a git-connections id string (object shape handled defensively).
+        connection?: string | { id?: string }
+        project?: string
+      }
+    }).repository
     const healthConfig = (app as { healthConfig?: Record<string, unknown> }).healthConfig
     const buildConfig = (app as { buildConfig?: Record<string, unknown> }).buildConfig
+
+    const connectionId = typeof repo?.connection === 'string'
+      ? repo.connection
+      : repo?.connection?.id ?? ''
 
     return NextResponse.json({
       id: app.id,
@@ -51,7 +66,17 @@ export async function GET(
       description: (app as { description?: string }).description ?? '',
       status: (app as { status?: string }).status ?? 'unknown',
       repository: repo
-        ? { url: repo.url ?? '', owner: repo.owner ?? '', name: repo.name ?? '', branch: repo.branch ?? '' }
+        ? {
+            url: repo.url ?? '',
+            owner: repo.owner ?? '',
+            name: repo.name ?? '',
+            branch: repo.branch ?? '',
+            // WI1 provider fields for the ADO-aware Go clone path. Empty for
+            // legacy/GitHub apps; the Go side branches on provider.
+            provider: repo.provider ?? '',
+            connectionId,
+            project: repo.project ?? '',
+          }
         : null,
       healthConfig: healthConfig ?? null,
       buildConfig: buildConfig ?? null,

--- a/orbit-www/src/collections/Apps.ts
+++ b/orbit-www/src/collections/Apps.ts
@@ -228,8 +228,28 @@ export const Apps: CollectionConfig = {
       },
       fields: [
         {
+          // No default: absent `provider` means a legacy GitHub row (created
+          // before ADO parity). GitHub rows authenticate via `installationId`;
+          // Azure DevOps rows via `connection` + `project`.
+          name: 'provider',
+          type: 'select',
+          options: [
+            { label: 'GitHub', value: 'github' },
+            { label: 'Azure DevOps', value: 'azure-devops' },
+          ],
+          admin: {
+            description:
+              'Repo source provider. Absent on legacy rows = GitHub. ' +
+              'GitHub rows use installationId; Azure DevOps rows use connection + project.',
+          },
+        },
+        {
           name: 'owner',
           type: 'text',
+          admin: {
+            description:
+              'GitHub repo owner, or the Azure DevOps organization (never the ADO project).',
+          },
         },
         {
           name: 'name',
@@ -243,7 +263,27 @@ export const Apps: CollectionConfig = {
           name: 'installationId',
           type: 'text',
           admin: {
-            description: 'GitHub App installation ID',
+            description: 'GitHub App installation ID (GitHub rows only).',
+          },
+        },
+        {
+          name: 'connection',
+          type: 'relationship',
+          relationTo: 'git-connections',
+          admin: {
+            description:
+              'Azure DevOps git-connection backing this repo — the auth root for clones. ' +
+              'ADO rows only.',
+            condition: (_data, siblingData) => siblingData?.provider === 'azure-devops',
+          },
+        },
+        {
+          name: 'project',
+          type: 'text',
+          admin: {
+            description:
+              'Azure DevOps project (the middle segment of org/project/repo). ADO rows only.',
+            condition: (_data, siblingData) => siblingData?.provider === 'azure-devops',
           },
         },
         {

--- a/orbit-www/src/components/features/apps/ImportAppForm.test.tsx
+++ b/orbit-www/src/components/features/apps/ImportAppForm.test.tsx
@@ -22,11 +22,21 @@ vi.mock('@/app/actions/github', () => ({
   searchInstallationRepositories: vi.fn(),
 }))
 
+vi.mock('@/app/actions/azure-devops', () => ({
+  getWorkspaceGitConnections: vi.fn(),
+  listConnectionRepositories: vi.fn(),
+  searchConnectionRepositories: vi.fn(),
+}))
+
 import { importRepository } from '@/app/actions/apps'
 import {
   getWorkspaceGitHubInstallations,
   listInstallationRepositories,
 } from '@/app/actions/github'
+import {
+  getWorkspaceGitConnections,
+  listConnectionRepositories,
+} from '@/app/actions/azure-devops'
 
 describe('ImportAppForm', () => {
   afterEach(() => {
@@ -35,6 +45,9 @@ describe('ImportAppForm', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: no Azure DevOps connections, so existing assertions exercise the
+    // GitHub-only path. ADO-specific tests override this.
+    vi.mocked(getWorkspaceGitConnections).mockResolvedValue({ success: true, connections: [] })
   })
 
   const mockWorkspaces = [
@@ -236,6 +249,105 @@ describe('ImportAppForm', () => {
 
     await waitFor(() => {
       expect(getWorkspaceGitHubInstallations).toHaveBeenCalledWith('ws-2')
+    })
+  })
+
+  it('auto-selects a lone Azure DevOps connection without a source selector', async () => {
+    vi.mocked(getWorkspaceGitHubInstallations).mockResolvedValue({ success: true, installations: [] })
+    vi.mocked(getWorkspaceGitConnections).mockResolvedValue({
+      success: true,
+      connections: [
+        { id: 'conn-1', name: 'Acme ADO', organization: 'acme', baseUrl: 'https://dev.azure.com' },
+      ],
+    })
+    vi.mocked(listConnectionRepositories).mockResolvedValue({
+      success: true,
+      repos: [
+        {
+          name: 'backend',
+          fullName: 'platform/backend',
+          description: null,
+          private: true,
+          defaultBranch: 'main',
+          project: 'platform',
+        },
+      ],
+      hasMore: false,
+    })
+
+    render(<ImportAppForm workspaces={mockWorkspaces} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('backend')).toBeInTheDocument()
+    })
+    // Single provider: no source-selector chrome.
+    expect(screen.queryByLabelText(/repository source/i)).not.toBeInTheDocument()
+  })
+
+  it('submits an ADO repo with connectionId and a dev.azure.com URL', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getWorkspaceGitHubInstallations).mockResolvedValue({ success: true, installations: [] })
+    vi.mocked(getWorkspaceGitConnections).mockResolvedValue({
+      success: true,
+      connections: [
+        { id: 'conn-1', name: 'Acme ADO', organization: 'acme', baseUrl: 'https://dev.azure.com' },
+      ],
+    })
+    vi.mocked(listConnectionRepositories).mockResolvedValue({
+      success: true,
+      repos: [
+        {
+          name: 'backend',
+          fullName: 'platform/backend',
+          description: null,
+          private: true,
+          defaultBranch: 'main',
+          project: 'platform',
+        },
+      ],
+      hasMore: false,
+    })
+    vi.mocked(importRepository).mockResolvedValue({ success: true, appId: 'app-ado' })
+
+    render(<ImportAppForm workspaces={mockWorkspaces} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('backend')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('backend'))
+    await user.click(screen.getByRole('button', { name: /import repository/i }))
+
+    await waitFor(() => {
+      expect(importRepository).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        repositoryUrl: 'https://dev.azure.com/acme/platform/_git/backend',
+        name: 'backend',
+        description: '',
+        connectionId: 'conn-1',
+      })
+    })
+  })
+
+  it('shows a source selector when both providers are available', async () => {
+    vi.mocked(getWorkspaceGitHubInstallations).mockResolvedValue({
+      success: true,
+      installations: [
+        { id: 'install-1', installationId: 12345, accountLogin: 'acme-org', accountAvatarUrl: '', accountType: 'Organization' },
+      ],
+    })
+    vi.mocked(getWorkspaceGitConnections).mockResolvedValue({
+      success: true,
+      connections: [
+        { id: 'conn-1', name: 'Acme ADO', organization: 'acme', baseUrl: 'https://dev.azure.com' },
+      ],
+    })
+    vi.mocked(listConnectionRepositories).mockResolvedValue({ success: true, repos: [], hasMore: false })
+
+    render(<ImportAppForm workspaces={mockWorkspaces} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/repository source/i)).toBeInTheDocument()
     })
   })
 })

--- a/orbit-www/src/components/features/apps/ImportAppForm.test.tsx
+++ b/orbit-www/src/components/features/apps/ImportAppForm.test.tsx
@@ -329,6 +329,38 @@ describe('ImportAppForm', () => {
     })
   })
 
+  it('shows a validation message naming both URL shapes for an unsupported manual URL (ADO source)', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getWorkspaceGitHubInstallations).mockResolvedValue({ success: true, installations: [] })
+    vi.mocked(getWorkspaceGitConnections).mockResolvedValue({
+      success: true,
+      connections: [
+        { id: 'conn-1', name: 'Acme ADO', organization: 'acme', baseUrl: 'https://dev.azure.com' },
+      ],
+    })
+    vi.mocked(listConnectionRepositories).mockResolvedValue({ success: true, repos: [], hasMore: false })
+
+    render(<ImportAppForm workspaces={mockWorkspaces} />)
+
+    // Lone ADO source is auto-selected; open the manual URL entry.
+    await waitFor(() => {
+      expect(screen.getByText(/enter a repository url manually/i)).toBeInTheDocument()
+    })
+    await user.click(screen.getByText(/enter a repository url manually/i))
+
+    await user.type(screen.getByLabelText(/repository url/i), 'https://gitlab.com/foo/bar')
+    await user.type(screen.getByLabelText(/application name/i), 'foo')
+    await user.click(screen.getByRole('button', { name: /import repository/i }))
+
+    // The inline error names both shapes ("Enter a GitHub …" distinguishes it
+    // from the always-present field description "A GitHub …").
+    await waitFor(() => {
+      expect(screen.getByText(/Enter a GitHub .*Azure DevOps.*_git\/repo/i)).toBeInTheDocument()
+    })
+    // Rejected client-side — no server round-trip.
+    expect(importRepository).not.toHaveBeenCalled()
+  })
+
   it('shows a source selector when both providers are available', async () => {
     vi.mocked(getWorkspaceGitHubInstallations).mockResolvedValue({
       success: true,

--- a/orbit-www/src/components/features/apps/ImportAppForm.tsx
+++ b/orbit-www/src/components/features/apps/ImportAppForm.tsx
@@ -50,6 +50,16 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>
 
+/** Message naming both accepted repo-URL shapes (GitHub and Azure DevOps). */
+const UNSUPPORTED_URL_MESSAGE =
+  'Enter a GitHub (github.com/owner/repo) or Azure DevOps ' +
+  '(dev.azure.com/org/project/_git/repo) repository URL'
+
+/** True when the URL is a recognized GitHub or Azure DevOps repo URL. */
+function isSupportedRepoUrl(url: string): boolean {
+  return /github\.com\/[^/]+\/[^/]+/.test(url) || parseAdoRepoUrl(url) !== null
+}
+
 /** Unified repo source across providers, so one selector can list both. */
 type ImportSource =
   | { kind: 'github'; id: string; label: string; installation: GitHubInstallation }
@@ -80,6 +90,9 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
   })
 
   const workspaceId = form.watch('workspaceId')
+  // Watched (reactive) so the submit button enables the same render the URL is
+  // auto-filled — form.getValues is non-reactive and lagged one render behind.
+  const repositoryUrlValue = form.watch('repositoryUrl')
 
   // Fetch both GitHub installations and Azure DevOps connections when the
   // workspace changes, then build the unified source list.
@@ -143,15 +156,25 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
   }
 
   const onSubmit = async (data: FormData) => {
+    const fallbackUrl =
+      selectedSource?.kind === 'github' && selectedRepo
+        ? `https://github.com/${selectedRepo.fullName}`
+        : ''
+    const repositoryUrl = data.repositoryUrl || fallbackUrl
+
+    // Client-side guard: a URL that is neither GitHub nor Azure DevOps surfaces
+    // an inline field error immediately (naming both shapes) rather than only
+    // failing on the server round-trip with nothing shown.
+    if (repositoryUrl && !isSupportedRepoUrl(repositoryUrl)) {
+      form.setError('repositoryUrl', { message: UNSUPPORTED_URL_MESSAGE })
+      return
+    }
+
     setIsSubmitting(true)
     try {
-      const fallbackUrl =
-        selectedSource?.kind === 'github' && selectedRepo
-          ? `https://github.com/${selectedRepo.fullName}`
-          : ''
       const result = await importRepository({
         workspaceId: data.workspaceId,
-        repositoryUrl: data.repositoryUrl || fallbackUrl,
+        repositoryUrl,
         name: data.name,
         description: data.description,
         ...(selectedSource?.kind === 'azure-devops'
@@ -173,6 +196,7 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
   // Auto-fill name from a manually entered URL (GitHub or Azure DevOps).
   const handleUrlChange = (url: string) => {
     form.setValue('repositoryUrl', url)
+    form.clearErrors('repositoryUrl')
     if (form.getValues('name')) return
     const ghMatch = url.match(/github\.com\/[^/]+\/([^/]+)/)
     if (ghMatch) {
@@ -408,7 +432,7 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
               </Button>
               <Button
                 type="submit"
-                disabled={isSubmitting || (!selectedRepo && !form.getValues('repositoryUrl'))}
+                disabled={isSubmitting || (!selectedRepo && !repositoryUrlValue)}
               >
                 {isSubmitting ? (
                   <>

--- a/orbit-www/src/components/features/apps/ImportAppForm.tsx
+++ b/orbit-www/src/components/features/apps/ImportAppForm.tsx
@@ -33,17 +33,27 @@ import {
   type GitHubInstallation,
   type Repository,
 } from '@/app/actions/github'
+import {
+  getWorkspaceGitConnections,
+  type GitConnectionSource,
+} from '@/app/actions/azure-devops'
+import { buildAdoRepoUrl, parseAdoRepoUrl } from '@/lib/connections/ado-url'
 import { RepositoryBrowser } from './RepositoryBrowser'
 import { InstallationPicker } from './InstallationPicker'
 
 const formSchema = z.object({
   workspaceId: z.string().min(1, 'Please select a workspace'),
-  repositoryUrl: z.string().url('Please enter a valid GitHub URL').optional().or(z.literal('')),
+  repositoryUrl: z.string().url('Please enter a valid repository URL').optional().or(z.literal('')),
   name: z.string().min(1, 'Name is required').max(100),
   description: z.string().max(500).optional(),
 })
 
 type FormData = z.infer<typeof formSchema>
+
+/** Unified repo source across providers, so one selector can list both. */
+type ImportSource =
+  | { kind: 'github'; id: string; label: string; installation: GitHubInstallation }
+  | { kind: 'azure-devops'; id: string; label: string; connection: GitConnectionSource }
 
 interface ImportAppFormProps {
   workspaces: { id: string; name: string }[]
@@ -53,9 +63,10 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [installations, setInstallations] = useState<GitHubInstallation[]>([])
-  const [selectedInstallation, setSelectedInstallation] = useState<GitHubInstallation | null>(null)
+  const [sources, setSources] = useState<ImportSource[]>([])
+  const [selectedSource, setSelectedSource] = useState<ImportSource | null>(null)
   const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null)
-  const [isLoadingInstallations, setIsLoadingInstallations] = useState(true)
+  const [isLoadingSources, setIsLoadingSources] = useState(true)
   const [showManualInput, setShowManualInput] = useState(false)
 
   const form = useForm<FormData>({
@@ -70,49 +81,82 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
 
   const workspaceId = form.watch('workspaceId')
 
-  // Fetch installations when workspace changes
+  // Fetch both GitHub installations and Azure DevOps connections when the
+  // workspace changes, then build the unified source list.
   useEffect(() => {
-    async function loadInstallations() {
+    async function loadSources() {
       if (!workspaceId) return
 
-      setIsLoadingInstallations(true)
-      setSelectedInstallation(null)
+      setIsLoadingSources(true)
+      setSelectedSource(null)
       setSelectedRepo(null)
 
-      const result = await getWorkspaceGitHubInstallations(workspaceId)
-      if (result.success) {
-        setInstallations(result.installations)
-        // Auto-select if only one installation
-        if (result.installations.length === 1) {
-          setSelectedInstallation(result.installations[0])
-        }
-        // Show manual input by default if no installations
-        if (result.installations.length === 0) {
-          setShowManualInput(true)
-        } else {
-          setShowManualInput(false)
-        }
+      const [ghResult, adoResult] = await Promise.all([
+        getWorkspaceGitHubInstallations(workspaceId),
+        getWorkspaceGitConnections(workspaceId),
+      ])
+
+      const ghInstallations = ghResult.success ? ghResult.installations : []
+      const adoConnections = adoResult.success ? adoResult.connections : []
+      setInstallations(ghInstallations)
+
+      const next: ImportSource[] = [
+        ...ghInstallations.map((installation): ImportSource => ({
+          kind: 'github',
+          id: installation.id,
+          label: `GitHub · ${installation.accountLogin}`,
+          installation,
+        })),
+        ...adoConnections.map((connection): ImportSource => ({
+          kind: 'azure-devops',
+          id: connection.id,
+          label: `Azure DevOps · ${connection.name}`,
+          connection,
+        })),
+      ]
+      setSources(next)
+
+      // Preselect a lone source; default to manual entry when there are none.
+      if (next.length === 1) {
+        setSelectedSource(next[0])
+        setShowManualInput(false)
+      } else if (next.length === 0) {
+        setShowManualInput(true)
+      } else {
+        setShowManualInput(false)
       }
-      setIsLoadingInstallations(false)
+
+      setIsLoadingSources(false)
     }
-    loadInstallations()
+    loadSources()
   }, [workspaceId])
 
   const handleRepoSelect = (repo: Repository) => {
     setSelectedRepo(repo)
     form.setValue('name', repo.name)
-    form.setValue('repositoryUrl', `https://github.com/${repo.fullName}`)
+    if (selectedSource?.kind === 'azure-devops') {
+      const { organization, baseUrl } = selectedSource.connection
+      form.setValue('repositoryUrl', buildAdoRepoUrl(baseUrl, organization, repo.project ?? '', repo.name))
+    } else {
+      form.setValue('repositoryUrl', `https://github.com/${repo.fullName}`)
+    }
   }
 
   const onSubmit = async (data: FormData) => {
     setIsSubmitting(true)
     try {
+      const fallbackUrl =
+        selectedSource?.kind === 'github' && selectedRepo
+          ? `https://github.com/${selectedRepo.fullName}`
+          : ''
       const result = await importRepository({
         workspaceId: data.workspaceId,
-        repositoryUrl: data.repositoryUrl || `https://github.com/${selectedRepo?.fullName}`,
+        repositoryUrl: data.repositoryUrl || fallbackUrl,
         name: data.name,
         description: data.description,
-        installationId: selectedInstallation?.id,
+        ...(selectedSource?.kind === 'azure-devops'
+          ? { connectionId: selectedSource.id }
+          : { installationId: selectedSource?.id }),
       })
       if (result.success && result.appId) {
         router.push(`/apps/${result.appId}`)
@@ -126,17 +170,26 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
     }
   }
 
-  // Auto-fill name from URL (for manual input)
+  // Auto-fill name from a manually entered URL (GitHub or Azure DevOps).
   const handleUrlChange = (url: string) => {
     form.setValue('repositoryUrl', url)
-    const match = url.match(/github\.com\/[^/]+\/([^/]+)/)
-    if (match && !form.getValues('name')) {
-      form.setValue('name', match[1].replace(/\.git$/, ''))
+    if (form.getValues('name')) return
+    const ghMatch = url.match(/github\.com\/[^/]+\/([^/]+)/)
+    if (ghMatch) {
+      form.setValue('name', ghMatch[1].replace(/\.git$/, ''))
+      return
     }
+    const ado = parseAdoRepoUrl(url)
+    if (ado) form.setValue('name', ado.repo)
   }
 
-  const hasInstallations = installations.length > 0
+  const hasSources = sources.length > 0
+  const hasAdo = sources.some((s) => s.kind === 'azure-devops')
   const hasMultipleInstallations = installations.length > 1
+  // Unified source selector: shown whenever an ADO connection exists and there
+  // is more than one source to choose from. A single-provider GitHub workspace
+  // keeps its existing InstallationPicker; a lone source is auto-selected.
+  const showSourceSelector = hasAdo && sources.length > 1
 
   return (
     <Card>
@@ -170,45 +223,78 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
             />
 
             {/* Loading state */}
-            {isLoadingInstallations && (
+            {isLoadingSources && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Loading GitHub integrations...
+                Loading repository sources...
               </div>
             )}
 
-            {/* No installations message */}
-            {!isLoadingInstallations && !hasInstallations && (
+            {/* No sources message */}
+            {!isLoadingSources && !hasSources && (
               <Alert>
                 <Info className="h-4 w-4" />
                 <AlertDescription>
-                  No GitHub integrations available.{' '}
+                  No repository sources available.{' '}
                   <a href="/settings/connections" className="underline hover:no-underline">
-                    Install a GitHub App
+                    Connect GitHub or Azure DevOps
                   </a>{' '}
                   in Settings, or enter a URL manually below.
                 </AlertDescription>
               </Alert>
             )}
 
-            {/* Installation picker (only if multiple) */}
-            {!isLoadingInstallations && hasMultipleInstallations && (
+            {/* Unified source selector (GitHub installations + ADO connections) */}
+            {!isLoadingSources && showSourceSelector && (
+              <FormItem>
+                <FormLabel>Repository Source</FormLabel>
+                <Select
+                  value={selectedSource?.id ?? ''}
+                  onValueChange={(id) => {
+                    setSelectedSource(sources.find((s) => s.id === id) ?? null)
+                    setSelectedRepo(null)
+                  }}
+                >
+                  <SelectTrigger aria-label="Repository Source">
+                    <SelectValue placeholder="Select a source" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sources.map((source) => (
+                      <SelectItem key={source.id} value={source.id}>
+                        {source.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormItem>
+            )}
+
+            {/* GitHub-only installation picker (preserved for single-provider GitHub) */}
+            {!isLoadingSources && !hasAdo && hasMultipleInstallations && (
               <FormItem>
                 <FormLabel>GitHub Installation</FormLabel>
                 <InstallationPicker
                   installations={installations}
-                  selected={selectedInstallation}
-                  onSelect={setSelectedInstallation}
+                  selected={selectedSource?.kind === 'github' ? selectedSource.installation : null}
+                  onSelect={(installation) =>
+                    setSelectedSource({
+                      kind: 'github',
+                      id: installation.id,
+                      label: `GitHub · ${installation.accountLogin}`,
+                      installation,
+                    })
+                  }
                 />
               </FormItem>
             )}
 
             {/* Repository Browser */}
-            {!isLoadingInstallations && hasInstallations && selectedInstallation && !showManualInput && (
+            {!isLoadingSources && hasSources && selectedSource && !showManualInput && (
               <FormItem>
                 <FormLabel>Repository</FormLabel>
                 <RepositoryBrowser
-                  installationId={selectedInstallation.id}
+                  installationId={selectedSource.kind === 'github' ? selectedSource.id : undefined}
+                  connectionId={selectedSource.kind === 'azure-devops' ? selectedSource.id : undefined}
                   onSelect={handleRepoSelect}
                 />
                 {selectedRepo && (
@@ -220,7 +306,7 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
             )}
 
             {/* Manual input toggle */}
-            {!isLoadingInstallations && hasInstallations && !showManualInput && (
+            {!isLoadingSources && hasSources && !showManualInput && (
               <button
                 type="button"
                 onClick={() => setShowManualInput(true)}
@@ -232,9 +318,9 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
             )}
 
             {/* Manual URL input */}
-            {(!isLoadingInstallations && showManualInput) && (
+            {(!isLoadingSources && showManualInput) && (
               <>
-                {hasInstallations && (
+                {hasSources && (
                   <button
                     type="button"
                     onClick={() => {
@@ -263,7 +349,8 @@ export function ImportAppForm({ workspaces }: ImportAppFormProps) {
                         />
                       </FormControl>
                       <FormDescription>
-                        The GitHub repository to import
+                        A GitHub (github.com/owner/repo) or Azure DevOps
+                        (dev.azure.com/org/project/_git/repo) repository URL
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/orbit-www/src/components/features/apps/RepositoryBrowser.test.tsx
+++ b/orbit-www/src/components/features/apps/RepositoryBrowser.test.tsx
@@ -8,6 +8,11 @@ vi.mock('@/app/actions/github', () => ({
   searchInstallationRepositories: vi.fn(),
 }))
 
+vi.mock('@/app/actions/azure-devops', () => ({
+  listConnectionRepositories: vi.fn(),
+  searchConnectionRepositories: vi.fn(),
+}))
+
 import {
   listInstallationRepositories,
   searchInstallationRepositories,

--- a/orbit-www/src/components/features/apps/RepositoryBrowser.test.tsx
+++ b/orbit-www/src/components/features/apps/RepositoryBrowser.test.tsx
@@ -104,6 +104,36 @@ describe('RepositoryBrowser', () => {
     })
   })
 
+  it('does not submit the surrounding form when a repo card is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const onSubmit = vi.fn((e: { preventDefault: () => void }) => e.preventDefault())
+
+    vi.mocked(listInstallationRepositories).mockResolvedValue({
+      success: true,
+      repos: [
+        { name: 'backend', fullName: 'org/backend', description: 'API', private: true, defaultBranch: 'main' },
+      ],
+      hasMore: false,
+    })
+
+    render(
+      <form onSubmit={onSubmit}>
+        <RepositoryBrowser installationId="install-1" onSelect={onSelect} />
+      </form>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('backend')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('backend'))
+
+    // Card is type="button": it selects without natively submitting the form.
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it('should filter repositories client-side', async () => {
     const user = userEvent.setup()
 

--- a/orbit-www/src/components/features/apps/RepositoryBrowser.tsx
+++ b/orbit-www/src/components/features/apps/RepositoryBrowser.tsx
@@ -12,13 +12,29 @@ import {
   searchInstallationRepositories,
   type Repository,
 } from '@/app/actions/github'
+import {
+  listConnectionRepositories,
+  searchConnectionRepositories,
+} from '@/app/actions/azure-devops'
 
 interface RepositoryBrowserProps {
-  installationId: string
+  /** GitHub source: the app installation id. */
+  installationId?: string
+  /** Azure DevOps source: the git-connection id. Takes precedence when set. */
+  connectionId?: string
   onSelect: (repo: Repository) => void
 }
 
-export function RepositoryBrowser({ installationId, onSelect }: RepositoryBrowserProps) {
+export function RepositoryBrowser({ installationId, connectionId, onSelect }: RepositoryBrowserProps) {
+  // Provider-aware source id + list/search actions. Azure DevOps listing is
+  // unpaginated (page is ignored) and search filters the full set server-side.
+  const sourceId = connectionId ?? installationId ?? ''
+  const listRepos = connectionId
+    ? (page: number) => listConnectionRepositories(connectionId, page)
+    : (page: number) => listInstallationRepositories(installationId ?? '', page)
+  const searchRepos = connectionId
+    ? (query: string) => searchConnectionRepositories(connectionId, query)
+    : (query: string) => searchInstallationRepositories(installationId ?? '', query)
   const [repos, setRepos] = useState<Repository[]>([])
   const [searchResults, setSearchResults] = useState<Repository[] | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -36,7 +52,7 @@ export function RepositoryBrowser({ installationId, onSelect }: RepositoryBrowse
       setError(null)
       setSearchResults(null)
       setSearchQuery('')
-      const result = await listInstallationRepositories(installationId)
+      const result = await listRepos(1)
       if (result.success) {
         setRepos(result.repos)
         setHasMore(result.hasMore)
@@ -46,13 +62,14 @@ export function RepositoryBrowser({ installationId, onSelect }: RepositoryBrowse
       setIsLoading(false)
     }
     loadRepos()
-  }, [installationId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceId])
 
   // Load more
   const handleLoadMore = async () => {
     setIsLoadingMore(true)
     const nextPage = page + 1
-    const result = await listInstallationRepositories(installationId, nextPage)
+    const result = await listRepos(nextPage)
     if (result.success) {
       setRepos((prev) => [...prev, ...result.repos])
       setHasMore(result.hasMore)
@@ -65,7 +82,7 @@ export function RepositoryBrowser({ installationId, onSelect }: RepositoryBrowse
   const handleSearchAll = async () => {
     if (searchQuery.length < 3) return
     setIsSearching(true)
-    const result = await searchInstallationRepositories(installationId, searchQuery)
+    const result = await searchRepos(searchQuery)
     if (result.success) {
       setSearchResults(result.repos)
     }

--- a/orbit-www/src/components/features/apps/RepositoryBrowser.tsx
+++ b/orbit-www/src/components/features/apps/RepositoryBrowser.tsx
@@ -155,6 +155,7 @@ export function RepositoryBrowser({ installationId, connectionId, onSelect }: Re
             <p className="text-sm text-muted-foreground">No repositories found</p>
             {showSearchAllButton && (
               <Button
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={handleSearchAll}
@@ -175,6 +176,7 @@ export function RepositoryBrowser({ installationId, connectionId, onSelect }: Re
           <div className="p-1">
             {filteredRepos.map((repo) => (
               <button
+                type="button"
                 key={repo.fullName}
                 onClick={() => onSelect(repo)}
                 className="flex w-full items-start gap-3 rounded-md p-3 text-left hover:bg-accent"
@@ -210,6 +212,7 @@ export function RepositoryBrowser({ installationId, connectionId, onSelect }: Re
 
       {hasMore && !searchQuery && (
         <Button
+          type="button"
           variant="outline"
           size="sm"
           onClick={handleLoadMore}

--- a/orbit-www/src/lib/connections/ado-repos-core.test.ts
+++ b/orbit-www/src/lib/connections/ado-repos-core.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Payload } from 'payload'
+
+// ado-repos-core resolves credentials through token-core, which imports
+// lib/encryption at module load. Stub it so no real ENCRYPTION_KEY is needed.
+vi.mock('@/lib/encryption', () => ({
+  decrypt: vi.fn((val: string) => `decrypted:${val}`),
+}))
+
+import {
+  listConnectionRepositoriesCore,
+  adoRepositoriesUrl,
+  type AdoFetch,
+} from './ado-repos-core'
+import { clearEntraTokenCache } from './token-core'
+
+// --- FakePayload -------------------------------------------------------------
+
+type Doc = Record<string, unknown> & { id: string }
+
+class FakePayload {
+  collections: Record<string, Doc[]> = { 'git-connections': [] }
+  async findByID({ collection, id }: { collection: string; id: string }) {
+    const doc = (this.collections[collection] ?? []).find((d) => d.id === id)
+    if (!doc) throw new Error(`findByID: ${collection}/${id} not found`)
+    return doc
+  }
+}
+
+const p = (f: FakePayload) => f as unknown as Payload
+const decryptStub = (v: string) => `decrypted:${v}`
+
+const patConn = (over: Partial<Doc> = {}): Doc => ({
+  id: 'conn-1',
+  provider: 'azure-devops',
+  organization: 'acme',
+  project: 'platform',
+  baseUrl: 'https://dev.azure.com',
+  authType: 'pat',
+  credentials: { pat: 'enc-pat' },
+  ...over,
+})
+
+/** A minimal ADO git-repositories REST payload. */
+function reposBody(repos: Array<Record<string, unknown>>) {
+  return { count: repos.length, value: repos }
+}
+
+function jsonResponse(status: number, body: unknown): { ok: boolean; status: number; json: () => Promise<unknown> } {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+describe('adoRepositoriesUrl', () => {
+  it('builds the project-scoped repositories URL', () => {
+    expect(adoRepositoriesUrl('https://dev.azure.com', 'acme', 'platform')).toBe(
+      'https://dev.azure.com/acme/platform/_apis/git/repositories?api-version=7.1',
+    )
+  })
+
+  it('trims a trailing slash and encodes segments', () => {
+    expect(adoRepositoriesUrl('https://dev.azure.com/', 'acme corp', 'My Project')).toBe(
+      'https://dev.azure.com/acme%20corp/My%20Project/_apis/git/repositories?api-version=7.1',
+    )
+  })
+})
+
+describe('listConnectionRepositoriesCore', () => {
+  beforeEach(() => {
+    clearEntraTokenCache()
+  })
+
+  it('lists repos for a project-scoped PAT connection with Basic auth', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [patConn()]
+
+    const seen: Array<{ url: string; auth: string }> = []
+    const fetchFn: AdoFetch = async (url, init) => {
+      seen.push({ url, auth: init.headers.Authorization })
+      return jsonResponse(
+        200,
+        reposBody([
+          { name: 'backend', defaultBranch: 'refs/heads/main', isDisabled: false },
+          { name: 'frontend', defaultBranch: 'refs/heads/develop' },
+        ]),
+      )
+    }
+
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-1', { fetchFn, decryptFn: decryptStub })
+
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.repos).toEqual([
+      {
+        name: 'backend',
+        fullName: 'platform/backend',
+        description: null,
+        private: true,
+        defaultBranch: 'main',
+        project: 'platform',
+      },
+      {
+        name: 'frontend',
+        fullName: 'platform/frontend',
+        description: null,
+        private: true,
+        defaultBranch: 'develop',
+        project: 'platform',
+      },
+    ])
+    // Single project-scoped call; Basic auth with empty username + PAT.
+    expect(seen).toHaveLength(1)
+    expect(seen[0].url).toBe(
+      'https://dev.azure.com/acme/platform/_apis/git/repositories?api-version=7.1',
+    )
+    expect(seen[0].auth).toBe(`Basic ${Buffer.from(':decrypted:enc-pat').toString('base64')}`)
+  })
+
+  it('filters out disabled repos', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [patConn()]
+    const fetchFn: AdoFetch = async () =>
+      jsonResponse(
+        200,
+        reposBody([
+          { name: 'live', defaultBranch: 'refs/heads/main', isDisabled: false },
+          { name: 'dead', defaultBranch: 'refs/heads/main', isDisabled: true },
+        ]),
+      )
+
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-1', { fetchFn, decryptFn: decryptStub })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.repos.map((r) => r.name)).toEqual(['live'])
+  })
+
+  it('fans in across all projects when the connection has no project', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [patConn({ project: '' })]
+
+    const urls: string[] = []
+    const fetchFn: AdoFetch = async (url) => {
+      urls.push(url)
+      if (url.includes('/_apis/projects')) {
+        return jsonResponse(200, { count: 2, value: [{ name: 'alpha' }, { name: 'beta' }] })
+      }
+      if (url.includes('/alpha/_apis/git/repositories')) {
+        return jsonResponse(200, reposBody([{ name: 'a-repo', defaultBranch: 'refs/heads/main' }]))
+      }
+      return jsonResponse(200, reposBody([{ name: 'b-repo', defaultBranch: 'refs/heads/trunk' }]))
+    }
+
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-1', { fetchFn, decryptFn: decryptStub })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.repos.map((r) => `${r.project}/${r.name}`)).toEqual(['alpha/a-repo', 'beta/b-repo'])
+    expect(urls[0]).toContain('/_apis/projects')
+  })
+
+  it('uses Bearer auth for a service-principal connection', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [
+      patConn({
+        id: 'conn-sp',
+        authType: 'service-principal',
+        credentials: { tenantId: 't', clientId: 'c', clientSecret: 'enc-secret' },
+      }),
+    ]
+    let authHeader = ''
+    const fetchFn: AdoFetch = async (_url, init) => {
+      authHeader = init.headers.Authorization
+      return jsonResponse(200, reposBody([{ name: 'x', defaultBranch: 'refs/heads/main' }]))
+    }
+    const mintFn = vi.fn(async () => ({ token: 'entra-token', expiresAtMs: Date.now() + 3_600_000 }))
+
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-sp', {
+      fetchFn,
+      decryptFn: decryptStub,
+      mintFn,
+    })
+    expect(res.ok).toBe(true)
+    expect(authHeader).toBe('Bearer entra-token')
+    expect(mintFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a credential-resolution failure to an error (never throws)', async () => {
+    const f = new FakePayload()
+    // No such connection.
+    const res = await listConnectionRepositoriesCore(p(f), 'missing', {
+      fetchFn: async () => jsonResponse(200, reposBody([])),
+      decryptFn: decryptStub,
+    })
+    expect(res).toMatchObject({ ok: false })
+    if (res.ok) return
+    expect(res.error).toBeTruthy()
+  })
+
+  it('maps a non-2xx ADO response to an auth-style error and never leaks the token', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [patConn()]
+    const fetchFn: AdoFetch = async () => jsonResponse(401, { message: 'unauthorized' })
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-1', { fetchFn, decryptFn: decryptStub })
+    expect(res).toMatchObject({ ok: false })
+    if (res.ok) return
+    expect(res.error).toMatch(/auth|401/i)
+    expect(res.error).not.toContain('enc-pat')
+    expect(res.error).not.toContain('decrypted')
+  })
+
+  it('maps a network throw to an error', async () => {
+    const f = new FakePayload()
+    f.collections['git-connections'] = [patConn()]
+    const fetchFn: AdoFetch = async () => {
+      throw new Error('ECONNREFUSED')
+    }
+    const res = await listConnectionRepositoriesCore(p(f), 'conn-1', { fetchFn, decryptFn: decryptStub })
+    expect(res).toMatchObject({ ok: false })
+  })
+})

--- a/orbit-www/src/lib/connections/ado-repos-core.ts
+++ b/orbit-www/src/lib/connections/ado-repos-core.ts
@@ -1,0 +1,170 @@
+import type { Payload } from 'payload'
+import { resolveConnectionToken, type EntraTokenMinter, type ConnectionTokenLookup } from './token-core'
+import { adoProjectsUrl } from './connections-core'
+
+/**
+ * Testable core for ADO repo listing (WI2) — the git-connections analogue of
+ * `listInstallationRepositories`. Resolves the connection's credentials through
+ * `resolveConnectionToken` (basic-pat or bearer) and hits the Azure DevOps git
+ * REST API directly. The decrypted token NEVER leaves this process: callers get
+ * back only repo metadata or an error string, never the credential.
+ *
+ * A connection may be project-scoped (list one project's repos) or org-wide
+ * (enumerate `_apis/projects`, then fan in). `fetchFn`/`decryptFn`/`mintFn` are
+ * injected so unit tests exercise the matrix without a real ADO org or network.
+ */
+
+const DEFAULT_BASE_URL = 'https://dev.azure.com'
+
+/** Same shape the repo browser consumes, plus the ADO `project` coordinate. */
+export interface AdoRepository {
+  name: string
+  fullName: string
+  description: string | null
+  private: boolean
+  defaultBranch: string
+  project: string
+}
+
+/** Minimal fetch surface: status + JSON body are all the core needs. */
+export type AdoFetch = (
+  url: string,
+  init: { headers: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>
+
+export type ListReposResult = { ok: true; repos: AdoRepository[] } | { ok: false; error: string }
+
+export interface ListReposOptions {
+  fetchFn: AdoFetch
+  decryptFn?: (s: string) => string
+  mintFn?: EntraTokenMinter
+}
+
+/**
+ * Build the ADO "list repositories" URL for a project:
+ *   {baseUrl}/{org}/{project}/_apis/git/repositories?api-version=7.1
+ */
+export function adoRepositoriesUrl(baseUrl: string, org: string, project: string): string {
+  const base = (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '')
+  return `${base}/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_apis/git/repositories?api-version=7.1`
+}
+
+function authHeader(authMode: 'basic-pat' | 'bearer', token: string): string {
+  // Azure DevOps PAT auth: HTTP Basic with an empty username and the PAT.
+  return authMode === 'bearer'
+    ? `Bearer ${token}`
+    : `Basic ${Buffer.from(`:${token}`).toString('base64')}`
+}
+
+/** ADO returns `refs/heads/main`; the browser wants the short branch name. */
+function stripBranch(ref: unknown): string {
+  return typeof ref === 'string' ? ref.replace(/^refs\/heads\//, '') : ''
+}
+
+/** ADO list endpoints wrap results in `{ count, value: [...] }`. */
+function extractValues(body: unknown): Array<Record<string, unknown>> {
+  if (body && typeof body === 'object') {
+    const value = (body as { value?: unknown }).value
+    if (Array.isArray(value)) {
+      return value.filter((v): v is Record<string, unknown> => !!v && typeof v === 'object')
+    }
+  }
+  return []
+}
+
+function credErrorMessage(resolved: Extract<ConnectionTokenLookup, { ok: false }>): string {
+  switch (resolved.code) {
+    case 'NOT_FOUND':
+      return 'Connection not found'
+    case 'NOT_CONFIGURED':
+      return 'Connection has no credentials configured'
+    case 'DECRYPT_FAILED':
+      return 'Failed to decrypt connection credentials'
+    default:
+      return `Microsoft Entra sign-in failed: ${resolved.error}`
+  }
+}
+
+function httpErrorMessage(status: number): string {
+  if (status === 401 || status === 403) {
+    return 'Authentication failed — check the connection credentials and their access to the organization'
+  }
+  if (status === 404) return 'Azure DevOps organization or project not found (HTTP 404)'
+  return `Azure DevOps returned HTTP ${status}`
+}
+
+function networkErrorMessage(e: unknown): string {
+  return `Could not reach Azure DevOps: ${e instanceof Error ? e.message : 'network error'}`
+}
+
+async function fetchProjectNames(
+  fetchFn: AdoFetch,
+  baseUrl: string,
+  organization: string,
+  headers: Record<string, string>,
+): Promise<{ ok: true; names: string[] } | { ok: false; error: string }> {
+  try {
+    const res = await fetchFn(adoProjectsUrl(baseUrl, organization), { headers })
+    if (!res.ok) return { ok: false, error: httpErrorMessage(res.status) }
+    const names = extractValues(await res.json())
+      .map((v) => String(v.name ?? ''))
+      .filter((n) => n.length > 0)
+    return { ok: true, names }
+  } catch (e) {
+    return { ok: false, error: networkErrorMessage(e) }
+  }
+}
+
+export async function listConnectionRepositoriesCore(
+  payload: Payload,
+  connectionId: string,
+  opts: ListReposOptions,
+): Promise<ListReposResult> {
+  const resolved = await resolveConnectionToken(payload, connectionId, opts.decryptFn, opts.mintFn)
+  if (!resolved.ok) {
+    return { ok: false, error: credErrorMessage(resolved) }
+  }
+
+  const { organization, project, baseUrl, authMode, token } = resolved.body
+  const headers = { Authorization: authHeader(authMode, token), Accept: 'application/json' }
+
+  // Project-scoped connections list one project; org-wide connections enumerate
+  // every project first, then fan in.
+  let projects: string[]
+  if (project) {
+    projects = [project]
+  } else {
+    const listed = await fetchProjectNames(opts.fetchFn, baseUrl, organization, headers)
+    if (!listed.ok) return listed
+    projects = listed.names
+  }
+
+  const repos: AdoRepository[] = []
+  for (const proj of projects) {
+    let body: unknown
+    try {
+      const res = await opts.fetchFn(adoRepositoriesUrl(baseUrl, organization, proj), { headers })
+      if (!res.ok) return { ok: false, error: httpErrorMessage(res.status) }
+      body = await res.json()
+    } catch (e) {
+      return { ok: false, error: networkErrorMessage(e) }
+    }
+
+    for (const raw of extractValues(body)) {
+      if (raw.isDisabled === true) continue
+      const name = String(raw.name ?? '')
+      if (!name) continue
+      repos.push({
+        name,
+        fullName: `${proj}/${name}`,
+        description: null,
+        // ADO git repos have no public/private flag; they are org-private.
+        private: true,
+        defaultBranch: stripBranch(raw.defaultBranch),
+        project: proj,
+      })
+    }
+  }
+
+  return { ok: true, repos }
+}

--- a/orbit-www/src/lib/connections/ado-url.test.ts
+++ b/orbit-www/src/lib/connections/ado-url.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { parseAdoRepoUrl, buildAdoRepoUrl } from './ado-url'
+
+describe('parseAdoRepoUrl', () => {
+  it('parses a dev.azure.com _git URL', () => {
+    expect(parseAdoRepoUrl('https://dev.azure.com/acme/platform/_git/backend')).toEqual({
+      organization: 'acme',
+      project: 'platform',
+      repo: 'backend',
+    })
+  })
+
+  it('parses an on-prem Azure DevOps Server URL (collection before project)', () => {
+    expect(
+      parseAdoRepoUrl('https://ado.acme.internal/tfs/DefaultCollection/platform/_git/backend'),
+    ).toEqual({
+      organization: 'DefaultCollection',
+      project: 'platform',
+      repo: 'backend',
+    })
+  })
+
+  it('handles project/repo names with spaces (percent-encoded)', () => {
+    expect(parseAdoRepoUrl('https://dev.azure.com/acme/My%20Project/_git/My%20Repo')).toEqual({
+      organization: 'acme',
+      project: 'My Project',
+      repo: 'My Repo',
+    })
+  })
+
+  it('strips a trailing .git suffix from the repo', () => {
+    expect(parseAdoRepoUrl('https://dev.azure.com/acme/platform/_git/backend.git')).toMatchObject({
+      repo: 'backend',
+    })
+  })
+
+  it('returns null for a GitHub URL', () => {
+    expect(parseAdoRepoUrl('https://github.com/acme/backend')).toBeNull()
+  })
+
+  it('returns null when there is no _git segment', () => {
+    expect(parseAdoRepoUrl('https://dev.azure.com/acme/platform/backend')).toBeNull()
+  })
+
+  it('returns null when org/project are missing before _git', () => {
+    expect(parseAdoRepoUrl('https://dev.azure.com/_git/backend')).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(parseAdoRepoUrl('not a url')).toBeNull()
+  })
+})
+
+describe('buildAdoRepoUrl', () => {
+  it('builds a dev.azure.com clone URL', () => {
+    expect(buildAdoRepoUrl('https://dev.azure.com', 'acme', 'platform', 'backend')).toBe(
+      'https://dev.azure.com/acme/platform/_git/backend',
+    )
+  })
+
+  it('trims a trailing slash from the base URL', () => {
+    expect(buildAdoRepoUrl('https://dev.azure.com/', 'acme', 'platform', 'backend')).toBe(
+      'https://dev.azure.com/acme/platform/_git/backend',
+    )
+  })
+
+  it('honours an on-prem base URL (collection carried as the org segment)', () => {
+    expect(
+      buildAdoRepoUrl('https://ado.acme.internal/tfs', 'DefaultCollection', 'platform', 'backend'),
+    ).toBe('https://ado.acme.internal/tfs/DefaultCollection/platform/_git/backend')
+  })
+})

--- a/orbit-www/src/lib/connections/ado-url.ts
+++ b/orbit-www/src/lib/connections/ado-url.ts
@@ -1,0 +1,70 @@
+/**
+ * Azure DevOps repo URL helpers, shared by the import server action (parsing a
+ * pasted/derived clone URL) and the import form (constructing one from a picked
+ * repo). Kept host-agnostic so on-prem Azure DevOps Server URLs work alongside
+ * dev.azure.com without a per-host allowlist.
+ *
+ * The canonical ADO repo coordinate is org/project/repo, expressed in a clone
+ * URL as `{host…}/{org}/{project}/_git/{repo}`. The `_git` segment is the stable
+ * anchor: the segment after it is the repo, the two before it are project then
+ * organization. That holds for both `https://dev.azure.com/{org}/{project}/_git/{repo}`
+ * and on-prem `https://{host}/{collection}/{project}/_git/{repo}` (collection = org).
+ */
+
+export interface AdoRepoCoordinate {
+  organization: string
+  project: string
+  repo: string
+}
+
+/**
+ * Parse an Azure DevOps `_git` repo URL into org/project/repo, or return null
+ * when the URL is not an ADO repo URL (e.g. a GitHub URL, or missing `_git`).
+ * Host-agnostic: works for dev.azure.com and on-prem Azure DevOps Server.
+ */
+export function parseAdoRepoUrl(rawUrl: string): AdoRepoCoordinate | null {
+  let pathname: string
+  try {
+    pathname = new URL(rawUrl).pathname
+  } catch {
+    return null
+  }
+
+  const segments = pathname
+    .split('/')
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      try {
+        return decodeURIComponent(s)
+      } catch {
+        return s
+      }
+    })
+
+  const gitIdx = segments.indexOf('_git')
+  // Need org, project before `_git` and repo after it.
+  if (gitIdx < 2 || gitIdx + 1 >= segments.length) return null
+
+  const organization = segments[gitIdx - 2]
+  const project = segments[gitIdx - 1]
+  const repo = segments[gitIdx + 1].replace(/\.git$/, '')
+  if (!organization || !project || !repo) return null
+
+  return { organization, project, repo }
+}
+
+/**
+ * Build an Azure DevOps clone/browse URL from a repo coordinate. `baseUrl` is
+ * the connection's base (default `https://dev.azure.com`; an on-prem base
+ * already carries the host and any collection prefix, with `organization` as the
+ * next segment).
+ */
+export function buildAdoRepoUrl(
+  baseUrl: string,
+  organization: string,
+  project: string,
+  repo: string,
+): string {
+  const base = (baseUrl || 'https://dev.azure.com').replace(/\/+$/, '')
+  return `${base}/${organization}/${project}/_git/${repo}`
+}

--- a/orbit-www/src/lib/discovery/import.test.ts
+++ b/orbit-www/src/lib/discovery/import.test.ts
@@ -64,6 +64,12 @@ class FakePayload {
     Object.assign(doc, data)
     return doc
   }
+
+  async findByID({ collection, id }: { collection: string; id: string }) {
+    const doc = (this.collections[collection] ?? []).find((d) => d.id === id)
+    if (!doc) throw new Error(`findByID: ${collection}/${id} not found`)
+    return doc
+  }
 }
 
 /** Supports the nested `repository.owner` dot-path queries the import lib uses. */
@@ -213,6 +219,106 @@ describe('importDiscoveredService', () => {
 
     expect(f.collections['apps']).toHaveLength(1)
   })
+
+  it('sets provider: github explicitly on a GitHub (installation-backed) accept', async () => {
+    const f = fp()
+    const d = discovery({ installation: 'inst-1', connection: undefined, proposal: { name: 'billing-svc' } })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    await importDiscoveredService(payloadOf(f), d)
+
+    expect(f.collections['apps'][0]).toMatchObject({
+      repository: { provider: 'github', owner: 'acme', name: 'billing', installationId: 'inst-1' },
+    })
+  })
+
+  it('ADO accept: reconstructs owner=organization from the linked git-connections doc, keeps repo.owner as project', async () => {
+    const f = fp()
+    f.collections['git-connections'] = [
+      { id: 'conn-1', organization: 'my-ado-org', name: 'ADO Conn' },
+    ]
+    const d = discovery({
+      installation: undefined,
+      connection: 'conn-1',
+      repo: { owner: 'my-project', name: 'billing', defaultBranch: 'main' },
+      proposal: { name: 'billing-svc' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), d)
+
+    expect(res.imported).toBe(true)
+    expect(f.collections['apps'][0]).toMatchObject({
+      repository: {
+        provider: 'azure-devops',
+        connection: 'conn-1',
+        owner: 'my-ado-org',
+        project: 'my-project',
+        name: 'billing',
+      },
+    })
+  })
+
+  it('ADO accept is idempotent: re-import finds the App by the resolved org, not the raw discovered project owner', async () => {
+    const f = fp()
+    f.collections['git-connections'] = [{ id: 'conn-1', organization: 'my-ado-org' }]
+    f.collections['apps'] = [
+      {
+        id: 'app-existing',
+        workspace: 'ws1',
+        name: 'billing',
+        repository: { provider: 'azure-devops', connection: 'conn-1', owner: 'my-ado-org', project: 'my-project', name: 'billing' },
+      },
+    ]
+    const d = discovery({
+      installation: undefined,
+      connection: 'conn-1',
+      repo: { owner: 'my-project', name: 'billing' },
+      proposal: { name: 'billing-svc' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), d)
+
+    expect(res.ref).toEqual({ collection: 'apps', id: 'app-existing' })
+    expect(f.collections['apps']).toHaveLength(1)
+  })
+
+  it('fails soft (no provider, no crash) for an entity with neither installation nor connection', async () => {
+    const f = fp()
+    const d = discovery({
+      installation: undefined,
+      connection: undefined,
+      repo: { owner: 'acme', name: 'billing' },
+      proposal: { name: 'billing-svc' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), d)
+
+    expect(res.imported).toBe(true)
+    expect(f.collections['apps'][0].repository).toMatchObject({ owner: 'acme', name: 'billing' })
+    expect((f.collections['apps'][0].repository as Record<string, unknown>).provider).toBeUndefined()
+  })
+
+  it('ADO accept: an unresolvable connection (deleted/missing) fails soft — no crash, owner falls back to discovered repo.owner', async () => {
+    const f = fp()
+    // No git-connections seeded — connection id points nowhere.
+    const d = discovery({
+      installation: undefined,
+      connection: 'conn-missing',
+      repo: { owner: 'my-project', name: 'billing' },
+      proposal: { name: 'billing-svc' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), d)
+
+    expect(res.imported).toBe(true)
+    const repo = f.collections['apps'][0].repository as Record<string, unknown>
+    expect(repo.provider).toBeUndefined()
+    expect(repo.owner).toBe('my-project')
+  })
 })
 
 // --- importDiscoveredApi -----------------------------------------------------
@@ -350,6 +456,36 @@ describe('importDiscoveredApi', () => {
     expect(res).toEqual({ imported: true, ref: { collection: 'api-schemas', id: 'schema-x' } })
     expect(f.collections['api-schemas']).toHaveLength(0)
   })
+
+  it('ADO: links the repository rel by resolved org, not the raw discovered project owner', async () => {
+    const f = fp()
+    f.collections['git-connections'] = [{ id: 'conn-1', organization: 'my-ado-org' }]
+    f.collections['apps'] = [
+      {
+        id: 'app-1',
+        workspace: 'ws1',
+        repository: { provider: 'azure-devops', connection: 'conn-1', owner: 'my-ado-org', project: 'my-project', name: 'billing' },
+      },
+    ]
+    const d = discovery({
+      detectedKind: 'api',
+      installation: undefined,
+      connection: 'conn-1',
+      repo: { owner: 'my-project', name: 'billing' },
+      proposal: {
+        schemaType: 'openapi',
+        specPath: 'openapi.yaml',
+        specTitle: 'Billing API',
+        rawContent: 'openapi: 3.0.0',
+      },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredApi(payloadOf(f), d, { actorUserId: 'user-9' })
+
+    expect(res.imported).toBe(true)
+    expect(f.collections['api-schemas'][0]).toMatchObject({ repository: 'app-1' })
+  })
 })
 
 // --- importDiscoveredGlobalEntity (WP8) -------------------------------------
@@ -417,6 +553,32 @@ describe('importDiscoveredGlobalEntity', () => {
     await importDiscoveredGlobalEntity(payloadOf(f), linked)
 
     expect(f.collections['catalog-entities']).toHaveLength(1)
+  })
+
+  it('ADO: folds provider/connection/org/project into metadata.repo (catalog-entities has no dedicated provider field)', async () => {
+    const f = fp()
+    f.collections['git-connections'] = [{ id: 'conn-1', organization: 'my-ado-org' }]
+    const d = discovery({
+      workspace: undefined,
+      installation: undefined,
+      connection: 'conn-1',
+      dedupeKey: 'adoglobalkey',
+      repo: { owner: 'my-project', name: 'billing' },
+      proposal: { name: 'billing' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredGlobalEntity(payloadOf(f), d)
+
+    expect(res.imported).toBe(true)
+    const metadata = f.collections['catalog-entities'][0].metadata as Record<string, unknown>
+    expect(metadata.repo).toMatchObject({
+      provider: 'azure-devops',
+      connection: 'conn-1',
+      owner: 'my-ado-org',
+      project: 'my-project',
+      name: 'billing',
+    })
   })
 })
 

--- a/orbit-www/src/lib/discovery/import.ts
+++ b/orbit-www/src/lib/discovery/import.ts
@@ -92,6 +92,75 @@ export function computeDedupeKey(
     .digest('hex')
 }
 
+/**
+ * Provider attribution resolved from a discovery row, ready to copy onto the
+ * created `apps` row's `repository` group (WI4, docs/plans/2026-07-09-ado-import-parity.md).
+ */
+interface ProviderInfo {
+  provider?: 'github' | 'azure-devops'
+  connection?: string
+  /** GitHub owner or ADO organization — never the ADO project. */
+  owner: string
+  /** ADO project (the middle org/project/repo segment). Absent for GitHub. */
+  project?: string
+}
+
+/**
+ * Resolve provider/connection/owner/project for a discovery row.
+ *
+ * GitHub rows (`installation` set): `discovery.repo.owner` is already the true
+ * GitHub owner — passed through, `provider: 'github'` set explicitly (preferred
+ * over the absent-provider legacy invariant).
+ *
+ * ADO rows (`connection` set): the scanner stores the ADO *project* name in
+ * `discovery.repo.owner` (there is no org field on discovered-entities — see
+ * DiscoveredEntities.ts `repo` group) — the true org lives on the linked
+ * `git-connections.organization`, so the connection doc must be resolved to
+ * reconstruct `apps.repository.owner`. `discovery.repo.owner` becomes `project`.
+ *
+ * Neither linkage, or the connection doc is missing/unresolvable: fails soft —
+ * no provider fields, `owner` falls back to `discovery.repo.owner` verbatim
+ * (matches pre-ADO-parity behavior; never throws).
+ */
+async function resolveProviderInfo(
+  payload: Payload,
+  discovery: DiscoveredEntity,
+): Promise<ProviderInfo> {
+  const installationId = relId(discovery.installation)
+  if (installationId) {
+    return { provider: 'github', owner: discovery.repo.owner }
+  }
+
+  const connectionId = relId(discovery.connection)
+  if (connectionId) {
+    try {
+      const conn = await payload.findByID({
+        collection: 'git-connections',
+        id: connectionId,
+        depth: 0,
+        overrideAccess: true,
+      })
+      const organization = (conn as { organization?: string } | null)?.organization
+      if (typeof organization === 'string' && organization.length > 0) {
+        return {
+          provider: 'azure-devops',
+          connection: connectionId,
+          owner: organization,
+          project: discovery.repo.owner,
+        }
+      }
+      console.error('[discovery/import] git-connections row missing organization', { connectionId })
+    } catch (err) {
+      console.error('[discovery/import] failed to resolve git-connections for ADO owner', {
+        connectionId,
+        err,
+      })
+    }
+  }
+
+  return { owner: discovery.repo.owner }
+}
+
 /** Find the App that represents a repo in a workspace (Phase 1: repo-scoped). */
 async function findRepoApp(
   payload: Payload,
@@ -136,9 +205,10 @@ export async function importDiscoveredService(
   if (!workspaceId) return { imported: false, skippedReason: 'missing-workspace' }
 
   const proposal = asRecord(discovery.proposal)
-  const { owner, name: repoName, url, defaultBranch } = discovery.repo
+  const { name: repoName, url, defaultBranch } = discovery.repo
+  const providerInfo = await resolveProviderInfo(payload, discovery)
 
-  let appId = await findRepoApp(payload, workspaceId, owner, repoName)
+  let appId = await findRepoApp(payload, workspaceId, providerInfo.owner, repoName)
   if (!appId) {
     const installationId = relId(discovery.installation)
     const buildConfig = asRecord(proposal.buildConfig)
@@ -150,10 +220,13 @@ export async function importDiscoveredService(
         name: (proposal.name as string) || repoName,
         ...(typeof proposal.description === 'string' ? { description: proposal.description } : {}),
         repository: {
-          owner,
+          owner: providerInfo.owner,
           name: repoName,
           ...(url ? { url } : {}),
           ...(installationId ? { installationId } : {}),
+          ...(providerInfo.provider ? { provider: providerInfo.provider } : {}),
+          ...(providerInfo.connection ? { connection: providerInfo.connection } : {}),
+          ...(providerInfo.project ? { project: providerInfo.project } : {}),
           ...(defaultBranch ? { branch: defaultBranch } : {}),
         },
         origin: { type: 'discovered' },
@@ -219,8 +292,12 @@ export async function importDiscoveredApi(
 
   const specPath =
     typeof proposal.specPath === 'string' ? proposal.specPath : discovery.path || ''
-  const { owner, name: repoName } = discovery.repo
-  const appId = await findRepoApp(payload, workspaceId, owner, repoName)
+  const { name: repoName } = discovery.repo
+  // api-schemas carries no provider/connection fields of its own — repo
+  // attribution lives entirely on the linked App, so only the lookup owner
+  // needs the ADO org (not the discovered project) to find the right App.
+  const providerInfo = await resolveProviderInfo(payload, discovery)
+  const appId = await findRepoApp(payload, workspaceId, providerInfo.owner, repoName)
 
   const existing = await payload.find({
     collection: 'api-schemas',
@@ -329,15 +406,23 @@ export async function importDiscoveredGlobalEntity(
   if (existing.docs.length > 0) {
     entityId = String(existing.docs[0].id)
   } else {
-    const { owner, name: repoName, url, defaultBranch } = discovery.repo
+    const { name: repoName, url, defaultBranch } = discovery.repo
     const name = (proposal.name as string) || repoName || 'entity'
     const buildConfig = asRecord(proposal.buildConfig)
+    // catalog-entities has no dedicated provider/connection/project fields
+    // (WI4 scope: do not widen this collection's schema) — `metadata` is
+    // already freeform JSON storing repo linkage, so provider attribution
+    // folds into `metadata.repo` alongside owner/name/url/defaultBranch.
+    const providerInfo = await resolveProviderInfo(payload, discovery)
     const metadata: Record<string, unknown> = {
       repo: {
-        owner,
+        owner: providerInfo.owner,
         name: repoName,
         ...(url ? { url } : {}),
         ...(defaultBranch ? { defaultBranch } : {}),
+        ...(providerInfo.provider ? { provider: providerInfo.provider } : {}),
+        ...(providerInfo.connection ? { connection: providerInfo.connection } : {}),
+        ...(providerInfo.project ? { project: providerInfo.project } : {}),
       },
       path: discovery.path ?? '',
       ...(typeof proposal.schemaType === 'string' ? { schemaType: proposal.schemaType } : {}),

--- a/orbit-www/src/payload-types.ts
+++ b/orbit-www/src/payload-types.ts
@@ -831,13 +831,28 @@ export interface App {
    * Optional - link to a Git repository
    */
   repository?: {
+    /**
+     * Repo source provider. Absent on legacy rows = GitHub. GitHub rows use installationId; Azure DevOps rows use connection + project.
+     */
+    provider?: ('github' | 'azure-devops') | null;
+    /**
+     * GitHub repo owner, or the Azure DevOps organization (never the ADO project).
+     */
     owner?: string | null;
     name?: string | null;
     url?: string | null;
     /**
-     * GitHub App installation ID
+     * GitHub App installation ID (GitHub rows only).
      */
     installationId?: string | null;
+    /**
+     * Azure DevOps git-connection backing this repo — the auth root for clones. ADO rows only.
+     */
+    connection?: (string | null) | GitConnection;
+    /**
+     * Azure DevOps project (the middle segment of org/project/repo). ADO rows only.
+     */
+    project?: string | null;
     /**
      * Branch to build from (default: main)
      */
@@ -977,6 +992,78 @@ export interface App {
    */
   registryConfig?: (string | null) | RegistryConfig;
   status?: ('healthy' | 'degraded' | 'down' | 'unknown') | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Non-GitHub git provider connections (Azure DevOps) for catalog discovery.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "git-connections".
+ */
+export interface GitConnection {
+  id: string;
+  /**
+   * Display name (e.g., "Acme Azure DevOps").
+   */
+  name: string;
+  /**
+   * Git provider. Azure DevOps only for now.
+   */
+  provider: 'azure-devops';
+  /**
+   * Provider organization (e.g., the ADO org name).
+   */
+  organization: string;
+  /**
+   * Optional project filter. Empty = all projects in the org.
+   */
+  project?: string | null;
+  /**
+   * API base URL. Override for Azure DevOps Server (on-prem).
+   */
+  baseUrl?: string | null;
+  /**
+   * How Orbit authenticates. Service principal mints short-lived Entra tokens (Microsoft-recommended; global PATs retire Dec 2026). PAT remains for ADO Server.
+   */
+  authType: 'pat' | 'service-principal';
+  /**
+   * Encrypted provider credentials.
+   */
+  credentials?: {
+    /**
+     * Personal access token (AES-256-GCM encrypted at rest).
+     */
+    pat?: string | null;
+    /**
+     * Entra tenant (directory) id — service principal auth.
+     */
+    tenantId?: string | null;
+    /**
+     * Entra app registration (client) id — service principal auth.
+     */
+    clientId?: string | null;
+    /**
+     * Entra client secret (AES-256-GCM encrypted at rest).
+     */
+    clientSecret?: string | null;
+  };
+  /**
+   * Workspaces a scan of this connection may attribute entities to.
+   */
+  allowedWorkspaces?: (string | Workspace)[] | null;
+  /**
+   * Connection health. "error" is set when validation fails.
+   */
+  status: 'active' | 'error';
+  /**
+   * When the PAT was last successfully validated against the provider.
+   */
+  lastValidatedAt?: string | null;
+  /**
+   * Most recent validation failure reason.
+   */
+  lastError?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -4156,78 +4243,6 @@ export interface DiscoveredEntity {
   createdAt: string;
 }
 /**
- * Non-GitHub git provider connections (Azure DevOps) for catalog discovery.
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "git-connections".
- */
-export interface GitConnection {
-  id: string;
-  /**
-   * Display name (e.g., "Acme Azure DevOps").
-   */
-  name: string;
-  /**
-   * Git provider. Azure DevOps only for now.
-   */
-  provider: 'azure-devops';
-  /**
-   * Provider organization (e.g., the ADO org name).
-   */
-  organization: string;
-  /**
-   * Optional project filter. Empty = all projects in the org.
-   */
-  project?: string | null;
-  /**
-   * API base URL. Override for Azure DevOps Server (on-prem).
-   */
-  baseUrl?: string | null;
-  /**
-   * How Orbit authenticates. Service principal mints short-lived Entra tokens (Microsoft-recommended; global PATs retire Dec 2026). PAT remains for ADO Server.
-   */
-  authType: 'pat' | 'service-principal';
-  /**
-   * Encrypted provider credentials.
-   */
-  credentials?: {
-    /**
-     * Personal access token (AES-256-GCM encrypted at rest).
-     */
-    pat?: string | null;
-    /**
-     * Entra tenant (directory) id — service principal auth.
-     */
-    tenantId?: string | null;
-    /**
-     * Entra app registration (client) id — service principal auth.
-     */
-    clientId?: string | null;
-    /**
-     * Entra client secret (AES-256-GCM encrypted at rest).
-     */
-    clientSecret?: string | null;
-  };
-  /**
-   * Workspaces a scan of this connection may attribute entities to.
-   */
-  allowedWorkspaces?: (string | Workspace)[] | null;
-  /**
-   * Connection health. "error" is set when validation fails.
-   */
-  status: 'active' | 'error';
-  /**
-   * When the PAT was last successfully validated against the provider.
-   */
-  lastValidatedAt?: string | null;
-  /**
-   * Most recent validation failure reason.
-   */
-  lastError?: string | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
@@ -4861,10 +4876,13 @@ export interface AppsSelect<T extends boolean = true> {
   repository?:
     | T
     | {
+        provider?: T;
         owner?: T;
         name?: T;
         url?: T;
         installationId?: T;
+        connection?: T;
+        project?: T;
         branch?: T;
       };
   origin?:

--- a/temporal-workflows/cmd/worker/main.go
+++ b/temporal-workflows/cmd/worker/main.go
@@ -602,7 +602,8 @@ func main() {
 	// workspace's connected GitHub App and clones the repo inside the
 	// sandbox. Token never reaches LLM context.
 	githubTokenClient := services.NewPayloadGitHubClient(orbitAPIURL, orbitInternalAPIKey, logger)
-	repoCloneActivities := agentactivity.NewOrbitRepoCloneActivities(sandboxExec, githubTokenClient, orbitContextClient, logger)
+	adoConnectionClient := services.NewPayloadADOConnectionClient(orbitAPIURL, orbitInternalAPIKey, logger)
+	repoCloneActivities := agentactivity.NewOrbitRepoCloneActivities(sandboxExec, githubTokenClient, adoConnectionClient, orbitContextClient, logger)
 	w.RegisterActivityWithOptions(repoCloneActivities.OrbitRepoClone, activity.RegisterOptions{Name: agentcontract.ActivityOrbitRepoClone})
 
 	log.Printf("Infrastructure Agent workflow + activities registered (sandbox backend=%s)", sandboxExec.Backend())

--- a/temporal-workflows/internal/activities/agent/orbit_repo_clone_activity.go
+++ b/temporal-workflows/internal/activities/agent/orbit_repo_clone_activity.go
@@ -22,30 +22,52 @@ type GitHubTokenClient interface {
 	GetInstallationTokenForRepo(ctx context.Context, workspaceID, owner, repo string) (services.InstallationToken, error)
 }
 
-// OrbitRepoCloneActivities back the orbit_repo_clone agent tool. It
-// resolves a private repo (either by Orbit app_id or raw URL), mints
-// a short-lived GitHub App installation token from the workspace's
-// connected installation, and runs `git clone --depth=1` inside the
-// agent's sandbox with the token projected as a one-shot env var.
-//
-// The token is URL-injected for the clone command, then immediately
-// scrubbed from .git/config via `git remote set-url`. The agent never
-// sees the raw token — it only receives clone path + head sha + branch.
-type OrbitRepoCloneActivities struct {
-	executor    sandbox.SandboxExecutor
-	tokenClient GitHubTokenClient
-	contextClient OrbitContextClient
-	logger      *slog.Logger
+// ADOTokenClient is the contract the orbit_repo_clone activity needs for
+// resolving Azure DevOps connection credentials. Implemented by
+// services.PayloadADOConnectionClient. Tests substitute a fake.
+type ADOTokenClient interface {
+	GetConnectionToken(ctx context.Context, connectionID string) (services.ADOConnectionToken, error)
 }
 
-// NewOrbitRepoCloneActivities constructs the activity group.
-func NewOrbitRepoCloneActivities(executor sandbox.SandboxExecutor, tokenClient GitHubTokenClient, contextClient OrbitContextClient, logger *slog.Logger) *OrbitRepoCloneActivities {
+// providerGitHub / providerADO are the canonical provider tags. They match
+// git-connections.provider and the catalog workflow input — do NOT introduce
+// azure_devops.
+const (
+	providerGitHub = "github"
+	providerADO    = "azure-devops"
+)
+
+// OrbitRepoCloneActivities back the orbit_repo_clone agent tool. It
+// resolves a private repo (either by Orbit app_id or raw URL), mints a
+// short-lived credential from the workspace's connected provider (a GitHub
+// App installation token, or an Azure DevOps connection PAT / bearer token),
+// and runs `git clone --depth=1` inside the agent's sandbox with the token
+// projected as a one-shot env var.
+//
+// The token is referenced only via an env var in the clone command (never
+// interpolated literally) and, for the GitHub / ADO basic-pat URL-injected
+// paths, immediately scrubbed from .git/config via `git remote set-url`. The
+// agent never sees the raw token — it only receives clone path + head sha +
+// branch.
+type OrbitRepoCloneActivities struct {
+	executor      sandbox.SandboxExecutor
+	tokenClient   GitHubTokenClient
+	adoClient     ADOTokenClient
+	contextClient OrbitContextClient
+	logger        *slog.Logger
+}
+
+// NewOrbitRepoCloneActivities constructs the activity group. adoClient may
+// be nil in deployments without ADO support — an ADO clone then fails with a
+// clear "not configured" error rather than panicking.
+func NewOrbitRepoCloneActivities(executor sandbox.SandboxExecutor, tokenClient GitHubTokenClient, adoClient ADOTokenClient, contextClient OrbitContextClient, logger *slog.Logger) *OrbitRepoCloneActivities {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &OrbitRepoCloneActivities{
 		executor:      executor,
 		tokenClient:   tokenClient,
+		adoClient:     adoClient,
 		contextClient: contextClient,
 		logger:        logger,
 	}
@@ -76,10 +98,26 @@ type OrbitRepoCloneResult struct {
 	ClonePath      string `json:"clone_path"`
 	Owner          string `json:"owner"`
 	Repo           string `json:"repo"`
+	Project        string `json:"project,omitempty"`
 	Branch         string `json:"branch"`
 	HeadSHA        string `json:"head_sha"`
 	InstallationID int64  `json:"installation_id"`
 	DurationMs     int64  `json:"duration_ms"`
+}
+
+// cloneSpec is the provider-resolved plan for a single clone: the bash
+// command (which references the token only through an env var), the env var
+// to project, the raw token (for defensive redaction of any surface output),
+// and the coordinates echoed back to the agent.
+type cloneSpec struct {
+	command   string
+	env       map[string]string
+	token     string
+	owner     string // GitHub owner or ADO organization
+	repo      string
+	project   string // ADO only
+	slug      string
+	installID int64 // GitHub only; 0 for ADO
 }
 
 // OrbitRepoClone implements the orbit_repo_clone tool.
@@ -100,8 +138,10 @@ func (a *OrbitRepoCloneActivities) OrbitRepoClone(ctx context.Context, in OrbitR
 		return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError("one of app_id or repo_url required", "InvalidInput", nil)
 	}
 
-	// Resolve repo URL.
+	// Resolve repo URL and, for the app_id path, capture the app-doc
+	// repository — its provider/connection linkage is the auth root for ADO.
 	repoURL := strings.TrimSpace(in.RepoURL)
+	var appRepo *services.AppRepository
 	if appID := strings.TrimSpace(in.AppID); appID != "" {
 		if a.contextClient == nil {
 			return OrbitRepoCloneResult{}, errors.New("orbit_repo_clone: orbit context client not configured (required for app_id resolution)")
@@ -118,52 +158,65 @@ func (a *OrbitRepoCloneActivities) OrbitRepoClone(ctx context.Context, in OrbitR
 			return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(
 				fmt.Sprintf("app %q has no repository URL configured", appID), "AppMissingRepo", nil)
 		}
+		appRepo = details.Repository
 		repoURL = strings.TrimSpace(details.Repository.URL)
 	}
 
-	owner, repo, err := parseGitHubRepoURL(repoURL)
+	parsed, err := parseRepoURL(repoURL)
 	if err != nil {
 		return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidRepoURL", err)
 	}
 
-	// Mint a fresh installation token.
-	token, err := a.tokenClient.GetInstallationTokenForRepo(ctx, in.WorkspaceID, owner, repo)
-	if err != nil {
-		if errors.Is(err, services.ErrInstallationNotFound) {
-			return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(
-				fmt.Sprintf("no GitHub App installation connected for owner %q in this workspace — install or grant access to the Orbit GitHub App for the %s organization", owner, owner),
-				"InstallationNotFound", err)
-		}
-		if errors.Is(err, services.ErrInstallationTokenExpired) {
-			return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(
-				"the installation token is expired and Orbit's refresh workflow appears stalled — ask an admin to check the GitHubTokenRefreshWorkflow",
-				"InstallationTokenExpired", err)
-		}
-		return OrbitRepoCloneResult{}, fmt.Errorf("orbit_repo_clone: mint token: %w", err)
-	}
-
-	// Clone inside the sandbox. The token is URL-injected for the
-	// clone command only and immediately scrubbed from .git/config via
-	// `git remote set-url`. The token also lives briefly in the
-	// sandbox process args (visible via `ps` inside the pod) — fine
-	// for the per-run isolated executor model.
-	slug := cloneRepoSlug(owner + "-" + repo)
-	clonePath := "repo/" + slug
-
-	revFlag := ""
+	// Validate the revision once — it is interpolated into the command.
+	revFlag := "--single-branch"
 	if rev := strings.TrimSpace(in.Revision); rev != "" {
 		if !isSafeGitRef(rev) {
 			return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(
 				fmt.Sprintf("invalid revision %q (must match [A-Za-z0-9._/-]+)", rev), "InvalidRevision", nil)
 		}
 		revFlag = "--branch=" + rev + " --single-branch"
-	} else {
-		revFlag = "--single-branch"
 	}
 
-	// Command runs in `bash -lc`. $GITHUB_TOKEN is the projected env
-	// var; the host URL and ${OWNER}/${REPO} are hard-coded into the
-	// command from validated inputs so they can't be injected.
+	// Provider branch — build the credentialed clone plan.
+	var spec cloneSpec
+	switch parsed.Provider {
+	case providerGitHub:
+		spec, err = a.githubCloneSpec(ctx, in.WorkspaceID, parsed, revFlag)
+	case providerADO:
+		spec, err = a.adoCloneSpec(ctx, appRepo, parsed, revFlag)
+	default:
+		return OrbitRepoCloneResult{}, temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("unsupported provider %q", parsed.Provider), "InvalidRepoURL", nil)
+	}
+	if err != nil {
+		return OrbitRepoCloneResult{}, err
+	}
+
+	return a.runClone(ctx, in, spec)
+}
+
+// githubCloneSpec mints an installation token and builds the GitHub clone
+// command. The token is URL-injected via the $GITHUB_TOKEN env var and
+// scrubbed from .git/config after clone.
+func (a *OrbitRepoCloneActivities) githubCloneSpec(ctx context.Context, workspaceID string, parsed parsedRepo, revFlag string) (cloneSpec, error) {
+	token, err := a.tokenClient.GetInstallationTokenForRepo(ctx, workspaceID, parsed.Owner, parsed.Repo)
+	if err != nil {
+		if errors.Is(err, services.ErrInstallationNotFound) {
+			return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("no GitHub App installation connected for owner %q in this workspace — install or grant access to the Orbit GitHub App for the %s organization", parsed.Owner, parsed.Owner),
+				"InstallationNotFound", err)
+		}
+		if errors.Is(err, services.ErrInstallationTokenExpired) {
+			return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+				"the installation token is expired and Orbit's refresh workflow appears stalled — ask an admin to check the GitHubTokenRefreshWorkflow",
+				"InstallationTokenExpired", err)
+		}
+		return cloneSpec{}, fmt.Errorf("orbit_repo_clone: mint token: %w", err)
+	}
+
+	slug := cloneRepoSlug(parsed.Owner + "-" + parsed.Repo)
+	// $GITHUB_TOKEN is the projected env var; the host and ${OWNER}/${REPO}
+	// are hard-coded from validated inputs so they can't be injected.
 	cmd := fmt.Sprintf(
 		`set -eo pipefail
 mkdir -p repo
@@ -175,28 +228,140 @@ git remote set-url origin "https://github.com/%[3]s/%[4]s.git"
 echo "ORBIT_HEAD_SHA=$(git rev-parse HEAD)"
 echo "ORBIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
 `,
-		slug, revFlag, owner, repo,
+		slug, revFlag, parsed.Owner, parsed.Repo,
 	)
+	return cloneSpec{
+		command:   cmd,
+		env:       map[string]string{"GITHUB_TOKEN": token.Token},
+		token:     token.Token,
+		owner:     parsed.Owner,
+		repo:      parsed.Repo,
+		slug:      slug,
+		installID: token.InstallationID,
+	}, nil
+}
 
+// adoCloneSpec resolves ADO connection credentials and builds the clone
+// command for the connection's auth mode. The connection id is the auth root
+// and must come from the app doc — a raw ADO URL with no linked Orbit app
+// cannot be cloned. For basic-pat the PAT is URL-injected via the $ADO_TOKEN
+// env var (and scrubbed after clone); for bearer the token is presented via
+// git -c http.extraheader and never touches the URL.
+func (a *OrbitRepoCloneActivities) adoCloneSpec(ctx context.Context, appRepo *services.AppRepository, parsed parsedRepo, revFlag string) (cloneSpec, error) {
+	if a.adoClient == nil {
+		return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+			"orbit_repo_clone: Azure DevOps cloning is not configured on this worker", "ADONotConfigured", nil)
+	}
+	connectionID := ""
+	if appRepo != nil {
+		connectionID = strings.TrimSpace(appRepo.ConnectionID)
+	}
+	if connectionID == "" {
+		return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+			"cloning an Azure DevOps repository requires importing it as an Orbit app with a linked git connection — a raw ADO URL has no credentials to clone with",
+			"ADOConnectionMissing", nil)
+	}
+
+	conn, err := a.adoClient.GetConnectionToken(ctx, connectionID)
+	if err != nil {
+		if errors.Is(err, services.ErrConnectionNotFound) {
+			return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+				"the Azure DevOps connection for this app no longer exists — reconnect it in workspace settings", "ADOConnectionNotFound", err)
+		}
+		if errors.Is(err, services.ErrConnectionNotConfigured) {
+			return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+				"the Azure DevOps connection for this app has no usable credentials — re-authorize it in workspace settings", "ADOConnectionNotConfigured", err)
+		}
+		return cloneSpec{}, fmt.Errorf("orbit_repo_clone: resolve ado connection: %w", err)
+	}
+
+	// The connection is the authoritative source for host + org (decrypted
+	// server-side); the specific project + repo come from the parsed app URL.
+	base := strings.TrimRight(conn.BaseURL, "/")
+	if !isSafeADOBaseURL(base) {
+		return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("azure devops connection has an unusable base URL %q", base), "ADOConfig", nil)
+	}
+	org := conn.Organization
+	project := parsed.Project
+	repo := parsed.Repo
+	if !isSafeRepoSegment(org) || !isSafeRepoSegment(project) || !isSafeRepoSegment(repo) {
+		return cloneSpec{}, temporal.NewNonRetryableApplicationError(
+			"azure devops org/project/repo contains unsupported characters", "InvalidRepoURL", nil)
+	}
+
+	slug := cloneRepoSlug(org + "-" + project + "-" + repo)
+	// Bare URL — no credentials. base already carries the https scheme.
+	bareURL := fmt.Sprintf("%s/%s/%s/_git/%s", base, org, project, repo)
+
+	var cmd string
+	if conn.AuthMode == "bearer" {
+		// Bearer: token presented via a per-invocation http.extraheader — it
+		// never appears in the URL and (via ${ADO_TOKEN}) never appears
+		// literally in the command string. `git -c` config is not persisted
+		// to .git/config, so no scrub is needed.
+		cmd = fmt.Sprintf(
+			`set -eo pipefail
+mkdir -p repo
+cd repo
+rm -rf %[1]q
+git -c http.extraheader="AUTHORIZATION: Bearer ${ADO_TOKEN}" clone --depth=1 %[2]s %[3]q %[1]q
+cd %[1]q
+echo "ORBIT_HEAD_SHA=$(git rev-parse HEAD)"
+echo "ORBIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+`,
+			slug, revFlag, bareURL,
+		)
+	} else {
+		// basic-pat: PAT URL-injected via ${ADO_TOKEN} (username is arbitrary),
+		// then scrubbed from .git/config via `git remote set-url`.
+		authURL := strings.Replace(bareURL, "https://", "https://pat:${ADO_TOKEN}@", 1)
+		cmd = fmt.Sprintf(
+			`set -eo pipefail
+mkdir -p repo
+cd repo
+rm -rf %[1]q
+git clone --depth=1 %[2]s "%[3]s" %[1]q
+cd %[1]q
+git remote set-url origin %[4]q
+echo "ORBIT_HEAD_SHA=$(git rev-parse HEAD)"
+echo "ORBIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+`,
+			slug, revFlag, authURL, bareURL,
+		)
+	}
+
+	return cloneSpec{
+		command: cmd,
+		env:     map[string]string{"ADO_TOKEN": conn.Token},
+		token:   conn.Token,
+		owner:   org,
+		repo:    repo,
+		project: project,
+		slug:    slug,
+	}, nil
+}
+
+// runClone executes the resolved clone plan in the sandbox, redacts the
+// token from any surfaced output, and maps the result. Shared by both
+// providers.
+func (a *OrbitRepoCloneActivities) runClone(ctx context.Context, in OrbitRepoCloneInput, spec cloneSpec) (OrbitRepoCloneResult, error) {
 	start := time.Now()
 	res, execErr := a.executor.Exec(ctx, sandbox.SandboxID(in.WorkflowID), sandbox.ExecOptions{
-		Command: cmd,
-		EnvOverrides: map[string]string{
-			"GITHUB_TOKEN": token.Token,
-		},
-		Timeout: 5 * time.Minute,
+		Command:      spec.command,
+		EnvOverrides: spec.env,
+		Timeout:      5 * time.Minute,
 	})
 	duration := time.Since(start)
 
-	// Redact the token defensively before we touch any error strings
-	// or surface output. Even though we don't include stdout/stderr in
-	// the result, the token could leak via the error string if git
-	// echoes the URL.
+	// Redact the token defensively before touching any error strings or
+	// surface output — even though we don't return stdout/stderr, the token
+	// could leak via an error string if git echoes an injected URL.
 	redact := func(s string) string {
-		if token.Token == "" {
+		if spec.token == "" {
 			return s
 		}
-		return strings.ReplaceAll(s, token.Token, "***REDACTED***")
+		return strings.ReplaceAll(s, spec.token, "***REDACTED***")
 	}
 
 	if execErr != nil {
@@ -204,8 +369,6 @@ echo "ORBIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
 	}
 	if res.ExitCode != 0 {
 		stderr := redact(res.Stderr)
-		// Keep the message bounded — the agent should see a useful
-		// error, not a dump.
 		if len(stderr) > 800 {
 			stderr = stderr[len(stderr)-800:]
 		}
@@ -219,47 +382,63 @@ echo "ORBIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
 	a.logger.Info("orbit_repo_clone success",
 		slog.String("workflow_id", in.WorkflowID),
 		slog.String("workspace_id", in.WorkspaceID),
-		slog.String("owner", owner),
-		slog.String("repo", repo),
+		slog.String("owner", spec.owner),
+		slog.String("repo", spec.repo),
+		slog.String("project", spec.project),
 		slog.String("branch", branch),
-		slog.Int64("installation_id", token.InstallationID),
+		slog.Int64("installation_id", spec.installID),
 		slog.Duration("duration", duration),
 	)
 
 	return OrbitRepoCloneResult{
-		ClonePath:      clonePath,
-		Owner:          owner,
-		Repo:           repo,
+		ClonePath:      "repo/" + spec.slug,
+		Owner:          spec.owner,
+		Repo:           spec.repo,
+		Project:        spec.project,
 		Branch:         branch,
 		HeadSHA:        headSHA,
-		InstallationID: token.InstallationID,
+		InstallationID: spec.installID,
 		DurationMs:     duration.Milliseconds(),
 	}, nil
 }
 
-// parseGitHubRepoURL extracts owner/repo from a github.com URL. Accepts
-// https://github.com/owner/repo[.git] forms; rejects SSH, other hosts,
-// and shapes the agent shouldn't be able to supply.
-func parseGitHubRepoURL(raw string) (owner, repo string, err error) {
+// parsedRepo is the provider-tagged result of parseRepoURL.
+type parsedRepo struct {
+	Provider string // providerGitHub | providerADO
+	Host     string
+	Owner    string // GitHub owner or ADO organization
+	Project  string // ADO only
+	Repo     string
+}
+
+// parseRepoURL recognizes two shapes:
+//
+//	https://github.com/{owner}/{repo}[.git]           → github
+//	https://{host}/{org}/{project}/_git/{repo}[.git]  → azure-devops (dev.azure.com or on-prem)
+//
+// Everything else (SSH, http, other hosts, malformed paths) is rejected. All
+// coordinate segments are validated against the shell-injection guard since
+// they are interpolated into the clone command.
+func parseRepoURL(raw string) (parsedRepo, error) {
 	s := strings.TrimSpace(raw)
 	if s == "" {
-		return "", "", errors.New("repo URL is empty")
+		return parsedRepo{}, errors.New("repo URL is empty")
 	}
-	// Strip protocol. https-only — we URL-inject a bearer token and
-	// can't send that over plaintext http.
+	// https-only — we URL-inject / bearer-auth and can't send that over plaintext.
 	if !strings.HasPrefix(s, "https://") {
-		return "", "", fmt.Errorf("only https github.com URLs are supported (got %q)", raw)
+		return parsedRepo{}, fmt.Errorf("only https URLs are supported (got %q)", raw)
 	}
 	s = strings.TrimPrefix(s, "https://")
-	// Strip any embedded credentials (the agent shouldn't be sending
-	// these, but be defensive).
+	// Strip any embedded credentials (be defensive — the agent shouldn't send these).
 	if at := strings.LastIndex(s, "@"); at != -1 {
 		s = s[at+1:]
 	}
-	if !strings.HasPrefix(s, "github.com/") {
-		return "", "", fmt.Errorf("only github.com URLs are supported (got %q)", raw)
+	slash := strings.Index(s, "/")
+	if slash == -1 {
+		return parsedRepo{}, fmt.Errorf("could not parse repo path from %q", raw)
 	}
-	rest := strings.TrimPrefix(s, "github.com/")
+	host := s[:slash]
+	rest := s[slash+1:]
 	// Drop query/fragment.
 	for _, sep := range []string{"?", "#"} {
 		if i := strings.Index(rest, sep); i != -1 {
@@ -267,19 +446,53 @@ func parseGitHubRepoURL(raw string) (owner, repo string, err error) {
 		}
 	}
 	rest = strings.TrimSuffix(rest, "/")
-	rest = strings.TrimSuffix(rest, ".git")
+
+	if host == "github.com" {
+		rest = strings.TrimSuffix(rest, ".git")
+		parts := strings.Split(rest, "/")
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+			return parsedRepo{}, fmt.Errorf("could not parse owner/repo from %q", raw)
+		}
+		owner, repo := parts[0], parts[1]
+		if !isSafeRepoSegment(owner) || !isSafeRepoSegment(repo) {
+			return parsedRepo{}, fmt.Errorf("invalid characters in owner/repo from %q", raw)
+		}
+		return parsedRepo{Provider: providerGitHub, Host: host, Owner: owner, Repo: repo}, nil
+	}
+
+	// Azure DevOps: {org}/{project}/_git/{repo}. The `_git` marker must sit at
+	// index 2 with a repo segment after it.
 	parts := strings.Split(rest, "/")
-	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("could not parse owner/repo from %q", raw)
+	if len(parts) >= 4 && parts[2] == "_git" {
+		org, project, repo := parts[0], parts[1], strings.TrimSuffix(parts[3], ".git")
+		if org == "" || project == "" || repo == "" {
+			return parsedRepo{}, fmt.Errorf("could not parse org/project/repo from %q", raw)
+		}
+		if !isSafeRepoSegment(org) || !isSafeRepoSegment(project) || !isSafeRepoSegment(repo) {
+			return parsedRepo{}, fmt.Errorf("invalid characters in org/project/repo from %q", raw)
+		}
+		return parsedRepo{Provider: providerADO, Host: host, Owner: org, Project: project, Repo: repo}, nil
 	}
-	owner, repo = parts[0], parts[1]
-	if !isSafeRepoSegment(owner) || !isSafeRepoSegment(repo) {
-		return "", "", fmt.Errorf("invalid characters in owner/repo from %q", raw)
-	}
-	return owner, repo, nil
+
+	return parsedRepo{}, fmt.Errorf(
+		"unsupported repo URL %q (expected https://github.com/{owner}/{repo} or https://{host}/{org}/{project}/_git/{repo})", raw)
 }
 
-// isSafeRepoSegment matches GitHub's owner/repo character rules
+// parseGitHubRepoURL extracts owner/repo from a github.com URL. Retained as a
+// thin wrapper over parseRepoURL so existing callers/tests keep their
+// contract; rejects any non-github shape.
+func parseGitHubRepoURL(raw string) (owner, repo string, err error) {
+	p, err := parseRepoURL(raw)
+	if err != nil {
+		return "", "", err
+	}
+	if p.Provider != providerGitHub {
+		return "", "", fmt.Errorf("only github.com URLs are supported (got %q)", raw)
+	}
+	return p.Owner, p.Repo, nil
+}
+
+// isSafeRepoSegment matches GitHub/ADO owner/repo/project character rules
 // loosely: alphanumerics, hyphens, dots, underscores. Used as a
 // shell-injection guard since these values are interpolated into the
 // command string.
@@ -287,6 +500,15 @@ var repoSegmentRE = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 func isSafeRepoSegment(s string) bool {
 	return len(s) > 0 && len(s) <= 100 && repoSegmentRE.MatchString(s)
+}
+
+// isSafeADOBaseURL guards the connection-supplied base URL before it is
+// interpolated into the clone command. Must be an https origin with a
+// host (and optional port) — no path, no credentials, no metacharacters.
+var adoBaseURLRE = regexp.MustCompile(`^https://[A-Za-z0-9.-]+(:[0-9]+)?$`)
+
+func isSafeADOBaseURL(s string) bool {
+	return len(s) > 0 && len(s) <= 253 && adoBaseURLRE.MatchString(s)
 }
 
 // isSafeGitRef restricts revisions to a shell-safe subset. Real git

--- a/temporal-workflows/internal/activities/agent/orbit_repo_clone_activity_test.go
+++ b/temporal-workflows/internal/activities/agent/orbit_repo_clone_activity_test.go
@@ -17,12 +17,26 @@ type fakeGitHubTokenClient struct {
 	err  error
 
 	gotWorkspaceID, gotOwner, gotRepo string
-	calls                              int
+	calls                             int
 }
 
 func (f *fakeGitHubTokenClient) GetInstallationTokenForRepo(_ context.Context, workspaceID, owner, repo string) (services.InstallationToken, error) {
 	f.calls++
 	f.gotWorkspaceID, f.gotOwner, f.gotRepo = workspaceID, owner, repo
+	return f.resp, f.err
+}
+
+type fakeADOTokenClient struct {
+	resp services.ADOConnectionToken
+	err  error
+
+	gotConnectionID string
+	calls           int
+}
+
+func (f *fakeADOTokenClient) GetConnectionToken(_ context.Context, connectionID string) (services.ADOConnectionToken, error) {
+	f.calls++
+	f.gotConnectionID = connectionID
 	return f.resp, f.err
 }
 
@@ -58,9 +72,9 @@ func (f *fakeSandboxExecutor) Backend() string                                  
 
 func TestParseGitHubRepoURL(t *testing.T) {
 	cases := []struct {
-		name, in        string
+		name, in            string
 		wantOwner, wantRepo string
-		wantErr         bool
+		wantErr             bool
 	}{
 		{"https plain", "https://github.com/drewpayment/orbit", "drewpayment", "orbit", false},
 		{"https .git", "https://github.com/drewpayment/orbit.git", "drewpayment", "orbit", false},
@@ -90,6 +104,67 @@ func TestParseGitHubRepoURL(t *testing.T) {
 				t.Errorf("got owner=%q repo=%q, want owner=%q repo=%q", owner, repo, tc.wantOwner, tc.wantRepo)
 			}
 		})
+	}
+}
+
+func TestParseRepoURL(t *testing.T) {
+	cases := []struct {
+		name, in                                       string
+		wantProvider, wantOwner, wantProject, wantRepo string
+		wantErr                                        bool
+	}{
+		// GitHub (parity with parseGitHubRepoURL)
+		{"github plain", "https://github.com/drewpayment/orbit", providerGitHub, "drewpayment", "", "orbit", false},
+		{"github .git", "https://github.com/drewpayment/orbit.git", providerGitHub, "drewpayment", "", "orbit", false},
+		{"github subpath dropped", "https://github.com/foo/bar/tree/main", providerGitHub, "foo", "", "bar", false},
+		{"github embedded creds", "https://user:pat@github.com/foo/bar.git", providerGitHub, "foo", "", "bar", false},
+		// Azure DevOps (dev.azure.com + on-prem host)
+		{"ado dev.azure.com", "https://dev.azure.com/myorg/myproject/_git/myrepo", providerADO, "myorg", "myproject", "myrepo", false},
+		{"ado .git suffix", "https://dev.azure.com/myorg/myproject/_git/myrepo.git", providerADO, "myorg", "myproject", "myrepo", false},
+		{"ado on-prem host", "https://tfs.corp.local/acme/platform/_git/svc", providerADO, "acme", "platform", "svc", false},
+		{"ado trailing slash", "https://dev.azure.com/o/p/_git/r/", providerADO, "o", "p", "r", false},
+		{"ado query dropped", "https://dev.azure.com/o/p/_git/r?path=/x", providerADO, "o", "p", "r", false},
+		// Rejections
+		{"http rejected", "http://github.com/foo/bar", "", "", "", "", true},
+		{"ssh rejected", "git@github.com:foo/bar.git", "", "", "", "", true},
+		{"gitlab rejected", "https://gitlab.com/foo/bar", "", "", "", "", true},
+		{"ado missing _git", "https://dev.azure.com/org/project/repo", "", "", "", "", true},
+		{"ado _git wrong position", "https://dev.azure.com/org/_git/repo", "", "", "", "", true},
+		{"ado injection in repo", "https://dev.azure.com/org/proj/_git/re;po", "", "", "", "", true},
+		{"empty", "", "", "", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRepoURL(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Provider != tc.wantProvider || got.Owner != tc.wantOwner || got.Project != tc.wantProject || got.Repo != tc.wantRepo {
+				t.Errorf("got %+v, want provider=%q owner=%q project=%q repo=%q",
+					got, tc.wantProvider, tc.wantOwner, tc.wantProject, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestIsSafeADOBaseURL(t *testing.T) {
+	ok := []string{"https://dev.azure.com", "https://tfs.corp.local", "https://tfs.corp.local:8443"}
+	bad := []string{"http://dev.azure.com", "https://dev.azure.com/", "https://dev.azure.com/path", "https://foo;rm", "", "dev.azure.com"}
+	for _, s := range ok {
+		if !isSafeADOBaseURL(s) {
+			t.Errorf("%q should be a safe base URL", s)
+		}
+	}
+	for _, s := range bad {
+		if isSafeADOBaseURL(s) {
+			t.Errorf("%q should be rejected", s)
+		}
 	}
 }
 
@@ -137,7 +212,7 @@ func TestExtractCloneMarkers(t *testing.T) {
 // --- activity behavior ---
 
 func newRepoCloneActivities(exec sandbox.SandboxExecutor, tokens *fakeGitHubTokenClient, ctx OrbitContextClient) *OrbitRepoCloneActivities {
-	return NewOrbitRepoCloneActivities(exec, tokens, ctx, nil)
+	return NewOrbitRepoCloneActivities(exec, tokens, &fakeADOTokenClient{}, ctx, nil)
 }
 
 func TestOrbitRepoClone_RequiresOneOfAppIDOrRepoURL(t *testing.T) {
@@ -357,5 +432,185 @@ func TestOrbitRepoClone_ExecError_RedactsToken(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "ghs_LEAKED") {
 		t.Errorf("token leaked into error: %v", err)
+	}
+}
+
+// --- Azure DevOps clone paths ---
+
+// newRepoCloneActivitiesADO wires an explicit ADO token client alongside the
+// GitHub + context fakes.
+func newRepoCloneActivitiesADO(exec sandbox.SandboxExecutor, ado *fakeADOTokenClient, ctx OrbitContextClient) *OrbitRepoCloneActivities {
+	return NewOrbitRepoCloneActivities(exec, &fakeGitHubTokenClient{}, ado, ctx, nil)
+}
+
+// adoAppCtx returns a context client whose app resolves to an ADO repository
+// with the given connection id.
+func adoAppCtx(connectionID string) *fakeOrbitContextClient {
+	return &fakeOrbitContextClient{
+		app: services.AppDetails{
+			ID:   "app-ado",
+			Name: "payments",
+			Repository: &services.AppRepository{
+				URL:          "https://dev.azure.com/myorg/myproject/_git/payments",
+				Owner:        "myorg",
+				Name:         "payments",
+				Branch:       "main",
+				Provider:     providerADO,
+				ConnectionID: connectionID,
+				Project:      "myproject",
+			},
+		},
+	}
+}
+
+func TestOrbitRepoClone_ADO_BasicPat_URLInjectsToken(t *testing.T) {
+	exec := &fakeSandboxExecutor{res: sandbox.ExecResult{
+		ExitCode: 0,
+		Stdout:   "ORBIT_HEAD_SHA=adodead\nORBIT_BRANCH=main\n",
+	}}
+	ado := &fakeADOTokenClient{resp: services.ADOConnectionToken{
+		Provider:     providerADO,
+		Organization: "myorg",
+		BaseURL:      "https://dev.azure.com",
+		AuthMode:     "basic-pat",
+		Token:        "ADO_PAT_SECRET",
+	}}
+	a := newRepoCloneActivitiesADO(exec, ado, adoAppCtx("conn-123"))
+
+	res, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-ado", WorkspaceID: "ws-1", AppID: "app-ado",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ado.calls != 1 || ado.gotConnectionID != "conn-123" {
+		t.Errorf("ado client got calls=%d conn=%q", ado.calls, ado.gotConnectionID)
+	}
+	if exec.gotEnv["ADO_TOKEN"] != "ADO_PAT_SECRET" {
+		t.Errorf("PAT not projected as env var; env=%+v", exec.gotEnv)
+	}
+	if strings.Contains(exec.gotCmd, "ADO_PAT_SECRET") {
+		t.Errorf("raw PAT leaked into command: %q", exec.gotCmd)
+	}
+	// basic-pat: username:token injected via env var into the clone URL.
+	if !strings.Contains(exec.gotCmd, "https://pat:${ADO_TOKEN}@dev.azure.com/myorg/myproject/_git/payments") {
+		t.Errorf("expected PAT-injected clone URL, got %q", exec.gotCmd)
+	}
+	// and scrubbed to a bare origin afterward.
+	if !strings.Contains(exec.gotCmd, `git remote set-url origin "https://dev.azure.com/myorg/myproject/_git/payments"`) {
+		t.Errorf("expected origin scrub to bare URL, got %q", exec.gotCmd)
+	}
+	if res.Owner != "myorg" || res.Project != "myproject" || res.Repo != "payments" {
+		t.Errorf("coordinates = %+v", res)
+	}
+	if res.InstallationID != 0 {
+		t.Errorf("ADO clone should have no installation id, got %d", res.InstallationID)
+	}
+	if res.ClonePath != "repo/myorg-myproject-payments" {
+		t.Errorf("clone_path = %q", res.ClonePath)
+	}
+}
+
+func TestOrbitRepoClone_ADO_Bearer_UsesExtraHeaderNotURL(t *testing.T) {
+	exec := &fakeSandboxExecutor{res: sandbox.ExecResult{
+		ExitCode: 0,
+		Stdout:   "ORBIT_HEAD_SHA=beef\nORBIT_BRANCH=main\n",
+	}}
+	ado := &fakeADOTokenClient{resp: services.ADOConnectionToken{
+		Provider:     providerADO,
+		Organization: "myorg",
+		BaseURL:      "https://dev.azure.com",
+		AuthMode:     "bearer",
+		Token:        "BEARER_SECRET_TOKEN",
+	}}
+	a := newRepoCloneActivitiesADO(exec, ado, adoAppCtx("conn-b"))
+
+	_, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-ado-b", WorkspaceID: "ws-1", AppID: "app-ado",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec.gotEnv["ADO_TOKEN"] != "BEARER_SECRET_TOKEN" {
+		t.Errorf("bearer token not projected as env var; env=%+v", exec.gotEnv)
+	}
+	// The literal token must appear nowhere in the command.
+	if strings.Contains(exec.gotCmd, "BEARER_SECRET_TOKEN") {
+		t.Errorf("raw bearer token leaked into command: %q", exec.gotCmd)
+	}
+	// Bearer is presented via http.extraheader, never in the URL.
+	if !strings.Contains(exec.gotCmd, `http.extraheader="AUTHORIZATION: Bearer ${ADO_TOKEN}"`) {
+		t.Errorf("expected bearer via extraheader, got %q", exec.gotCmd)
+	}
+	// The clone URL is bare — no credentials spliced in.
+	if !strings.Contains(exec.gotCmd, `"https://dev.azure.com/myorg/myproject/_git/payments"`) {
+		t.Errorf("expected bare clone URL, got %q", exec.gotCmd)
+	}
+	if strings.Contains(exec.gotCmd, "${ADO_TOKEN}@") || strings.Contains(exec.gotCmd, "pat:") {
+		t.Errorf("bearer clone URL must not embed credentials: %q", exec.gotCmd)
+	}
+}
+
+func TestOrbitRepoClone_ADO_RawURL_NoConnection_Rejected(t *testing.T) {
+	// A raw ADO URL (no app_id) has no connection linkage — must fail clearly.
+	ado := &fakeADOTokenClient{}
+	a := newRepoCloneActivitiesADO(&fakeSandboxExecutor{}, ado, &fakeOrbitContextClient{})
+
+	_, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-1", WorkspaceID: "ws-1",
+		RepoURL: "https://dev.azure.com/myorg/myproject/_git/payments",
+	})
+	if err == nil || !strings.Contains(err.Error(), "linked git connection") {
+		t.Fatalf("expected missing-connection error, got %v", err)
+	}
+	if ado.calls != 0 {
+		t.Errorf("token client should not be called without a connection id")
+	}
+}
+
+func TestOrbitRepoClone_ADO_NotConfigured(t *testing.T) {
+	// adoClient nil → ADO clone fails with a clear not-configured error.
+	a := NewOrbitRepoCloneActivities(&fakeSandboxExecutor{}, &fakeGitHubTokenClient{}, nil, adoAppCtx("conn-x"), nil)
+	_, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-1", WorkspaceID: "ws-1", AppID: "app-ado",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("expected not-configured error, got %v", err)
+	}
+}
+
+func TestOrbitRepoClone_ADO_ConnectionNotFound_SurfacesNonRetryable(t *testing.T) {
+	ado := &fakeADOTokenClient{err: services.ErrConnectionNotFound}
+	a := newRepoCloneActivitiesADO(&fakeSandboxExecutor{}, ado, adoAppCtx("conn-gone"))
+	_, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-1", WorkspaceID: "ws-1", AppID: "app-ado",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no longer exists") {
+		t.Fatalf("expected connection-not-found error, got %v", err)
+	}
+}
+
+func TestOrbitRepoClone_ADO_CloneFailure_RedactsToken(t *testing.T) {
+	exec := &fakeSandboxExecutor{res: sandbox.ExecResult{
+		ExitCode: 128,
+		Stderr:   "fatal: Authentication failed for 'https://pat:ADO_PAT_SECRET@dev.azure.com/myorg/myproject/_git/payments'",
+	}}
+	ado := &fakeADOTokenClient{resp: services.ADOConnectionToken{
+		Organization: "myorg", BaseURL: "https://dev.azure.com",
+		AuthMode: "basic-pat", Token: "ADO_PAT_SECRET",
+	}}
+	a := newRepoCloneActivitiesADO(exec, ado, adoAppCtx("conn-123"))
+
+	_, err := a.OrbitRepoClone(context.Background(), OrbitRepoCloneInput{
+		WorkflowID: "wf-1", WorkspaceID: "ws-1", AppID: "app-ado",
+	})
+	if err == nil {
+		t.Fatal("expected error from non-zero exit")
+	}
+	if strings.Contains(err.Error(), "ADO_PAT_SECRET") {
+		t.Errorf("PAT leaked into error message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "***REDACTED***") {
+		t.Errorf("expected redaction marker in error: %v", err)
 	}
 }

--- a/temporal-workflows/internal/services/payload_ado_connection_client.go
+++ b/temporal-workflows/internal/services/payload_ado_connection_client.go
@@ -1,0 +1,129 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// PayloadADOConnectionClient backs the agent's orbit_repo_clone tool for
+// Azure DevOps apps. It calls orbit-www's internal git-connections token
+// endpoint to resolve a connection id into the decrypted credentials and
+// coordinates needed to clone an ADO repo.
+//
+// This is the ADO twin of PayloadGitHubClient: same X-API-Key auth, same
+// short-lived-token contract. The token it returns is sensitive — the
+// activity layer MUST project it into the sandbox via EnvOverrides on a
+// single Exec call and never log the raw value or embed it (bearer mode)
+// in a clone URL.
+type PayloadADOConnectionClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// NewPayloadADOConnectionClient constructs the client. baseURL points at
+// orbit-www (ORBIT_API_URL); apiKey is ORBIT_INTERNAL_API_KEY — the same
+// origin/secret the GitHub token client uses.
+func NewPayloadADOConnectionClient(baseURL, apiKey string, logger *slog.Logger) *PayloadADOConnectionClient {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PayloadADOConnectionClient{
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		logger:     logger,
+	}
+}
+
+// ADOConnectionToken is the decrypted connection detail returned by the
+// /api/internal/git-connections/token route. Token is sensitive — callers
+// MUST keep it out of logs, error strings, and clone URLs (bearer mode).
+type ADOConnectionToken struct {
+	Provider     string `json:"provider"`
+	Organization string `json:"organization"`
+	// Project is empty when the connection is org-wide (scans all projects).
+	// The specific repo's project comes from the app/URL, not this field.
+	Project string `json:"project"`
+	BaseURL string `json:"baseUrl"`
+	// AuthMode is how the token must be presented: "basic-pat" (HTTP Basic,
+	// PAT as password) or "bearer" (a short-lived Microsoft Entra access
+	// token presented via http.extraheader for service-principal connections).
+	AuthMode string `json:"authMode"`
+	Token    string `json:"token"`
+}
+
+// ErrConnectionNotFound is returned when no git-connections doc matches the
+// id (404 from the token route). Surface to the user, do not retry.
+var ErrConnectionNotFound = errors.New("git connection not found")
+
+// ErrConnectionNotConfigured is returned when the connection exists but has
+// no usable credentials (410 from the token route). Surface, do not retry.
+var ErrConnectionNotConfigured = errors.New("git connection has no usable credentials")
+
+// GetConnectionToken resolves a git-connections doc id to its decrypted
+// credentials + ADO coordinates. Each call re-reads the connection (no
+// caching). The token it returns is sensitive.
+func (c *PayloadADOConnectionClient) GetConnectionToken(ctx context.Context, connectionID string) (ADOConnectionToken, error) {
+	if c.baseURL == "" {
+		return ADOConnectionToken{}, errors.New("ado connection client: base URL not configured")
+	}
+	if connectionID == "" {
+		return ADOConnectionToken{}, errors.New("ado connection client: connectionID required")
+	}
+
+	buf, err := json.Marshal(map[string]string{"connectionId": connectionID})
+	if err != nil {
+		return ADOConnectionToken{}, fmt.Errorf("ado connection client: marshal: %w", err)
+	}
+
+	u := c.baseURL + "/api/internal/git-connections/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(buf))
+	if err != nil {
+		return ADOConnectionToken{}, err
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return ADOConnectionToken{}, err
+	}
+	defer resp.Body.Close()
+	// The success body carries the token; never echo it into an error string.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var out ADOConnectionToken
+		if err := json.Unmarshal(body, &out); err != nil {
+			return ADOConnectionToken{}, fmt.Errorf("ado connection client: parse response: %w", err)
+		}
+		if out.Token == "" {
+			return ADOConnectionToken{}, errors.New("ado connection client: empty token in response")
+		}
+		if out.BaseURL == "" {
+			return ADOConnectionToken{}, errors.New("ado connection client: empty baseUrl in response")
+		}
+		if out.Organization == "" {
+			return ADOConnectionToken{}, errors.New("ado connection client: empty organization in response")
+		}
+		return out, nil
+	case http.StatusNotFound:
+		return ADOConnectionToken{}, ErrConnectionNotFound
+	case http.StatusGone:
+		return ADOConnectionToken{}, ErrConnectionNotConfigured
+	default:
+		// Status only — never risk leaking a token echoed back in the body.
+		return ADOConnectionToken{}, fmt.Errorf("ado connection client: HTTP %d", resp.StatusCode)
+	}
+}

--- a/temporal-workflows/internal/services/payload_orbit_context_client.go
+++ b/temporal-workflows/internal/services/payload_orbit_context_client.go
@@ -38,11 +38,21 @@ func NewPayloadOrbitContextClient(baseURL, apiKey string, logger *slog.Logger) *
 }
 
 // AppRepository mirrors the repository sub-shape the apps endpoint returns.
+//
+// Provider discriminates the repo source: "github" (also the default when
+// absent, for legacy rows) or "azure-devops". ConnectionID + Project are
+// ADO-only — they carry the git-connections linkage the clone activity
+// needs to resolve credentials. They are empty for GitHub rows (which use
+// the installation-token path instead) and absent on the wire until the
+// apps endpoint is extended to emit them.
 type AppRepository struct {
-	URL    string `json:"url"`
-	Owner  string `json:"owner"`
-	Name   string `json:"name"`
-	Branch string `json:"branch"`
+	URL          string `json:"url"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	Branch       string `json:"branch"`
+	Provider     string `json:"provider,omitempty"`
+	ConnectionID string `json:"connectionId,omitempty"`
+	Project      string `json:"project,omitempty"`
 }
 
 // AppSummary is what GET /api/internal/workspaces/[id]/apps returns per row.

--- a/temporal-workflows/internal/workflows/infrastructure_agent_workflow.go
+++ b/temporal-workflows/internal/workflows/infrastructure_agent_workflow.go
@@ -79,13 +79,13 @@ const (
 	ToolProposeToUser = agentcontract.ToolProposeToUser
 	ToolDone          = agentcontract.ToolDone
 
-	ToolShellExec       = agentcontract.ToolShellExec
-	ToolHTTPRequest     = agentcontract.ToolHTTPRequest
-	ToolReadFile        = agentcontract.ToolReadFile
-	ToolWriteFile       = agentcontract.ToolWriteFile
-	ToolListDir         = agentcontract.ToolListDir
-	ToolRepoInspect     = agentcontract.ToolRepoInspect
-	ToolRequestApproval  = agentcontract.ToolRequestApproval
+	ToolShellExec          = agentcontract.ToolShellExec
+	ToolHTTPRequest        = agentcontract.ToolHTTPRequest
+	ToolReadFile           = agentcontract.ToolReadFile
+	ToolWriteFile          = agentcontract.ToolWriteFile
+	ToolListDir            = agentcontract.ToolListDir
+	ToolRepoInspect        = agentcontract.ToolRepoInspect
+	ToolRequestApproval    = agentcontract.ToolRequestApproval
 	ToolRegisterTool       = agentcontract.ToolRegisterTool
 	ToolStartHealthCheck   = agentcontract.ToolStartHealthCheck
 	ToolProposePattern     = agentcontract.ToolProposePattern
@@ -98,11 +98,11 @@ const (
 	ToolOrbitCloudLogin        = agentcontract.ToolOrbitCloudLogin
 	ToolOrbitRepoClone         = agentcontract.ToolOrbitRepoClone
 
-	EventKindConversationTurn = agentcontract.EventKindConversationTurn
-	EventKindTokenDelta       = agentcontract.EventKindTokenDelta
-	EventKindProposalUpdate   = agentcontract.EventKindProposalUpdate
-	EventKindApprovalRequest  = agentcontract.EventKindApprovalRequest
-	EventKindApprovalResolved = agentcontract.EventKindApprovalResolved
+	EventKindConversationTurn    = agentcontract.EventKindConversationTurn
+	EventKindTokenDelta          = agentcontract.EventKindTokenDelta
+	EventKindProposalUpdate      = agentcontract.EventKindProposalUpdate
+	EventKindApprovalRequest     = agentcontract.EventKindApprovalRequest
+	EventKindApprovalResolved    = agentcontract.EventKindApprovalResolved
 	EventKindStatusUpdate        = agentcontract.EventKindStatusUpdate
 	EventKindToolCallOutputChunk = agentcontract.EventKindToolCallOutputChunk
 	EventKindToolCallOutput      = agentcontract.EventKindToolCallOutput
@@ -110,9 +110,9 @@ const (
 
 // Default behavioral knobs. Tunable via input.
 const (
-	defaultMaxIterations    = 80
-	defaultMaxHistoryTurns  = 80
-	defaultUserWaitTimeout  = 24 * time.Hour
+	defaultMaxIterations   = 80
+	defaultMaxHistoryTurns = 80
+	defaultUserWaitTimeout = 24 * time.Hour
 )
 
 // DefaultApprovalTimeout bounds how long an approval gate may stay pending
@@ -143,38 +143,38 @@ func effectiveApprovalTimeout(input *InfrastructureAgentInput) time.Duration {
 
 // agentState is the in-workflow mutable state.
 type agentState struct {
-	status               string
+	status string
 	// workspaceID is the run's workspace, copied from input once at
 	// initState. Carried on state so helpers (event flush, pending-approval
 	// resolve) can stamp it without threading input through every call.
-	workspaceID          string
+	workspaceID string
 	// unflushedDurable buffers durable-kind events emitted since the last
 	// successful PersistAgentEvents flush. Flushed in batches at every
 	// barrier and before continue-as-new / return. A failed flush keeps the
 	// buffer intact for the next attempt (sequence idempotency makes that
 	// safe). Carried across continue-as-new is NOT needed — flushes run
 	// before CAN — so this stays workflow-local.
-	unflushedDurable     []AgentEventWire
+	unflushedDurable []AgentEventWire
 	// toolOutputBuffers accumulates streamed tool output per callId so the
 	// workflow can persist one aggregated tool_call_output event when the
 	// call completes (the per-chunk events are ephemeral and not durable).
 	// Capped at toolOutputCap bytes per call: oldest output is dropped (keep
 	// tail) and the aggregate is marked truncated. Keyed by callId.
-	toolOutputBuffers    map[string]*toolOutputBuffer
-	history              []ConversationTurn
-	events               []AgentEvent
-	nextSeq              uint64
-	streamingPartial     string
-	streamingTurnID      string
-	proposal             *Proposal
-	pendingApprovals     map[string]PendingApproval
+	toolOutputBuffers map[string]*toolOutputBuffer
+	history           []ConversationTurn
+	events            []AgentEvent
+	nextSeq           uint64
+	streamingPartial  string
+	streamingTurnID   string
+	proposal          *Proposal
+	pendingApprovals  map[string]PendingApproval
 	// pendingApprovalRowIDs maps approval_id → PendingApprovals collection
 	// row id so the workflow can call ResolvePendingApproval on the right
 	// row when the gate closes (Spike 7 commit γ). Empty = the open call
 	// failed; resolve falls back to a no-op so a flaky internal API
 	// can't deadlock the gate.
 	pendingApprovalRowIDs map[string]string
-	registeredTools      map[string]agentactivity.ApprovedAgentTool
+	registeredTools       map[string]agentactivity.ApprovedAgentTool
 	// availablePatterns is the in-memory snapshot of the platform-wide
 	// Patterns catalog (approved only), refreshed at the top of each LLM
 	// iteration via refreshAvailablePatterns. Keyed by pattern name to
@@ -290,10 +290,10 @@ func InfrastructureAgentWorkflow(ctx workflow.Context, input InfrastructureAgent
 		StartToCloseTimeout: 5 * time.Minute,
 		HeartbeatTimeout:    30 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval:    2 * time.Second,
-			BackoffCoefficient: 2.0,
-			MaximumInterval:    30 * time.Second,
-			MaximumAttempts:    3,
+			InitialInterval:        2 * time.Second,
+			BackoffCoefficient:     2.0,
+			MaximumInterval:        30 * time.Second,
+			MaximumAttempts:        3,
 			NonRetryableErrorTypes: []string{"InvalidInput", "LLMNonRetryable"},
 		},
 	})
@@ -305,10 +305,10 @@ func InfrastructureAgentWorkflow(ctx workflow.Context, input InfrastructureAgent
 		StartToCloseTimeout: 60 * time.Minute,
 		HeartbeatTimeout:    30 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval:    2 * time.Second,
-			BackoffCoefficient: 2.0,
-			MaximumInterval:    30 * time.Second,
-			MaximumAttempts:    2,
+			InitialInterval:        2 * time.Second,
+			BackoffCoefficient:     2.0,
+			MaximumInterval:        30 * time.Second,
+			MaximumAttempts:        2,
 			NonRetryableErrorTypes: []string{"InvalidInput", "PathEscape", "HostNotAllowed"},
 		},
 	})
@@ -1085,11 +1085,11 @@ func dispatchTool(ctx workflow.Context, sandboxCtx workflow.Context, state *agen
 			return jsonError("repo_inspect", err), false
 		}
 		return jsonResult(map[string]any{
-			"source":      res.Source,
-			"revision":    res.Revision,
-			"clone_ref":   res.CloneRef,
-			"tree":        res.Tree,
-			"files":       res.Files,
+			"source":       res.Source,
+			"revision":     res.Revision,
+			"clone_ref":    res.CloneRef,
+			"tree":         res.Tree,
+			"files":        res.Files,
 			"truncated_at": res.TruncatedAt,
 		}), false
 
@@ -1240,6 +1240,7 @@ func dispatchTool(ctx workflow.Context, sandboxCtx workflow.Context, state *agen
 			"clone_path":      res.ClonePath,
 			"owner":           res.Owner,
 			"repo":            res.Repo,
+			"project":         res.Project,
 			"branch":          res.Branch,
 			"head_sha":        res.HeadSHA,
 			"installation_id": res.InstallationID,
@@ -1547,13 +1548,13 @@ func dispatchRegisterTool(ctx workflow.Context, sandboxCtx workflow.Context, sta
 	}
 
 	emitEvent(ctx, state, EventKindApprovalResolved, map[string]any{
-		"approval_id":            approvalID,
-		"approved":               resolution.Approved,
-		"resolved_by":            resolution.ResolvedBy,
-		"notes":                  resolution.Notes,
-		"edited":                 resolution.Approved && len(resolveResult.EditedFields) > 0,
-		"edited_fields":          resolveResult.EditedFields,
-		"agent_tool_version_id":  resolveResult.AgentToolVersionID,
+		"approval_id":           approvalID,
+		"approved":              resolution.Approved,
+		"resolved_by":           resolution.ResolvedBy,
+		"notes":                 resolution.Notes,
+		"edited":                resolution.Approved && len(resolveResult.EditedFields) > 0,
+		"edited_fields":         resolveResult.EditedFields,
+		"agent_tool_version_id": resolveResult.AgentToolVersionID,
 	})
 	resolvePendingApproval(auditCtx, state, approvalID, "resolved", resolutionLabel(resolution.Approved), resolution.ResolvedBy, resolution.Notes)
 
@@ -1799,13 +1800,13 @@ func dispatchProposePattern(ctx workflow.Context, sandboxCtx workflow.Context, s
 	}
 
 	emitEvent(ctx, state, EventKindApprovalResolved, map[string]any{
-		"approval_id":         approvalID,
-		"approved":            resolution.Approved,
-		"resolved_by":         resolution.ResolvedBy,
-		"notes":               resolution.Notes,
-		"edited":              resolution.Approved && len(resolveResult.EditedFields) > 0,
-		"edited_fields":       resolveResult.EditedFields,
-		"pattern_version_id":  resolveResult.PatternVersionID,
+		"approval_id":        approvalID,
+		"approved":           resolution.Approved,
+		"resolved_by":        resolution.ResolvedBy,
+		"notes":              resolution.Notes,
+		"edited":             resolution.Approved && len(resolveResult.EditedFields) > 0,
+		"edited_fields":      resolveResult.EditedFields,
+		"pattern_version_id": resolveResult.PatternVersionID,
 	})
 	resolvePendingApproval(auditCtx, state, approvalID, "resolved", resolutionLabel(resolution.Approved), resolution.ResolvedBy, resolution.Notes)
 
@@ -1892,18 +1893,18 @@ func dispatchListPatterns(state *agentState, tc providers.ToolCall) (string, boo
 
 // dispatchInstantiatePattern provisions an approved Pattern into the
 // current workspace. Lifecycle:
-//   1. GetPatternByID — load templateJson + inputSchemaJson + version.
-//   2. Validate user-supplied parameters against the schema's required[].
-//   3. CreatePatternInstance — row at status=pending; bind to workspace,
-//      app (optional), name (unique per workspace), patternVersion snap.
-//   4. UpdateStatus(validating), then UpdateStatus(provisioning).
-//   5. tooltemplate.Expand against the user-supplied parameters and
-//      dispatch each expanded primitive via dispatchTool — same path
-//      registered tools use, so all the existing safety / approval /
-//      sandbox plumbing applies. Failures along the way short-circuit
-//      to UpdateStatus(failed, errorMessage=...).
-//   6. On success: UpdateStatus(active, outputs={...}). Outputs are the
-//      JSON-decoded results of each primitive call, in step order.
+//  1. GetPatternByID — load templateJson + inputSchemaJson + version.
+//  2. Validate user-supplied parameters against the schema's required[].
+//  3. CreatePatternInstance — row at status=pending; bind to workspace,
+//     app (optional), name (unique per workspace), patternVersion snap.
+//  4. UpdateStatus(validating), then UpdateStatus(provisioning).
+//  5. tooltemplate.Expand against the user-supplied parameters and
+//     dispatch each expanded primitive via dispatchTool — same path
+//     registered tools use, so all the existing safety / approval /
+//     sandbox plumbing applies. Failures along the way short-circuit
+//     to UpdateStatus(failed, errorMessage=...).
+//  6. On success: UpdateStatus(active, outputs={...}). Outputs are the
+//     JSON-decoded results of each primitive call, in step order.
 //
 // See plans/merry-strolling-bumblebee.md (Phase 3). For v1, instance
 // execution lives inside the agent run. A future iteration moves
@@ -2289,7 +2290,7 @@ func buildCloudLoginCommand(provider, tenant string) (string, string, error) {
 }
 
 // bashQuote single-quotes s for safe inclusion in a bash command line. The
-// classic '\'' trick escapes embedded single quotes.
+// classic '\” trick escapes embedded single quotes.
 func bashQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
@@ -2300,15 +2301,15 @@ func bashQuote(s string) string {
 // overlays on top via mergeEnv so callers can still pin a different value.
 func defaultSandboxEnv() map[string]string {
 	return map[string]string{
-		"AZURE_CORE_NO_PAGER":          "1",
-		"AZURE_CORE_OUTPUT":            "json",
-		"AZURE_CORE_ONLY_SHOW_ERRORS":  "false",
-		"AWS_PAGER":                    "",
+		"AZURE_CORE_NO_PAGER":           "1",
+		"AZURE_CORE_OUTPUT":             "json",
+		"AZURE_CORE_ONLY_SHOW_ERRORS":   "false",
+		"AWS_PAGER":                     "",
 		"CLOUDSDK_CORE_DISABLE_PROMPTS": "1",
 		"CLOUDSDK_PYTHON_SITEPACKAGES":  "1",
-		"GIT_TERMINAL_PROMPT":          "0",
-		"PYTHONUNBUFFERED":             "1",
-		"DEBIAN_FRONTEND":              "noninteractive",
+		"GIT_TERMINAL_PROMPT":           "0",
+		"PYTHONUNBUFFERED":              "1",
+		"DEBIAN_FRONTEND":               "noninteractive",
 	}
 }
 
@@ -2725,7 +2726,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolShellExec,
+			Name:        ToolShellExec,
 			Description: "Run a bash command inside the run's sandbox. Use this for `az`, `gcloud`, `kubectl`, `helm`, `terraform`, `pulumi`, `git`, `npm`, etc. Output is captured and returned. Long commands heartbeat automatically. Returns {exit_code, stdout, stderr, duration_ms, truncated}.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2737,7 +2738,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolHTTPRequest,
+			Name:        ToolHTTPRequest,
 			Description: "Make an outbound HTTP request, gated by the workspace's host allowlist. Use for cloud-provider REST APIs the agent doesn't have a CLI for. Returns {status, status_code, headers, body, truncated}.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2751,7 +2752,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolReadFile,
+			Name:        ToolReadFile,
 			Description: "Read a file inside the sandbox. Path is relative to the sandbox root and rejected if it escapes.",
 			InputSchema: map[string]any{
 				"type":       "object",
@@ -2760,7 +2761,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolWriteFile,
+			Name:        ToolWriteFile,
 			Description: "Write a file inside the sandbox (parent directories are created). Use to author terraform / helm / pulumi files before applying.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2772,7 +2773,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolListDir,
+			Name:        ToolListDir,
 			Description: "List the contents of a directory inside the sandbox.",
 			InputSchema: map[string]any{
 				"type":       "object",
@@ -2780,7 +2781,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolRepoInspect,
+			Name:        ToolRepoInspect,
 			Description: "Survey a git repository (tree + key manifest files like README, package.json, go.mod, Dockerfile). Tries the GitHub API first; falls back to a shallow clone of the main branch into the sandbox at repo/<slug>/. Use this to learn what kind of app the user wants to deploy before proposing a plan.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2793,7 +2794,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolRequestApproval,
+			Name:        ToolRequestApproval,
 			Description: "Request explicit human approval before proceeding. The workflow blocks on this; the chat UI surfaces an inline Approve/Reject card. Use BEFORE any destructive command (terraform destroy, kubectl delete, az ... delete) and any time the user has not yet given consent for a billable / observable action. Returns {approved, resolved_by, notes}.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2806,7 +2807,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolRegisterTool,
+			Name:        ToolRegisterTool,
 			Description: `Register a new named tool for this workspace. The tool becomes a parameterized template over primitives (shell or http); after a workspace admin approves it the agent can invoke it by name in subsequent turns and the template expands to vetted primitive calls. You never write executable code — the template references {{var}} placeholders that bind to your supplied args at call time. Use this to capture a useful procedure once instead of re-deriving it every run (e.g. deploy_azure_appservice → shell_exec("az appservice create ...")). Returns {approved, name, agent_tool_id, resolved_by, notes}.`,
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2822,7 +2823,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolInstantiatePattern,
+			Name:        ToolInstantiatePattern,
 			Description: `Provision an approved Pattern into a workspace. Pass pattern_id (from list_patterns), workspace_id (defaults to the current run's workspace), a unique name for the instance, and the parameters object (must satisfy the pattern's input_schema_json). The platform validates parameters, expands the template through the same engine that runs registered tools (shell / http / composite primitives), runs each primitive with the agent's existing safety + approval plumbing, and writes the result back as a PatternInstance row. Returns {instance_id, pattern_id, status, outputs}. Prefer this over shell when a matching pattern exists — patterns are audited, deterministic, and cheap to re-run.`,
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2837,7 +2838,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolListPatterns,
+			Name:        ToolListPatterns,
 			Description: `List the platform-wide Patterns catalog (admin-approved deployment recipes available to every workspace). Call this EARLY in a run — before reaching for shell — to see whether an existing pattern already solves the user's request. Each entry includes the pattern's id, name, display_name, description, category, and input_schema_json (the parameters it accepts). When a pattern matches, prefer it: invoke it via instantiate_pattern instead of re-deriving from shell. Returns {patterns: [...], count}.`,
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2851,7 +2852,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolProposePattern,
+			Name:        ToolProposePattern,
 			Description: `Propose a new platform-wide deployment Pattern. Patterns are the durable, curated counterpart to register_tool — once a platform admin approves the proposal, the pattern lives in the global catalog and any workspace can instantiate it (via instantiate_pattern, later via a browse UI). Use this AFTER you've successfully completed a deployment via shell so the next person doesn't have to re-derive the steps. The pattern's template_json compiles via the same engine as register_tool (shell / http / composite). Returns {approved, name, pattern_id, resolved_by, notes, edited_fields}.`,
 			InputSchema: map[string]any{
 				"type": "object",
@@ -2869,7 +2870,7 @@ func builtInToolSchemas() []providers.ToolSchema {
 			},
 		},
 		{
-			Name: ToolStartHealthCheck,
+			Name:        ToolStartHealthCheck,
 			Description: "Set up a periodic HTTP health check against a deployed URL. Writes the spec onto the App's healthConfig; Orbit's platform then runs exactly one HealthCheckWorkflow per app (durable, survives this agent run, survives worker restarts) and the App detail page shows live status. Idempotent — calling again with new params restarts the same canonical workflow. Use this once you've successfully deployed something the user wants monitored.",
 			InputSchema: map[string]any{
 				"type": "object",
@@ -3035,11 +3036,11 @@ Style: be concise. Prefer structured proposals over wall-of-text. When the user'
 
 func initState(ctx workflow.Context, input InfrastructureAgentInput) agentState {
 	state := agentState{
-		status:           "starting",
-		workspaceID:      input.WorkspaceID,
-		history:          append([]ConversationTurn(nil), input.History...),
-		events:           append([]AgentEvent(nil), input.Events...),
-		nextSeq:          input.NextSequence,
+		status:                "starting",
+		workspaceID:           input.WorkspaceID,
+		history:               append([]ConversationTurn(nil), input.History...),
+		events:                append([]AgentEvent(nil), input.Events...),
+		nextSeq:               input.NextSequence,
 		pendingApprovals:      map[string]PendingApproval{},
 		pendingApprovalRowIDs: map[string]string{},
 		toolOutputBuffers:     map[string]*toolOutputBuffer{},


### PR DESCRIPTION
## Summary
- Azure DevOps connections are now a first-class repo-import source, on par with GitHub App installations: `apps.repository` gains a provider discriminator (`provider`, `connection`, `project`), the import form shows a unified GitHub + ADO source picker with live repo browsing, and manual URL entry accepts both `github.com/...` and `dev.azure.com/{org}/{project}/_git/{repo}` shapes.
- Discovery-accepted proposals now carry provider + connection linkage through to the created `apps` row (previously provider-lossy, so accepted ADO entities had no way to reconstruct a clone URL).
- The Temporal agent's repo-clone activity is provider-aware: GitHub keeps its existing `token-for-repo` path unchanged, and ADO resolves credentials via the connections token endpoint, supporting both PAT (URL-embedded) and Entra service-principal (bearer via `http.extraheader`, never in the URL or logs) auth modes.

## Test plan
- [x] `bunx tsc --noEmit` — 0 errors
- [x] `bunx vitest run` on the 7 changed/added test files — 91/91 passing (includes a deliberate fail-soft case for an unresolvable connection, visible as an expected stderr log)
- [x] `go build ./...` and `go test -race -count=1 ./internal/activities/agent/... ./internal/services/... ./internal/workflows/...` — all green
- [x] `go vet` and `eslint` on touched files — clean (2 pre-existing `no-explicit-any` warnings in `github.ts` are on lines this branch didn't touch)
- [x] No new `as any` casts introduced (grep-verified against the PR #83 merge base)
- [x] agent-browser QA walkthrough on local dev (WI7): created a throwaway ADO connection with a dummy PAT and confirmed graceful failure end-to-end — the import form's repo browser surfaces "Azure DevOps organization or project not found (HTTP 404)" inline with no crash and no secret in the DOM; manual ADO URL entry auto-fills the app name, imports successfully (no ADO API call needed for manual-URL import), and the created app's repo link correctly points at `dev.azure.com/...`; Discovery's provider picker lists the ADO connection without crashing on a scan against invalid credentials. Test connection and app deleted after validation.
- [ ] Real-ADO smoke test (listing + clone against actual Azure DevOps credentials) — flagged in the plan as a post-merge manual step; no real ADO org is available in local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZTZi92tWSCeto6SKbwBbT