### PR TITLE
feat(catalog): support GraphQL schema import in Catalog Discovery

### DIFF
--- a/docs/plans/2026-07-10-graphql-schema-import.md
+++ b/docs/plans/2026-07-10-graphql-schema-import.md
@@ -1,7 +1,7 @@
 # GraphQL schema import support (Catalog Discovery → api-schemas)
 
 **Date:** 2026-07-10
-**Status:** Implementation complete (WI1-WI5); manual/agent-browser verification pending
+**Status:** Implementation complete (WI1-WI7); manual/agent-browser verification pending
 **Branch:** `feat/graphql-schema-import`
 
 ## Problem
@@ -89,6 +89,56 @@ File: `orbit-www/src/types/api-catalog.ts:10` — widen `schemaType` union to in
 - Grepped for other `'openapi' | 'asyncapi'` unions: only `detectors.ts` (already
   `'openapi' | 'asyncapi' | 'graphql'` pre-existing for the filename-match type) and
   `import.ts` (updated in WI2). `tsc --noEmit` is clean (0 errors).
+
+## Phase 2 — edit flow + naming (Drew's feedback after Phase 1, 2026-07-10)
+
+Feedback: the imported entity is named "schema" (useless), and it cannot be edited —
+the edit page validates ALL content as OpenAPI, so Save is permanently disabled for
+GraphQL rows, with bogus OpenAPI errors shown in real time.
+
+### WI6 — edit page is schemaType-aware (the actual blocker) — DONE
+File: `orbit-www/src/app/(frontend)/workspaces/[slug]/apis/[id]/edit-api-client.tsx`
+- Line 96: replace `validateOpenAPI(rawContent)` with
+  `validateSchemaByType(rawContent, api.schemaType)` (already exported from
+  `@/lib/schema-validators`) so live validation matches the schema type and Save
+  (line 401, disabled on `!validation.valid`) becomes reachable for GraphQL.
+- Line 334 card title: "GraphQL Schema" / "AsyncAPI Specification" / "OpenAPI
+  Specification" by `api.schemaType`.
+- Line 353 Monaco `language`: `'graphql'` when `api.schemaType === 'graphql'`,
+  `'yaml'` otherwise (Monaco has a built-in graphql language id).
+- Validation errors from `validateGraphQL` already carry line/column — the existing
+  error list rendering (line 374+) needs no change.
+- No component test infra existed for this client component (confirmed, still
+  none added). Per the deviation allowance, added dispatch-level coverage for
+  `validateSchemaByType` in `orbit-www/src/lib/schema-validators.test.ts`
+  (graphql/openapi/asyncapi routing) instead of a component test; the UI wiring
+  itself (`useEffect` dep on `api.schemaType`, card title, Monaco language) is
+  covered by `tsc --noEmit` plus the manual verification pass below.
+
+### WI7 — sane default names for spec proposals without a title — DONE
+File: `orbit-www/src/lib/discovery/ingest.ts` (`buildProposal`, line 130)
+- Mirror the existing `'service'`→repoName normalization: for `kind === 'api'`
+  proposals with no `specTitle` whose name is a generic spec filename stem
+  (`schema`, `index`, `api`, `types`, `main`, `openapi`, `swagger`, `asyncapi`),
+  rename to `` `${repoName} ${label} API` `` where label is `GraphQL` / `OpenAPI` /
+  `AsyncAPI` from `proposal.schemaType` (fallback `API` suffix only).
+  e.g. booksrus `schema.graphql` → `booksrus GraphQL API`.
+- Unit tests in the ingest test suite (generic name → renamed; specTitle present →
+  untouched; service normalization unchanged).
+- Already-imported rows keep their name — fixable via the now-working edit page.
+- Implemented as-is; no dedicated `ingest.test.ts` file existed (the ingest test
+  suite lives alongside the route it backs, at
+  `orbit-www/src/app/api/internal/discovery/ingest/route.test.ts`, which imports
+  and exercises `ingestScan` directly against a `FakePayload`) — added the two new
+  WI7 cases there. The "service normalization unchanged" case was already covered
+  by pre-existing tests in that file and re-verified green after the change.
+
+### Verification (Phase 2)
+- Touched vitest suites + tsc as before.
+- Browser: open the imported "schema" row → Edit → rename to a real name, confirm
+  live validation accepts the SDL, break the SDL and see a GraphQL parse error
+  appear in real time, fix it, Save → detail page shows new name (and a new
+  version when content changed).
 
 ### Out of scope (follow-ups, do NOT do now)
 - Manual "New API" wizard graphql support (`wizard/SchemaContentStep.tsx`,

--- a/docs/plans/2026-07-10-graphql-schema-import.md
+++ b/docs/plans/2026-07-10-graphql-schema-import.md
@@ -140,6 +140,80 @@ File: `orbit-www/src/lib/discovery/ingest.ts` (`buildProposal`, line 130)
   appear in real time, fix it, Save → detail page shows new name (and a new
   version when content changed).
 
+## Phase 3 — show + inline-rename proposal names in the review queue (Drew, 2026-07-10)
+
+Decision (Drew, via option picker): proposal rows should DISPLAY the proposed entity
+name and allow INLINE rename before import. No confirmation dialog on Approve (a real
+org scan produces ~266 proposals; per-approve friction is unacceptable and bulk
+approve would bypass it anyway). The edited name persists on the proposal, so both
+single and bulk approve import with it.
+
+Current gaps: `ProposalRow.tsx` renders kind/confidence/path/schemaType but NOT the
+proposal name (`proposalDisplayName()` exists in `discovery-ui.tsx` but is only used
+for toasts). There is no rename action.
+
+### WI8 — rename core with per-row RBAC — DONE
+File: `orbit-www/src/lib/discovery/actions-core.ts`
+- New `renameDiscoveryCore(payload, betterAuthId, actorUserId, isAdmin, id, name)`
+  (mirror `approveDiscoveriesCore`'s shape/auth exactly): load row via findByID
+  (not-found → error result, no throw); authorize — workspace row → platform admin
+  OR active member (reuse `isMemberCached`), global row → admin only; only rows with
+  `status: 'proposed'` are renameable (`invalid-status` otherwise); validate name —
+  trimmed, non-empty, ≤ 120 chars (`invalid-name`); write `{ proposal: { ...existing
+  proposal, name } }` with overrideAccess. Return a discriminated result
+  (`{ ok: true } | { ok: false, reason }`).
+- TDD in `actions-core.test.ts` (FakePayload): happy path persists proposal.name and
+  preserves other proposal keys; forbidden non-member; global row non-admin
+  forbidden; imported/ignored row rejected; whitespace-only name rejected.
+- Implemented as-is, with two extra cases beyond the plan's minimum for full
+  coverage of the discriminated result: a >120-char name (`invalid-name`) and a
+  missing row (`not-found`). `actorUserId` is threaded through and intentionally
+  unused inside the core (there's no "renamed by" field) — kept only so the
+  `'use server'` wrapper resolves the caller identically to `approveDiscoveries`;
+  `void actorUserId` silences the otherwise-unused binding. Order of checks:
+  findByID → authorize → status → name validity → write (matches the plan's
+  listed order, which also matches what makes the test assertions unambiguous).
+
+### WI9 — server action wrapper — DONE
+File: `orbit-www/src/app/actions/discovery.ts`
+- `renameDiscovery(id: string, name: string)` following the exact auth-resolution
+  pattern of `approveDiscoveries` (same session lookup, same admin resolution),
+  delegating to `renameDiscoveryCore`.
+- Returns `{ success: boolean; error?: string }` (the raw `renameDiscoveryCore`
+  reason code on failure, e.g. `'forbidden'`) — mirrors `ignoreDiscoveries`'
+  shape rather than `approveDiscoveries`' batched `results` array, since rename
+  only ever acts on one row. No `revalidatePath` call, again matching
+  `ignoreDiscoveries` — the client refreshes via `router.refresh()` on success.
+
+### WI10 — review-queue UI — DONE
+Files: `orbit-www/src/components/features/discovery/ProposalRow.tsx`,
+`DiscoveryClient.tsx`, `GlobalDiscoveryClient.tsx`, `discovery-ui.tsx`
+- ProposalRow: render `proposalDisplayName(row)` prominently (font-medium, first
+  line of the row, above the mono path). New optional `onRename?: (name: string) =>
+  Promise<boolean>` prop: when provided AND the row is renameable (proposed tab),
+  show a small pencil (lucide `Pencil`) button next to the name → swaps to an
+  inline `<Input>` + Save button; Enter saves, Escape cancels; disable while
+  pending; on success update display (parent refreshes/optimistically updates), on
+  failure toast the reason. No `onRename` (imported/ignored tabs, or rows the
+  caller can't rename) → name renders read-only, no pencil.
+- DiscoveryClient + GlobalDiscoveryClient: wire `onRename` for proposed rows to the
+  new server action, refresh the list (or update local state) on success, toast on
+  failure. Keep bulk-select/approve behavior untouched.
+- Keep `proposalDisplayName` as the single source for the display fallback chain.
+- Added `humanizeRenameReason()` to `discovery-ui.tsx` (mirrors
+  `humanizeSkippedReason`) to turn the core's reason codes into UI copy for the
+  failure toast; covered by new unit tests in `discovery-ui.test.ts`.
+- No component-test infra exists for `ProposalRow`/`DiscoveryClient`/
+  `GlobalDiscoveryClient` (same gap noted in Phase 2's WI6) — the TDD weight went
+  into WI8's core tests and the `humanizeRenameReason` unit tests, per the
+  pointer; the UI wiring is covered by `tsc --noEmit` plus the browser pass.
+
+### Verification (Phase 3)
+- Touched vitest suites + `bunx tsc --noEmit` (0 errors).
+- Browser (main session): a proposed row shows its name; pencil → rename →
+  persists across reload; approve → imported entity carries the edited name;
+  imported rows show name without pencil; bulk approve unaffected.
+
 ### Out of scope (follow-ups, do NOT do now)
 - Manual "New API" wizard graphql support (`wizard/SchemaContentStep.tsx`,
   `apis/actions.ts:47` hardcodes `openapi`).

--- a/docs/plans/2026-07-10-graphql-schema-import.md
+++ b/docs/plans/2026-07-10-graphql-schema-import.md
@@ -1,0 +1,104 @@
+# GraphQL schema import support (Catalog Discovery → api-schemas)
+
+**Date:** 2026-07-10
+**Status:** Implementation complete (WI1-WI5); manual/agent-browser verification pending
+**Branch:** `feat/graphql-schema-import`
+
+## Problem
+
+Catalog Discovery detects GraphQL schemas (`detectApiSpecs` emits `schemaType: 'graphql'`
+with high confidence when the file is real SDL), but approving the proposal skips the
+import with `unsupported-schema-type:graphql`, shown in the UI as
+"GRAPHQL specs aren't importable yet."
+
+Root cause chain:
+- `orbit-www/src/collections/api-catalog/APISchemas.ts:174` — `schemaType` select only
+  allows `openapi` / `asyncapi`.
+- `orbit-www/src/lib/discovery/import.ts:50` — `SUPPORTED_API_SCHEMA_TYPES` mirrors that
+  enum, so `importDiscoveredApi` returns the skip.
+- Everything downstream (projection, review queue) already passes `schemaType` through
+  as an opaque string; the global-entity import path (`importDiscoveredGlobalEntity`)
+  already imports graphql rows fine.
+
+## Work items (TDD: write/adjust the failing test first for each)
+
+### WI1 — `api-schemas` collection accepts `graphql` — DONE
+File: `orbit-www/src/collections/api-catalog/APISchemas.ts`
+- Add `{ label: 'GraphQL', value: 'graphql' }` to the `schemaType` select options;
+  update the field + `rawContent` admin descriptions ("OpenAPI, AsyncAPI, GraphQL").
+- beforeValidate hook: `extractSpecMetadata` is YAML-based and returns `null` for SDL —
+  keep it from misfiring, and add a GraphQL-aware metadata branch when
+  `data.schemaType === 'graphql'` (or content sniffs as SDL):
+  - use the existing `graphql` dependency (`^16.8.1`, orbit-www/package.json): `parse()`
+    the SDL; on success set `endpointCount` = total fields across
+    `Query`/`Mutation`/`Subscription` object type definitions (0 if none).
+  - never throw from the hook on unparseable content — leave metadata unset.
+- Regenerate types: `cd orbit-www && pnpm generate:types` → `payload-types.ts`
+  `schemaType: 'openapi' | 'asyncapi' | 'graphql'`.
+- Implemented as a new exported `extractGraphQLMetadata()` in `detectors.ts` (parses SDL
+  via the `graphql` package, counts Query/Mutation/Subscription fields, returns `null` on
+  unparseable content) with its own unit tests in `detectors.test.ts` — the hook branches
+  on `data.schemaType === 'graphql'` to call it instead of `extractSpecMetadata`, and
+  regenerated `payload-types.ts` (used `bun run generate:types`, not `pnpm` — this repo's
+  `package.json` pins `packageManager: bun@1.2.23`; there is no `pnpm-lock.yaml`).
+
+### WI2 — importer allows graphql — DONE
+File: `orbit-www/src/lib/discovery/import.ts`
+- Add `'graphql'` to `SUPPORTED_API_SCHEMA_TYPES` (line 50) and widen the cast at
+  line 338 to `'openapi' | 'asyncapi' | 'graphql'`.
+- Update the now-stale doc comments (lines 23, 44–49, 255–258).
+- Test: flip `import.test.ts:417` ("SKIPS graphql proposals…") into "imports graphql
+  proposals into api-schemas" — assert created row has `schemaType: 'graphql'`,
+  `rawContent`, `repositoryPath`, and the discovery row flips to
+  `status: 'imported'` + `importedRef`. Keep a skip test for a genuinely unknown
+  type (e.g. `protobuf`) so the guard still has coverage.
+- Note: filename-only (medium-confidence) graphql proposals have no `rawContent` and
+  still skip with `missing-raw-content` — unchanged, already covered.
+- Also flipped the equivalent graphql-skip test in `actions-core.test.ts` (the
+  `approveDiscoveriesCore` suite had its own copy) to expect a successful import, with a
+  new skip test there for a genuinely unsupported type (`protobuf`).
+
+### WI3 — real GraphQL validation — DONE
+File: `orbit-www/src/lib/schema-validators.ts`
+- Replace the regex-heuristic `validateGraphQL` body with `graphql` package `parse()`:
+  syntax errors → `{ valid: false, errors: [{ line, message }] }` (GraphQLError has
+  `locations`). Keep the empty-content → valid behavior and the exported signature.
+- Update/extend `schema-validators` tests accordingly (check for an existing test file).
+- No existing test file was found for `schema-validators.ts`; created
+  `orbit-www/src/lib/schema-validators.test.ts` scoped to `validateGraphQL` (empty
+  content, valid SDL, unparseable SDL with line/message, dangling `type` keyword).
+
+### WI4 — API detail page renders SDL instead of feeding Scalar — DONE
+Files: `orbit-www/src/app/(frontend)/catalog/apis/[id]/api-detail-client.tsx`,
+`orbit-www/src/components/features/api-catalog/SwaggerUIViewer.tsx`
+- `APISpecViewer` parses spec as JSON/YAML and hands it to Scalar's
+  `ApiReferenceReact` — GraphQL SDL would hit the "Invalid specification format" error.
+- Add an optional `schemaType` prop to `APISpecViewer`; when `'graphql'`, render the
+  SDL in a scrollable `<pre>` code block (match existing dark-theme styling used
+  elsewhere in the app) instead of Scalar. Pass the doc's `schemaType` from
+  `api-detail-client.tsx` (the api-schemas doc is already loaded there).
+- Keep behavior identical for openapi/asyncapi.
+- No dedicated component test was added for `APISpecViewer`/`api-detail-client.tsx` (none
+  existed prior to this change, and the plan's verification section defers UI checks to
+  manual/agent-browser). Covered by `tsc` + the manual verification pass below.
+
+### WI5 — types — DONE
+File: `orbit-www/src/types/api-catalog.ts:10` — widen `schemaType` union to include
+`'graphql'`. Grep for any other `'openapi' | 'asyncapi'` unions that now conflict
+(`tsc` will catch them; keep tsc at 0 errors — that is a repo requirement).
+- Grepped for other `'openapi' | 'asyncapi'` unions: only `detectors.ts` (already
+  `'openapi' | 'asyncapi' | 'graphql'` pre-existing for the filename-match type) and
+  `import.ts` (updated in WI2). `tsc --noEmit` is clean (0 errors).
+
+### Out of scope (follow-ups, do NOT do now)
+- Manual "New API" wizard graphql support (`wizard/SchemaContentStep.tsx`,
+  `apis/actions.ts:47` hardcodes `openapi`).
+- GraphQL-native doc viewer (GraphiQL-style); the SDL code block is Phase 1.
+- Go api-catalog service / proto changes — import path is TS-only via Payload.
+
+## Verification
+1. `cd orbit-www && pnpm exec vitest run src/lib/discovery/import.test.ts src/lib/discovery/actions-core.test.ts src/lib/schema-validators.test.ts` (only touched suites — main carries ~98 unrelated pre-existing vitest failures; do not chase those).
+2. `cd orbit-www && pnpm exec tsc --noEmit` → 0 errors.
+3. Manual/agent-browser (done by main session after implementation): approve the
+   `drewpayment/booksrus` graphql proposal in Catalog Discovery → row moves to
+   Imported, api-schemas row exists, catalog API detail page renders the SDL.

--- a/orbit-www/src/app/(frontend)/catalog/apis/[id]/api-detail-client.tsx
+++ b/orbit-www/src/app/(frontend)/catalog/apis/[id]/api-detail-client.tsx
@@ -379,6 +379,7 @@ export function APIDetailClient({ api, versions, canEdit, userId }: APIDetailCli
               <APISpecViewer
                 spec={displayContent}
                 version={selectedVersionContent ? 'Historical Version' : api.currentVersion ?? undefined}
+                schemaType={api.schemaType}
               />
             </CardContent>
           </Card>

--- a/orbit-www/src/app/(frontend)/workspaces/[slug]/apis/[id]/edit-api-client.tsx
+++ b/orbit-www/src/app/(frontend)/workspaces/[slug]/apis/[id]/edit-api-client.tsx
@@ -34,7 +34,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Loader2, Save, X, AlertCircle, Eye } from 'lucide-react'
-import { validateOpenAPI, type ValidationResult } from '@/lib/schema-validators'
+import { validateSchemaByType, type ValidationResult } from '@/lib/schema-validators'
 import { updateAPISchema } from '../actions'
 import { toast } from 'sonner'
 import type { APISchema } from '@/types/api-catalog'
@@ -90,13 +90,21 @@ export function EditAPIClient({ api, workspaceSlug: _workspaceSlug, userId }: Ed
   const rawContent = form.watch('rawContent')
   const hasContentChanged = rawContent !== api.rawContent
 
+  const specCardTitle =
+    api.schemaType === 'graphql'
+      ? 'GraphQL Schema'
+      : api.schemaType === 'asyncapi'
+        ? 'AsyncAPI Specification'
+        : 'OpenAPI Specification'
+  const editorLanguage = api.schemaType === 'graphql' ? 'graphql' : 'yaml'
+
   // Validate content when it changes
   React.useEffect(() => {
     if (rawContent) {
-      const result = validateOpenAPI(rawContent)
+      const result = validateSchemaByType(rawContent, api.schemaType)
       setValidation(result)
     }
-  }, [rawContent])
+  }, [rawContent, api.schemaType])
 
   const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && tagInput.trim()) {
@@ -331,7 +339,7 @@ export function EditAPIClient({ api, workspaceSlug: _workspaceSlug, userId }: Ed
 
           <Card>
             <CardHeader>
-              <CardTitle>OpenAPI Specification</CardTitle>
+              <CardTitle>{specCardTitle}</CardTitle>
               <CardDescription>
                 {hasContentChanged && (
                   <span className="text-yellow-600">
@@ -350,7 +358,7 @@ export function EditAPIClient({ api, workspaceSlug: _workspaceSlug, userId }: Ed
                       <div className="border rounded-md overflow-hidden">
                         <Editor
                           height="400px"
-                          language="yaml"
+                          language={editorLanguage}
                           value={field.value}
                           onChange={(value) => field.onChange(value || '')}
                           theme="vs-dark"

--- a/orbit-www/src/app/actions/discovery.ts
+++ b/orbit-www/src/app/actions/discovery.ts
@@ -13,6 +13,7 @@ import {
   listGlobalDiscoveriesCore,
   approveDiscoveriesCore,
   ignoreDiscoveriesCore,
+  renameDiscoveryCore,
   startWorkspaceScanCore,
   startInstallationScanCore,
   type DiscoveryFilter,
@@ -151,6 +152,34 @@ export async function approveDiscoveries(
   revalidatePath('/discovery')
 
   return { success: true, results }
+}
+
+/**
+ * Rename a single proposal before import (Phase 3, inline rename in the review
+ * queue — no confirm dialog on approve, so the entity name must be fixable
+ * up-front). Same auth-resolution pattern as `approveDiscoveries`: the Payload
+ * user id is threaded through for call-shape symmetry even though the core
+ * doesn't persist it (there's no "renamed by" field on the proposal).
+ */
+export async function renameDiscovery(id: string, name: string): Promise<{
+  success: boolean
+  error?: string
+}> {
+  const actor = await getPayloadUserFromSession()
+  if (!actor) return { success: false, error: 'Unauthorized' }
+
+  const payload = await getPayload({ config })
+  const result = await renameDiscoveryCore(
+    payload,
+    actor.betterAuthId ?? '',
+    String(actor.id),
+    isPlatformAdmin(actor),
+    id,
+    name,
+  )
+
+  if (!result.ok) return { success: false, error: result.reason }
+  return { success: true }
 }
 
 export async function ignoreDiscoveries(ids: string[]): Promise<{

--- a/orbit-www/src/app/api/internal/discovery/ingest/route.test.ts
+++ b/orbit-www/src/app/api/internal/discovery/ingest/route.test.ts
@@ -133,6 +133,22 @@ const heuristicServiceBundle = () => ({
   files: { 'go.mod': 'module github.com/acme/billing\n' },
 })
 
+/** A repo with a GraphQL SDL file named with a generic stem -> no specTitle (WI7). */
+const graphqlGenericStemBundle = () => ({
+  tree: ['schema.graphql'],
+  files: {
+    'schema.graphql': 'type Book {\n  id: ID!\n}\n\ntype Query {\n  books: [Book!]!\n}\n',
+  },
+})
+
+/** An OpenAPI spec whose title happens to collide with a generic stem (WI7). */
+const openapiGenericTitledBundle = () => ({
+  tree: ['openapi.yaml'],
+  files: {
+    'openapi.yaml': 'openapi: 3.0.0\ninfo:\n  title: Schema\n  version: 1.0.0\npaths: {}\n',
+  },
+})
+
 // --- POST: auth + validation -------------------------------------------------
 
 describe('POST /api/internal/discovery/ingest — auth & validation', () => {
@@ -356,6 +372,24 @@ describe('ingestScan', () => {
     const row = f.collections['discovered-entities'][0]
     expect(row.status).toBe('imported')
     expect((row.importedRef as { collectionSlug: string }).collectionSlug).toBe('catalog-entities')
+  })
+
+  it('renames a generic-stem GraphQL proposal to "<repo> GraphQL API" (WI7)', async () => {
+    const f = new FakePayload()
+    await ingestScan(p(f), body({ bundle: graphqlGenericStemBundle() }))
+
+    const row = f.collections['discovered-entities'][0]
+    expect(row.detectedKind).toBe('api')
+    expect((row.proposal as Record<string, unknown>).name).toBe('billing GraphQL API')
+  })
+
+  it('leaves the proposal name untouched when a specTitle is present, even if it matches a generic stem (WI7)', async () => {
+    const f = new FakePayload()
+    await ingestScan(p(f), body({ bundle: openapiGenericTitledBundle() }))
+
+    const row = f.collections['discovered-entities'][0]
+    expect((row.proposal as Record<string, unknown>).name).toBe('Schema')
+    expect((row.proposal as Record<string, unknown>).specTitle).toBe('Schema')
   })
 
   it('resolves the numeric installationId to the github-installations doc id for the relationship', async () => {

--- a/orbit-www/src/collections/api-catalog/APISchemas.ts
+++ b/orbit-www/src/collections/api-catalog/APISchemas.ts
@@ -338,7 +338,7 @@ export const APISchemas: CollectionConfig = {
   ],
   hooks: {
     beforeValidate: [
-      async ({ data, operation, req }) => {
+      async ({ data, operation, req, originalDoc }) => {
         if (!data) return data
 
         // Auto-generate slug from name if not provided
@@ -363,8 +363,15 @@ export const APISchemas: CollectionConfig = {
         // detectors lib so there is one implementation shared with the
         // catalog scanner. GraphQL SDL is not YAML, so it gets its own
         // extractor rather than misfiring `extractSpecMetadata`.
+        //
+        // On update, `data` is the partial patch from the edit form and may
+        // omit `schemaType` entirely (it's not a field the edit page sends) —
+        // fall back to the persisted value on `originalDoc` so a graphql row's
+        // content edit still hits the graphql branch instead of misfiring the
+        // yaml-based extractor.
+        const effectiveSchemaType = data.schemaType ?? originalDoc?.schemaType
         if (data.rawContent) {
-          if (data.schemaType === 'graphql') {
+          if (effectiveSchemaType === 'graphql') {
             const { extractGraphQLMetadata } = await import('@/lib/discovery/detectors')
             const meta = extractGraphQLMetadata(data.rawContent)
             if (meta) {

--- a/orbit-www/src/collections/api-catalog/APISchemas.ts
+++ b/orbit-www/src/collections/api-catalog/APISchemas.ts
@@ -178,9 +178,10 @@ export const APISchemas: CollectionConfig = {
       options: [
         { label: 'OpenAPI', value: 'openapi' },
         { label: 'AsyncAPI', value: 'asyncapi' },
+        { label: 'GraphQL', value: 'graphql' },
       ],
       admin: {
-        description: 'Schema format (OpenAPI and AsyncAPI supported)',
+        description: 'Schema format (OpenAPI, AsyncAPI, GraphQL supported)',
       },
     },
     {
@@ -196,7 +197,7 @@ export const APISchemas: CollectionConfig = {
       required: true,
       admin: {
         language: 'yaml',
-        description: 'OpenAPI specification content',
+        description: 'OpenAPI, AsyncAPI, GraphQL specification content',
       },
     },
     {
@@ -360,33 +361,42 @@ export const APISchemas: CollectionConfig = {
 
         // Parse spec to extract metadata. Sniffing lives in the discovery
         // detectors lib so there is one implementation shared with the
-        // catalog scanner.
+        // catalog scanner. GraphQL SDL is not YAML, so it gets its own
+        // extractor rather than misfiring `extractSpecMetadata`.
         if (data.rawContent) {
-          const { extractSpecMetadata } = await import('@/lib/discovery/detectors')
-          const meta = extractSpecMetadata(data.rawContent)
-          if (meta) {
-            // Auto-detect schema type from content
-            if (meta.schemaType) {
-              data.schemaType = meta.schemaType
-            }
-
-            if (meta.hasInfo) {
-              data.specTitle = meta.title
-              data.specDescription = meta.description
-              data.currentVersion = meta.version
-
-              if (meta.hasContact) {
-                data.contactName = data.contactName || meta.contactName
-                data.contactEmail = data.contactEmail || meta.contactEmail
-              }
-            }
-
-            if (meta.serverUrls) {
-              data.serverUrls = meta.serverUrls.map((url) => ({ url }))
-            }
-
-            if (meta.endpointCount !== null) {
+          if (data.schemaType === 'graphql') {
+            const { extractGraphQLMetadata } = await import('@/lib/discovery/detectors')
+            const meta = extractGraphQLMetadata(data.rawContent)
+            if (meta) {
               data.endpointCount = meta.endpointCount
+            }
+          } else {
+            const { extractSpecMetadata } = await import('@/lib/discovery/detectors')
+            const meta = extractSpecMetadata(data.rawContent)
+            if (meta) {
+              // Auto-detect schema type from content
+              if (meta.schemaType) {
+                data.schemaType = meta.schemaType
+              }
+
+              if (meta.hasInfo) {
+                data.specTitle = meta.title
+                data.specDescription = meta.description
+                data.currentVersion = meta.version
+
+                if (meta.hasContact) {
+                  data.contactName = data.contactName || meta.contactName
+                  data.contactEmail = data.contactEmail || meta.contactEmail
+                }
+              }
+
+              if (meta.serverUrls) {
+                data.serverUrls = meta.serverUrls.map((url) => ({ url }))
+              }
+
+              if (meta.endpointCount !== null) {
+                data.endpointCount = meta.endpointCount
+              }
             }
           }
         }

--- a/orbit-www/src/components/features/api-catalog/SwaggerUIViewer.tsx
+++ b/orbit-www/src/components/features/api-catalog/SwaggerUIViewer.tsx
@@ -21,12 +21,14 @@ const ApiReferenceReact = dynamic(
 )
 
 interface APISpecViewerProps {
-  /** OpenAPI or AsyncAPI spec content (YAML or JSON string) */
+  /** OpenAPI, AsyncAPI, or GraphQL SDL spec content */
   spec: string
   /** Optional version label to display */
   version?: string
   /** Additional class names */
   className?: string
+  /** When 'graphql', the spec is rendered as raw SDL instead of fed to Scalar */
+  schemaType?: 'openapi' | 'asyncapi' | 'graphql'
 }
 
 function parseSpec(content: string): { spec: Record<string, unknown> | null; error: string | null } {
@@ -52,8 +54,37 @@ function parseSpec(content: string): { spec: Record<string, unknown> | null; err
   }
 }
 
-export function APISpecViewer({ spec, version, className }: APISpecViewerProps) {
-  const { spec: parsedSpec, error } = React.useMemo(() => parseSpec(spec), [spec])
+export function APISpecViewer({ spec, version, className, schemaType }: APISpecViewerProps) {
+  const { spec: parsedSpec, error } = React.useMemo(
+    () => (schemaType === 'graphql' ? { spec: null, error: null } : parseSpec(spec)),
+    [spec, schemaType]
+  )
+
+  if (schemaType === 'graphql') {
+    if (!spec?.trim()) {
+      return (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            <div className="font-semibold">Failed to load API documentation</div>
+            <p className="text-sm mt-1">No specification content provided</p>
+          </AlertDescription>
+        </Alert>
+      )
+    }
+    return (
+      <div className={className}>
+        {version && (
+          <div className="mb-4 text-sm text-muted-foreground">
+            Viewing version: <span className="font-medium">{version}</span>
+          </div>
+        )}
+        <pre className="max-h-[600px] overflow-auto rounded-md bg-zinc-900 p-4 text-sm text-zinc-100">
+          <code>{spec}</code>
+        </pre>
+      </div>
+    )
+  }
 
   if (error) {
     return (

--- a/orbit-www/src/components/features/discovery/DiscoveryClient.tsx
+++ b/orbit-www/src/components/features/discovery/DiscoveryClient.tsx
@@ -14,11 +14,13 @@ import {
   startWorkspaceScan,
   approveDiscoveries,
   ignoreDiscoveries,
+  renameDiscovery,
   getScanStatus,
   type ScanStatusEntry,
 } from '@/app/actions/discovery'
 import {
   groupByRepo,
+  humanizeRenameReason,
   humanizeSkippedReason,
   importedHref,
   proposalDisplayName,
@@ -194,6 +196,21 @@ export function DiscoveryClient({
     [router],
   )
 
+  // Inline rename (Phase 3): no confirm dialog, just persist and refresh so the
+  // edited name is what single/bulk approve import with.
+  const onRename = useCallback(
+    async (id: string, name: string) => {
+      const res = await renameDiscovery(id, name)
+      if (!res.success) {
+        toast.error(humanizeRenameReason(res.error))
+        return false
+      }
+      router.refresh()
+      return true
+    },
+    [router],
+  )
+
   const proposedIds = proposed.map((d) => d.id)
   const selectedProposed = proposedIds.filter((id) => selected.has(id))
 
@@ -282,6 +299,7 @@ export function DiscoveryClient({
                           pending={isPending}
                           onApprove={() => onApprove([row.id])}
                           onIgnore={() => onIgnore([row.id])}
+                          onRename={(name) => onRename(row.id, name)}
                         />
                       ))}
                     </ul>

--- a/orbit-www/src/components/features/discovery/GlobalDiscoveryClient.tsx
+++ b/orbit-www/src/components/features/discovery/GlobalDiscoveryClient.tsx
@@ -24,12 +24,14 @@ import {
   startInstallationScan,
   approveDiscoveries,
   ignoreDiscoveries,
+  renameDiscovery,
   getInstallationScanStatus,
 } from '@/app/actions/discovery'
 import type { ApproveResult } from '@/lib/discovery/actions-core'
 import { startConnectionScan, getConnectionScanStatus } from '@/app/actions/git-connections'
 import {
   groupByRepo,
+  humanizeRenameReason,
   humanizeSkippedReason,
   importedHref,
   KindBadge,
@@ -330,6 +332,21 @@ export function GlobalDiscoveryClient({
     [router],
   )
 
+  // Inline rename (Phase 3): no confirm dialog, just persist and refresh so the
+  // edited name is what single/bulk approve import with.
+  const onRename = useCallback(
+    async (id: string, name: string) => {
+      const res = await renameDiscovery(id, name)
+      if (!res.success) {
+        toast.error(humanizeRenameReason(res.error))
+        return false
+      }
+      router.refresh()
+      return true
+    },
+    [router],
+  )
+
   const proposedIds = proposed.map((d) => d.id)
   const selectedProposed = proposedIds.filter((id) => selected.has(id))
 
@@ -409,6 +426,7 @@ export function GlobalDiscoveryClient({
                           pending={isPending}
                           onApprove={() => openConfirm(row)}
                           onIgnore={() => onIgnore([row.id])}
+                          onRename={(name) => onRename(row.id, name)}
                         />
                       ))}
                     </ul>

--- a/orbit-www/src/components/features/discovery/ProposalRow.tsx
+++ b/orbit-www/src/components/features/discovery/ProposalRow.tsx
@@ -2,10 +2,11 @@
 
 import { useState, type ReactNode } from 'react'
 import Link from 'next/link'
-import { Check, ChevronDown, ExternalLink, X } from 'lucide-react'
+import { Check, ChevronDown, ExternalLink, Pencil, X } from 'lucide-react'
 import type { DiscoveredEntity } from '@/payload-types'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
 import {
   Collapsible,
   CollapsibleContent,
@@ -19,6 +20,7 @@ import {
   importedHref,
   ownershipHints,
   parseEvidence,
+  proposalDisplayName,
   proposalSummary,
 } from './discovery-ui'
 
@@ -30,6 +32,12 @@ import {
  * global queue (GlobalDiscoveryClient, WP8). The `footer` slot lets the global
  * queue inject its per-row approval choice (import as global entity vs. assign to
  * a workspace) without forking the row.
+ *
+ * `onRename` (Phase 3): only passed by the caller for renameable (proposed)
+ * rows. When present, a pencil next to the name swaps it for an inline
+ * text input; Enter saves, Escape cancels. There is no approve-time confirm
+ * dialog for renames — Drew's call, since a real org scan produces ~200+
+ * proposals and per-approve friction is unacceptable.
  */
 export function ProposalRow({
   row,
@@ -40,6 +48,7 @@ export function ProposalRow({
   pending = false,
   onApprove,
   onIgnore,
+  onRename,
   imported = false,
   footer,
 }: {
@@ -51,15 +60,40 @@ export function ProposalRow({
   pending?: boolean
   onApprove?: () => void
   onIgnore?: () => void
+  onRename?: (name: string) => Promise<boolean>
   imported?: boolean
   footer?: ReactNode
 }) {
   const [open, setOpen] = useState(false)
+  const [renaming, setRenaming] = useState(false)
+  const [draftName, setDraftName] = useState('')
+  const [savingRename, setSavingRename] = useState(false)
   const evidence = parseEvidence(row.evidence)
   const detectors = detectionEvidence(evidence)
   const owners = ownershipHints(evidence)
   const summary = proposalSummary(row)
   const pathLabel = row.path ? row.path : 'repository root'
+  const displayName = proposalDisplayName(row)
+
+  const startRename = () => {
+    setDraftName(displayName)
+    setRenaming(true)
+  }
+
+  const cancelRename = () => {
+    setRenaming(false)
+    setDraftName('')
+  }
+
+  const saveRename = async () => {
+    if (!onRename) return
+    const trimmed = draftName.trim()
+    if (!trimmed) return
+    setSavingRename(true)
+    const ok = await onRename(trimmed)
+    setSavingRename(false)
+    if (ok) setRenaming(false)
+  }
 
   return (
     <li className="px-4 py-3">
@@ -73,6 +107,54 @@ export function ProposalRow({
           />
         )}
         <div className="min-w-0 flex-1 space-y-2">
+          {renaming ? (
+            <div className="flex items-center gap-2">
+              <Input
+                autoFocus
+                value={draftName}
+                onChange={(e) => setDraftName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    void saveRename()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    cancelRename()
+                  }
+                }}
+                disabled={savingRename}
+                maxLength={120}
+                className="h-8 max-w-sm"
+                aria-label="Proposal name"
+              />
+              <Button
+                size="sm"
+                disabled={savingRename || !draftName.trim()}
+                onClick={saveRename}
+              >
+                Save
+              </Button>
+              <Button size="sm" variant="ghost" disabled={savingRename} onClick={cancelRename}>
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <span className="font-medium">{displayName}</span>
+              {onRename && (
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  className="h-6 w-6"
+                  onClick={startRename}
+                  aria-label={`Rename ${displayName}`}
+                >
+                  <Pencil className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          )}
+
           <div className="flex flex-wrap items-center gap-2">
             <KindBadge kind={row.detectedKind} />
             <ConfidenceChip confidence={row.confidence} />

--- a/orbit-www/src/components/features/discovery/discovery-ui.test.ts
+++ b/orbit-www/src/components/features/discovery/discovery-ui.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { DiscoveredEntity } from '@/payload-types'
-import { importedHref, proposalDisplayName } from './discovery-ui'
+import { humanizeRenameReason, importedHref, proposalDisplayName } from './discovery-ui'
 
 function row(partial: Partial<DiscoveredEntity> = {}): DiscoveredEntity {
   return {
@@ -61,5 +61,19 @@ describe('importedHref', () => {
 
   it('returns null for a collection with no user-facing detail route', () => {
     expect(importedHref('some-other-collection', 'x1')).toBeNull()
+  })
+})
+
+describe('humanizeRenameReason', () => {
+  it('maps known renameDiscoveryCore reasons to human copy', () => {
+    expect(humanizeRenameReason('forbidden')).toMatch(/not allowed/i)
+    expect(humanizeRenameReason('not-found')).toMatch(/no longer exists/i)
+    expect(humanizeRenameReason('invalid-status')).toMatch(/proposed/i)
+    expect(humanizeRenameReason('invalid-name')).toMatch(/120 characters/i)
+  })
+
+  it('falls back to a generic message for an unknown or missing reason', () => {
+    expect(humanizeRenameReason(undefined)).toBe('Could not rename this proposal.')
+    expect(humanizeRenameReason('weird-reason')).toBe('Could not rename this proposal (weird-reason).')
   })
 })

--- a/orbit-www/src/components/features/discovery/discovery-ui.tsx
+++ b/orbit-www/src/components/features/discovery/discovery-ui.tsx
@@ -147,6 +147,19 @@ export function humanizeSkippedReason(reason?: string): string {
   return SKIPPED_REASON_LABELS[reason] ?? `Could not be imported (${reason}).`
 }
 
+const RENAME_REASON_LABELS: Record<string, string> = {
+  forbidden: 'You are not allowed to rename this proposal.',
+  'not-found': 'This proposal no longer exists.',
+  'invalid-status': 'Only proposed rows can be renamed.',
+  'invalid-name': 'Enter a name (up to 120 characters).',
+}
+
+/** Human-readable note for a failed rename (`renameDiscoveryCore` reason). */
+export function humanizeRenameReason(reason?: string): string {
+  if (!reason) return 'Could not rename this proposal.'
+  return RENAME_REASON_LABELS[reason] ?? `Could not rename this proposal (${reason}).`
+}
+
 export function KindBadge({ kind }: { kind: DiscoveredEntity['detectedKind'] }) {
   return (
     <Badge variant={kind === 'api' ? 'secondary' : 'default'} className="capitalize">

--- a/orbit-www/src/lib/discovery/actions-core.test.ts
+++ b/orbit-www/src/lib/discovery/actions-core.test.ts
@@ -237,17 +237,34 @@ describe('approveDiscoveriesCore', () => {
     expect(f.collections['api-schemas'][0]).toMatchObject({ createdBy: 'payload-user-9' })
   })
 
-  it('surfaces the import skippedReason (graphql) instead of throwing', async () => {
+  it('imports a graphql proposal into api-schemas', async () => {
     const f = fp()
     seedMember(f, 'ws1')
     seedDiscovery(f, {
       id: 'd1',
       detectedKind: 'api',
-      proposal: { name: 'graph', schemaType: 'graphql', rawContent: 'type Query' },
+      proposal: { name: 'graph', schemaType: 'graphql', rawContent: 'type Query { a: String }' },
     })
 
     const res = await approveDiscoveriesCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, ['d1'])
-    expect(res).toEqual([{ id: 'd1', imported: false, skippedReason: 'unsupported-schema-type:graphql' }])
+    expect(res).toEqual([
+      { id: 'd1', imported: true, ref: { collectionSlug: 'api-schemas', docId: expect.any(String) } },
+    ])
+    expect(f.collections['api-schemas']).toHaveLength(1)
+    expect(f.collections['api-schemas'][0]).toMatchObject({ schemaType: 'graphql' })
+  })
+
+  it('surfaces the import skippedReason for a genuinely unsupported schema type instead of throwing', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, {
+      id: 'd1',
+      detectedKind: 'api',
+      proposal: { name: 'proto', schemaType: 'protobuf', rawContent: 'syntax = "proto3";' },
+    })
+
+    const res = await approveDiscoveriesCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, ['d1'])
+    expect(res).toEqual([{ id: 'd1', imported: false, skippedReason: 'unsupported-schema-type:protobuf' }])
     expect(f.collections['api-schemas']).toHaveLength(0)
   })
 

--- a/orbit-www/src/lib/discovery/actions-core.test.ts
+++ b/orbit-www/src/lib/discovery/actions-core.test.ts
@@ -8,6 +8,7 @@ import {
   listGlobalDiscoveriesCore,
   approveDiscoveriesCore,
   ignoreDiscoveriesCore,
+  renameDiscoveryCore,
   startWorkspaceScanCore,
   startInstallationScanCore,
 } from './actions-core'
@@ -420,6 +421,121 @@ describe('ignoreDiscoveriesCore', () => {
     ])
     expect(f.collections['discovered-entities'].find((d) => d.id === 'mine')?.status).toBe('ignored')
     expect(f.collections['discovered-entities'].find((d) => d.id === 'theirs')?.status).toBe('proposed')
+  })
+})
+
+// --- renameDiscoveryCore (Phase 3, WI8) --------------------------------------
+
+describe('renameDiscoveryCore', () => {
+  it('renames a proposed row, trims the name, and preserves other proposal keys', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, {
+      id: 'd1',
+      proposal: { name: 'schema', schemaType: 'graphql', specPath: 'schema.graphql' },
+    })
+
+    const res = await renameDiscoveryCore(
+      payloadOf(f),
+      AUTH_ID,
+      'payload-user-9',
+      false,
+      'd1',
+      '  Billing GraphQL API  ',
+    )
+
+    expect(res).toEqual({ ok: true })
+    expect(f.collections['discovered-entities'][0].proposal).toEqual({
+      name: 'Billing GraphQL API',
+      schemaType: 'graphql',
+      specPath: 'schema.graphql',
+    })
+  })
+
+  it('forbids a non-member from renaming a workspace row', async () => {
+    const f = fp()
+    seedDiscovery(f, { id: 'd1', workspace: 'ws1', proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, 'd1', 'New name')
+
+    expect(res).toEqual({ ok: false, reason: 'forbidden' })
+    expect((f.collections['discovered-entities'][0].proposal as Record<string, unknown>).name).toBe('schema')
+  })
+
+  it('forbids a non-admin from renaming a global row', async () => {
+    const f = fp()
+    seedMember(f, 'ws1') // member elsewhere — the row itself is global
+    seedDiscovery(f, { id: 'g1', workspace: undefined, proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, 'g1', 'New name')
+
+    expect(res).toEqual({ ok: false, reason: 'forbidden' })
+  })
+
+  it('lets a platform admin rename a global row', async () => {
+    const f = fp()
+    seedDiscovery(f, { id: 'g1', workspace: undefined, proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', true, 'g1', 'New name')
+
+    expect(res).toEqual({ ok: true })
+    expect((f.collections['discovered-entities'][0].proposal as Record<string, unknown>).name).toBe('New name')
+  })
+
+  it('rejects renaming an already-imported row', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, { id: 'd1', status: 'imported', proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, 'd1', 'New name')
+
+    expect(res).toEqual({ ok: false, reason: 'invalid-status' })
+  })
+
+  it('rejects renaming an ignored row', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, { id: 'd1', status: 'ignored', proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, 'd1', 'New name')
+
+    expect(res).toEqual({ ok: false, reason: 'invalid-status' })
+  })
+
+  it('rejects a whitespace-only name', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, { id: 'd1', proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', false, 'd1', '   ')
+
+    expect(res).toEqual({ ok: false, reason: 'invalid-name' })
+    expect((f.collections['discovered-entities'][0].proposal as Record<string, unknown>).name).toBe('schema')
+  })
+
+  it('rejects a name over 120 characters', async () => {
+    const f = fp()
+    seedMember(f, 'ws1')
+    seedDiscovery(f, { id: 'd1', proposal: { name: 'schema' } })
+
+    const res = await renameDiscoveryCore(
+      payloadOf(f),
+      AUTH_ID,
+      'payload-user-9',
+      false,
+      'd1',
+      'x'.repeat(121),
+    )
+
+    expect(res).toEqual({ ok: false, reason: 'invalid-name' })
+  })
+
+  it('returns not-found for a missing row', async () => {
+    const f = fp()
+
+    const res = await renameDiscoveryCore(payloadOf(f), AUTH_ID, 'payload-user-9', true, 'ghost', 'New name')
+
+    expect(res).toEqual({ ok: false, reason: 'not-found' })
   })
 })
 

--- a/orbit-www/src/lib/discovery/actions-core.ts
+++ b/orbit-www/src/lib/discovery/actions-core.ts
@@ -269,6 +269,77 @@ export async function ignoreDiscoveriesCore(
   return results
 }
 
+export type RenameResult = { ok: true } | { ok: false; reason: string }
+
+const MAX_PROPOSAL_NAME_LENGTH = 120
+
+/**
+ * Rename a single proposal (Phase 3, `docs/plans/2026-07-10-graphql-schema-import.md`):
+ * Drew chose inline rename over an approve-time confirm dialog, since a real org
+ * scan produces ~200+ proposals and per-approve friction is unacceptable. The
+ * edited name is written onto `proposal.name`, so both single and bulk approve
+ * import with it (`buildProposal`/the importers already read `proposal.name`
+ * first).
+ *
+ * Authorization mirrors `approveDiscoveriesCore`: workspace row → platform admin
+ * OR an active member of that workspace; global row → platform admin only.
+ * `actorUserId` isn't written anywhere (there's no "renamed by" field), but is
+ * kept in the signature so the `'use server'` wrapper resolves the caller
+ * identically to `approveDiscoveries`.
+ */
+export async function renameDiscoveryCore(
+  payload: Payload,
+  betterAuthId: string,
+  actorUserId: string,
+  isAdmin: boolean,
+  id: string,
+  name: string,
+): Promise<RenameResult> {
+  void actorUserId
+
+  let row: DiscoveredEntity
+  try {
+    row = (await payload.findByID({
+      collection: 'discovered-entities',
+      id,
+      depth: 0,
+      overrideAccess: true,
+    })) as DiscoveredEntity
+  } catch {
+    return { ok: false, reason: 'not-found' }
+  }
+
+  const workspaceId = relId(row.workspace)
+  const allowed = workspaceId
+    ? isAdmin || (await isMemberCached(payload, betterAuthId, workspaceId, new Map()))
+    : isAdmin // global rows: platform admin only
+  if (!allowed) {
+    return { ok: false, reason: 'forbidden' }
+  }
+
+  if (row.status !== 'proposed') {
+    return { ok: false, reason: 'invalid-status' }
+  }
+
+  const trimmed = name.trim()
+  if (!trimmed || trimmed.length > MAX_PROPOSAL_NAME_LENGTH) {
+    return { ok: false, reason: 'invalid-name' }
+  }
+
+  const proposal = (row.proposal && typeof row.proposal === 'object' && !Array.isArray(row.proposal)
+    ? row.proposal
+    : {}) as Record<string, unknown>
+
+  await payload.update({
+    collection: 'discovered-entities',
+    id,
+    overrideAccess: true,
+    data: { proposal: { ...proposal, name: trimmed } },
+  })
+
+  return { ok: true }
+}
+
 export interface StartedScan {
   installationId: string
   workflowId: string

--- a/orbit-www/src/lib/discovery/detectors.test.ts
+++ b/orbit-www/src/lib/discovery/detectors.test.ts
@@ -6,6 +6,7 @@ import {
   detectOwnershipHints,
   runDetectors,
   extractSpecMetadata,
+  extractGraphQLMetadata,
   isVendoredPath,
   DISCOVERY_FETCH_PATTERNS,
   type EvidenceBundle,
@@ -96,6 +97,42 @@ describe('extractSpecMetadata', () => {
   it('leaves serverUrls null when spec has no servers array', () => {
     const meta = extractSpecMetadata('openapi: 3.0.0\ninfo:\n  title: X\n  version: "1"\n')
     expect(meta!.serverUrls).toBeNull()
+  })
+})
+
+describe('extractGraphQLMetadata', () => {
+  it('counts fields across Query, Mutation, and Subscription', () => {
+    const sdl = `
+      type Query {
+        user(id: ID!): User
+        users: [User!]!
+      }
+      type Mutation {
+        createUser(name: String!): User
+      }
+      type Subscription {
+        userCreated: User
+      }
+      type User {
+        id: ID!
+        name: String!
+      }
+    `
+    const meta = extractGraphQLMetadata(sdl)
+    expect(meta).not.toBeNull()
+    // 2 Query fields + 1 Mutation field + 1 Subscription field = 4
+    // (the User type's own fields do not count)
+    expect(meta!.endpointCount).toBe(4)
+  })
+
+  it('returns 0 when there is no Query, Mutation, or Subscription type', () => {
+    const meta = extractGraphQLMetadata('type User {\n  id: ID!\n}\n')
+    expect(meta).not.toBeNull()
+    expect(meta!.endpointCount).toBe(0)
+  })
+
+  it('returns null for unparseable SDL', () => {
+    expect(extractGraphQLMetadata('type Query { this is not valid')).toBeNull()
   })
 })
 

--- a/orbit-www/src/lib/discovery/detectors.ts
+++ b/orbit-www/src/lib/discovery/detectors.ts
@@ -1,4 +1,5 @@
 import * as yaml from 'yaml'
+import { parse as parseGraphQL, Kind } from 'graphql'
 import { parseAppManifest, mapManifestToAppFields } from '@/lib/app-manifest'
 
 // --- Types ---
@@ -203,6 +204,37 @@ export function extractSpecMetadata(rawContent: string): SpecMetadata | null {
     serverUrls,
     endpointCount,
   }
+}
+
+export interface GraphQLSpecMetadata {
+  /** Total fields across top-level Query/Mutation/Subscription type definitions. */
+  endpointCount: number
+}
+
+const GRAPHQL_ROOT_TYPE_NAMES = new Set(['Query', 'Mutation', 'Subscription'])
+
+/**
+ * Parse GraphQL SDL and derive the metadata the catalog cares about. Returns
+ * `null` when the content does not parse as GraphQL — this is the
+ * GraphQL-analog of `extractSpecMetadata` (which is YAML-based and cannot
+ * read SDL), reused by the `api-schemas` beforeValidate hook.
+ */
+export function extractGraphQLMetadata(rawContent: string): GraphQLSpecMetadata | null {
+  let doc
+  try {
+    doc = parseGraphQL(rawContent)
+  } catch {
+    return null
+  }
+
+  let endpointCount = 0
+  for (const def of doc.definitions) {
+    if (def.kind === Kind.OBJECT_TYPE_DEFINITION && GRAPHQL_ROOT_TYPE_NAMES.has(def.name.value)) {
+      endpointCount += def.fields?.length ?? 0
+    }
+  }
+
+  return { endpointCount }
 }
 
 // --- detectOrbitManifest ---

--- a/orbit-www/src/lib/discovery/import.test.ts
+++ b/orbit-www/src/lib/discovery/import.test.ts
@@ -414,7 +414,7 @@ describe('importDiscoveredApi', () => {
     expect(f.collections['api-schemas']).toHaveLength(0)
   })
 
-  it('SKIPS graphql proposals with an explicit reason (schemaType not in api-schemas enum)', async () => {
+  it('imports graphql proposals into api-schemas', async () => {
     const f = fp()
     const d = discovery({
       detectedKind: 'api',
@@ -422,9 +422,34 @@ describe('importDiscoveredApi', () => {
     })
     f.collections['discovered-entities'] = [{ ...d } as Doc]
 
+    const res = await importDiscoveredApi(payloadOf(f), d, { actorUserId: 'user-9' })
+
+    expect(res.imported).toBe(true)
+    const schemas = f.collections['api-schemas']
+    expect(schemas).toHaveLength(1)
+    expect(schemas[0]).toMatchObject({
+      schemaType: 'graphql',
+      rawContent: 'type Query { a: String }',
+      repositoryPath: 'schema.graphql',
+    })
+    expect(f.collections['discovered-entities'][0].status).toBe('imported')
+    expect(f.collections['discovered-entities'][0].importedRef).toEqual({
+      collectionSlug: 'api-schemas',
+      docId: schemas[0].id,
+    })
+  })
+
+  it('SKIPS proposals with a genuinely unknown schema type', async () => {
+    const f = fp()
+    const d = discovery({
+      detectedKind: 'api',
+      proposal: { schemaType: 'protobuf', specPath: 'schema.proto', rawContent: 'syntax = "proto3";' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
     const res = await importDiscoveredApi(payloadOf(f), d)
 
-    expect(res).toEqual({ imported: false, skippedReason: 'unsupported-schema-type:graphql' })
+    expect(res).toEqual({ imported: false, skippedReason: 'unsupported-schema-type:protobuf' })
     expect(f.collections['api-schemas']).toHaveLength(0)
     // proposal row untouched — still available in the review queue
     expect(f.collections['discovered-entities'][0].status).toBe('proposed')

--- a/orbit-www/src/lib/discovery/import.ts
+++ b/orbit-www/src/lib/discovery/import.ts
@@ -20,7 +20,7 @@ import type { DiscoveredEntity } from '@/payload-types'
 
 export interface ImportResult {
   imported: boolean
-  /** Set when the proposal was intentionally not imported (e.g. graphql). */
+  /** Set when the proposal was intentionally not imported (e.g. an unsupported schema type). */
   skippedReason?: string
   ref?: { collection: string; id: string }
 }
@@ -42,12 +42,12 @@ export interface ImportOptions {
 }
 
 /**
- * `api-schemas` only supports these two schema types (see APISchemas.ts). The
- * `detectApiSpecs` detector can additionally emit 'graphql'; those proposals are
- * skipped on import rather than writing an invalid enum value — the proposal row
- * still lives in the review queue for visibility.
+ * `api-schemas` supports these schema types (see APISchemas.ts `schemaType`
+ * select). Any other value the `detectApiSpecs` detector could theoretically
+ * emit is skipped on import rather than writing an invalid enum value — the
+ * proposal row still lives in the review queue for visibility.
  */
-const SUPPORTED_API_SCHEMA_TYPES = new Set(['openapi', 'asyncapi'])
+const SUPPORTED_API_SCHEMA_TYPES = new Set(['openapi', 'asyncapi', 'graphql'])
 
 function relId(v: unknown): string | undefined {
   if (typeof v === 'string') return v
@@ -254,10 +254,10 @@ export async function importDiscoveredService(
 
 /**
  * Import an API proposal into an `api-schemas` row, letting the existing
- * projection emit the `api` entity + `exposes-api` relation. graphql proposals
- * are skipped (unsupported schemaType). Idempotent: an existing api-schemas row
- * for the same workspace + repositoryPath (+ App when known) is linked, not
- * duplicated.
+ * projection emit the `api` entity + `exposes-api` relation. A proposal with a
+ * schema type `api-schemas` does not support is skipped rather than written as
+ * an invalid enum value. Idempotent: an existing api-schemas row for the same
+ * workspace + repositoryPath (+ App when known) is linked, not duplicated.
  */
 export async function importDiscoveredApi(
   payload: Payload,
@@ -335,7 +335,7 @@ export async function importDiscoveredApi(
         workspace: workspaceId,
         visibility: 'workspace',
         status: 'draft',
-        schemaType: schemaType as 'openapi' | 'asyncapi',
+        schemaType: schemaType as 'openapi' | 'asyncapi' | 'graphql',
         rawContent,
         repositoryPath: specPath,
         ...(appId ? { repository: appId } : {}),

--- a/orbit-www/src/lib/discovery/ingest.ts
+++ b/orbit-www/src/lib/discovery/ingest.ts
@@ -122,16 +122,53 @@ function isTier1(detection: Detection): boolean {
 }
 
 /**
- * Build the persisted proposal, normalizing a fallen-back heuristic service name
- * to the repo name. `detectService` names a root-scope service literally
- * `'service'` when no build manifest gives one; the ingest side knows the real
- * repo name, so use it (handoff note from WP1).
+ * Generic spec filename stems that carry no real title info (`schema.graphql`,
+ * `openapi.yaml`, etc.) — an api proposal named after one of these gets
+ * renamed to something a human can recognize in the review queue.
+ */
+const GENERIC_API_NAME_STEMS = new Set([
+  'schema',
+  'index',
+  'api',
+  'types',
+  'main',
+  'openapi',
+  'swagger',
+  'asyncapi',
+])
+
+const SCHEMA_TYPE_LABELS: Record<string, string> = {
+  graphql: 'GraphQL',
+  openapi: 'OpenAPI',
+  asyncapi: 'AsyncAPI',
+}
+
+/**
+ * Build the persisted proposal, normalizing generic fallback names to something
+ * recognizable in the review queue.
+ * - `detectService` names a root-scope service literally `'service'` when no
+ *   build manifest gives one; the ingest side knows the real repo name, so use
+ *   it (handoff note from WP1).
+ * - `detectApiSpecs` names an api proposal after the spec filename stem when it
+ *   has no parsed title (`specTitle`); a generic stem (`schema`, `index`, `api`,
+ *   `types`, `main`, `openapi`, `swagger`, `asyncapi`) is renamed to
+ *   `` `${repoName} ${label} API` `` using the schema type as the label
+ *   (falls back to just `` `${repoName} API` `` for an unrecognized type).
  */
 function buildProposal(detection: Detection, repoName: string): Record<string, unknown> {
   const base = detection.proposal ?? {}
   let name = (base.name as string) ?? detection.name
   if (detection.kind === 'service' && detection.path === '' && (!name || name === 'service')) {
     name = repoName
+  }
+  if (
+    detection.kind === 'api' &&
+    !base.specTitle &&
+    name &&
+    GENERIC_API_NAME_STEMS.has(name.toLowerCase())
+  ) {
+    const label = SCHEMA_TYPE_LABELS[base.schemaType as string]
+    name = label ? `${repoName} ${label} API` : `${repoName} API`
   }
   return { ...base, name }
 }

--- a/orbit-www/src/lib/schema-validators.test.ts
+++ b/orbit-www/src/lib/schema-validators.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { validateGraphQL } from './schema-validators'
+
+describe('validateGraphQL', () => {
+  it('treats empty content as valid', () => {
+    expect(validateGraphQL('')).toEqual({ valid: true, errors: [] })
+    expect(validateGraphQL('   \n  ')).toEqual({ valid: true, errors: [] })
+  })
+
+  it('accepts valid SDL', () => {
+    const sdl = `
+      type Query {
+        user(id: ID!): User
+      }
+      type User {
+        id: ID!
+        name: String!
+      }
+    `
+    expect(validateGraphQL(sdl)).toEqual({ valid: true, errors: [] })
+  })
+
+  it('rejects unparseable SDL with a line/message error', () => {
+    const result = validateGraphQL('type Query { this is not valid')
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0].message).toEqual(expect.any(String))
+    expect(result.errors[0].line).toEqual(expect.any(Number))
+  })
+
+  it('rejects a dangling type keyword with no body', () => {
+    const result = validateGraphQL('type')
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+})

--- a/orbit-www/src/lib/schema-validators.test.ts
+++ b/orbit-www/src/lib/schema-validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateGraphQL } from './schema-validators'
+import { validateGraphQL, validateSchemaByType } from './schema-validators'
 
 describe('validateGraphQL', () => {
   it('treats empty content as valid', () => {
@@ -32,5 +32,33 @@ describe('validateGraphQL', () => {
     const result = validateGraphQL('type')
     expect(result.valid).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
+  })
+})
+
+// Dispatch coverage for the edit page (edit-api-client.tsx), which validates
+// live content by schemaType rather than always assuming OpenAPI (WI6).
+describe('validateSchemaByType', () => {
+  it('dispatches graphql content to validateGraphQL, accepting valid SDL', () => {
+    const sdl = 'type Query {\n  user(id: ID!): String\n}\n'
+    expect(validateSchemaByType(sdl, 'graphql')).toEqual({ valid: true, errors: [] })
+  })
+
+  it('dispatches graphql content to validateGraphQL, rejecting broken SDL with a line/message error', () => {
+    const result = validateSchemaByType('type Query { this is not valid', 'graphql')
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0].message).toEqual(expect.any(String))
+  })
+
+  it('dispatches openapi content to the OpenAPI validator', () => {
+    const result = validateSchemaByType('{}', 'openapi')
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.message.includes('OpenAPI'))).toBe(true)
+  })
+
+  it('dispatches asyncapi content to the AsyncAPI validator', () => {
+    const result = validateSchemaByType('{}', 'asyncapi')
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.message.includes('asyncapi'))).toBe(true)
   })
 })

--- a/orbit-www/src/lib/schema-validators.ts
+++ b/orbit-www/src/lib/schema-validators.ts
@@ -1,3 +1,4 @@
+import { parse as parseGraphQL, GraphQLError } from 'graphql';
 import { SchemaType } from '@/lib/proto/api_catalog_pb';
 
 export interface ValidationResult {
@@ -182,63 +183,35 @@ export function validateSchemaByType(content: string, schemaType: string): Valid
 }
 
 /**
- * Validates GraphQL schema syntax
+ * Validates GraphQL schema syntax using the `graphql` package's parser.
  */
 export function validateGraphQL(content: string): ValidationResult {
-  const errors: ValidationError[] = [];
-
   if (!content.trim()) {
     return { valid: true, errors: [] };
   }
 
-  // Basic GraphQL syntax validation
-  const lines = content.split('\n');
-  let inBlockComment = false;
-
-  lines.forEach((line, index) => {
-    const trimmedLine = line.trim();
-
-    // Handle block comments
-    if (trimmedLine.includes('"""')) {
-      inBlockComment = !inBlockComment;
-      return;
+  try {
+    parseGraphQL(content);
+    return { valid: true, errors: [] };
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      const location = error.locations?.[0];
+      return {
+        valid: false,
+        errors: [
+          {
+            line: location?.line,
+            column: location?.column,
+            message: error.message,
+          },
+        ],
+      };
     }
-    if (inBlockComment || trimmedLine.startsWith('#')) {
-      return;
-    }
-
-    // Check for valid GraphQL type definitions
-    if (trimmedLine && !trimmedLine.match(/^(type|interface|union|enum|input|scalar|schema|extend|directive|query|mutation|subscription)\s/)) {
-      // Check if it's part of a type definition (fields, etc.)
-      if (!trimmedLine.match(/^\w+(\(.*\))?:\s*[\w\[\]!]+/) &&
-          !trimmedLine.endsWith('{') &&
-          !trimmedLine.endsWith('}') &&
-          trimmedLine.length > 0) {
-        // This might be an error, but let's be lenient for now
-      }
-    }
-
-    // Check for unclosed braces
-    const openBraces = (line.match(/{/g) || []).length;
-    const closeBraces = (line.match(/}/g) || []).length;
-    if (openBraces > 1 || closeBraces > 1) {
-      errors.push({
-        line: index + 1,
-        message: 'Multiple braces on single line'
-      });
-    }
-  });
-
-  if (inBlockComment) {
-    errors.push({
-      message: 'Unclosed block comment'
-    });
+    return {
+      valid: false,
+      errors: [{ message: error instanceof Error ? error.message : 'Invalid GraphQL syntax' }],
+    };
   }
-
-  return {
-    valid: errors.length === 0,
-    errors
-  };
 }
 
 /**

--- a/orbit-www/src/payload-types.ts
+++ b/orbit-www/src/payload-types.ts
@@ -3416,15 +3416,15 @@ export interface ApiSchema {
    */
   visibility: 'private' | 'workspace' | 'public';
   /**
-   * Schema format (OpenAPI and AsyncAPI supported)
+   * Schema format (OpenAPI, AsyncAPI, GraphQL supported)
    */
-  schemaType: 'openapi' | 'asyncapi';
+  schemaType: 'openapi' | 'asyncapi' | 'graphql';
   /**
    * Current version string (from OpenAPI info.version)
    */
   currentVersion?: string | null;
   /**
-   * OpenAPI specification content
+   * OpenAPI, AsyncAPI, GraphQL specification content
    */
   rawContent: string;
   status: 'draft' | 'published' | 'deprecated';

--- a/orbit-www/src/types/api-catalog.ts
+++ b/orbit-www/src/types/api-catalog.ts
@@ -7,7 +7,7 @@ export interface APISchema {
   description?: string | null
   workspace: string | { id: string; slug: string; name?: string }
   visibility: 'private' | 'workspace' | 'public'
-  schemaType: 'openapi' | 'asyncapi'
+  schemaType: 'openapi' | 'asyncapi' | 'graphql'
   currentVersion?: string | null
   rawContent?: string | null
   status: 'draft' | 'published' | 'deprecated'


### PR DESCRIPTION
## Summary

Approving a GraphQL proposal in Catalog Discovery previously skipped the import with `unsupported-schema-type:graphql` ("GRAPHQL specs aren't importable yet" in the UI), because `api-schemas` only accepted `openapi`/`asyncapi`. This PR makes GraphQL a first-class schema type on the workspace import path, makes the resulting rows editable and sanely named, and adds pre-import name review to the discovery queue.

### Phase 1 — import support (05cedc9)
- **`api-schemas` collection**: `schemaType` select gains `graphql`; the beforeValidate hook branches to a new GraphQL-aware metadata extractor instead of misfiring the YAML-based one on SDL.
- **New `extractGraphQLMetadata()`** (`lib/discovery/detectors.ts`): parses SDL with the `graphql` package, counts fields across `Query`/`Mutation`/`Subscription` as `endpointCount`; returns `null` on unparseable content.
- **Importer** (`lib/discovery/import.ts`): `graphql` added to `SUPPORTED_API_SCHEMA_TYPES`; genuinely unknown types still skip with an explicit reason.
- **`validateGraphQL`** rewritten from a regex heuristic to real parsing via `graphql`'s `parse()`, with line/column error locations.
- **API detail viewer** (`APISpecViewer`): new optional `schemaType` prop — `graphql` renders the SDL in a scrollable code block instead of feeding it to Scalar (which errored with "Invalid specification format"). OpenAPI/AsyncAPI behavior unchanged.
- Types widened (`types/api-catalog.ts`, regenerated `payload-types.ts`).

### Phase 2 — edit flow + naming (f78e1ae, 59f9581)
- **Edit page was un-usable for GraphQL rows**: it validated ALL content as OpenAPI, permanently disabling Save with bogus errors. Now validates via `validateSchemaByType(rawContent, schemaType)`, retitles the spec card per type, and switches Monaco to GraphQL syntax highlighting. Live validation shows real GraphQL parse errors (with line numbers) as you type.
- **Sane default names**: api proposals with no parsed spec title and a generic filename stem (`schema`, `index`, `api`, `types`, `main`, `openapi`, `swagger`, `asyncapi`) are renamed at ingest to `<repo> <SchemaType> API` (e.g. `booksrus GraphQL API`) instead of surfacing as "schema".
- **Metadata refresh on update**: the beforeValidate hook now resolves `schemaType` from `originalDoc` when the partial update omits it, so editing GraphQL content refreshes `endpointCount` instead of leaving it stale.

### Phase 3 — name review before import (f59690c)
- **Review-queue rows now display the proposed entity name** (previously only kind/confidence/path/schema type — you approved imports blind).
- **Inline rename on proposed rows**: pencil → input, Enter saves / Escape cancels; the edit persists to `proposal.name`, so both single and bulk approve import with it. Deliberately no approve-time confirm dialog: a real org scan produces ~266 proposals, and bulk approve would bypass a dialog anyway.
- **`renameDiscoveryCore`** with the same per-row RBAC as approve (workspace row → platform admin or active member; global row → admin only), gated to `proposed` rows, trimmed/length-validated.

Plan doc: `docs/plans/2026-07-10-graphql-schema-import.md`

## Out of scope (follow-ups)
- Manual "New API" wizard still OpenAPI/AsyncAPI-only.
- GraphiQL-style doc viewer (SDL code block is Phase 1).

## Testing

- TDD throughout; touched vitest suites all passing (import, actions-core, detectors, schema-validators, discovery ingest route, discovery-ui — incl. 9 new rename-core RBAC tests).
- `bunx tsc --noEmit`: 0 errors.
- Live browser verification on local dev:
  - Approved the `drewpayment/booksrus` GraphQL proposal → Imported, api-schemas row with `schemaType: graphql`, detail page shows endpoint count from the SDL extractor and renders the schema as a code block.
  - Renamed the row via the edit page; broke the SDL mid-edit → "Line 69: Syntax Error: Expected Name" shown live, Save disabled; fixed → re-enabled. Content edit → release-notes dialog → new version (Versions 1→2); added a Query field → endpoint count refreshed 14→15.
  - Phase 3 loop: proposed row displays its name with a pencil; inline rename saved on Enter, survived a hard reload, and the subsequent approve imported the entity with the edited name ("BooksRUs Storefront GraphQL", verified in Mongo). Test artifacts cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)