### PR TITLE
feat(discovery): monorepo-aware catalog discovery (Phase 1)

### DIFF
--- a/docs/plans/2026-07-19-catalog-representation-gaps.md
+++ b/docs/plans/2026-07-19-catalog-representation-gaps.md
@@ -1,0 +1,382 @@
+# Catalog Representation Gaps — Self-Hosted / Monorepo Applications
+
+**Date:** 2026-07-19
+**Status:** Proposed
+**Origin:** Dogfooding exercise — attempting to register `drewpayment/sprinklergoose`
+(a monorepo with a Next.js UI, a FastAPI executor, a shared Postgres, a Rain Bird
+hardware controller dependency, deployed to a home Kubernetes cluster) exposed six
+gaps in how the catalog represents real-world self-hosted applications.
+
+## Gap list (what this plan resolves)
+
+| # | Gap | Resolution (phase) |
+|---|-----|--------------------|
+| 1 | Go scan worker only collects build manifests/Dockerfiles at repo root, so monorepo sub-apps are never proposed | Phase 1 |
+| 2 | No deployed-URL / hosting representation on entities | Phase 2 |
+| 3 | No way to distinguish a hardware device / postgres / etc. within a kind (`resource`/`datastore` are opaque buckets) | Phase 2 |
+| 4 | `.orbit.yaml` can only declare a single `Application` — no systems, datastores, resources, relations, or ownership | Phase 3 |
+| 5 | A public repo without a GitHub App installation can only be an inert manual entry | Phase 4 |
+| 6 | Ownership requires a `team` entity — no solo-developer path | Phase 5 |
+
+Phases 1, 4, and 5 are independent of each other. Phase 2 must land before
+Phase 3 (the v2 manifest writes the fields Phase 2 adds). Phase 6 is the
+end-to-end dogfood verification using sprinklergoose itself.
+
+Each phase is a separate PR off `main`. TDD throughout: write the failing test
+first, then implement. Frontend tests are vitest (`bunx vitest run <path>`),
+Go tests are table-driven testify (`go test -v -race ./...`).
+
+## Design decisions (recommendations — veto here before implementation)
+
+1. **Subtype over new kinds.** Rather than adding `device`/`website` kinds (each
+   new kind touches ~8 files: `constants.ts`, `entity-kind-meta.ts`,
+   `EntityKindBadge.tsx`, `projection.ts`, `evaluate.ts`, `rule-builder.ts`,
+   `EntityTypes.ts`, discovery UI), add one optional free-text `subtype` field
+   rendered as a badge. `resource` + subtype `iot-device`, `datastore` + subtype
+   `postgresql`. Kind stays the scoring/graph axis; subtype is descriptive.
+2. **`runtime` group over polluting `links`.** A first-class
+   `runtime { url, platform, notes }` group on `catalog-entities` answers
+   "where does this run and how do I reach it." Topology ("runs in *which*
+   environment") stays in the graph via `runs-in` edges — the two are
+   complementary, not redundant.
+3. **Manifest v2 is a superset, parsed with zod.** `apiVersion: orbit.dev/v2`,
+   `kind: System`, with a `spec.entities` list and inline relation declarations.
+   v1 (`kind: Application`) continues to parse forever via the existing
+   hand-rolled path; v2 gets a zod schema (zod is already a frontend dep).
+4. **Personal ownership via auto-provisioned personal team**, not a polymorphic
+   `owner` field. Polymorphic owner (team-or-user) ripples through `owns`
+   relations, scorecard golden-path checks, and `isTeamEntity` authz. A
+   one-click "Create my personal team" affordance gets the same UX for a tiny
+   fraction of the blast radius.
+5. **Public-repo import = explicit degraded mode, one-shot anonymous scan.**
+   The `importRepository` server action already accepts a URL with no
+   `installationId`/`connectionId`; we make that path intentional: label the
+   app "read-only / not connected", run a single anonymous GitHub API scan at
+   import time (unauthenticated rate limit is 60 req/hr — one tree + ≤10 file
+   fetches per import, no polling ever), and surface an "install the GitHub App
+   to enable sync/health" upgrade prompt.
+
+---
+
+## Phase 1 — Monorepo-aware discovery (Go worker subdirectory collection)
+
+**Why first:** the TS detectors (`detectService`, `detectApiSpecs`) already
+group signals per directory and emit one proposal per subdir — they just never
+receive subdirectory build manifests because the Go side filters them out.
+Zero schema changes; immediately makes sprinklergoose scan as two services.
+
+### Tasks
+
+1. **Relax `classifyWellKnown`** in
+   `temporal-workflows/internal/activities/catalog_scan_activities.go` (~L406):
+   - Allow build manifests (`package.json`, `go.mod`, `pom.xml`, `Cargo.toml`,
+     `pyproject.toml`, `requirements.txt`), `Dockerfile`, and `docker-compose*`
+     at **any non-vendored path up to depth 3**, not just `isRoot`.
+   - Allow `.orbit.yaml` / `.orbit.yml` at non-root paths (needed by Phase 3;
+     harmless now — the TS detector ignores non-root manifests until then).
+   - Keep the vendored-path exclusion (`isVendoredPath`) authoritative.
+   - TDD: extend `TestClassifyWellKnown` and `TestSelectWellKnownFiles` in
+     `catalog_scan_activities_test.go` with monorepo cases
+     (`apps/web-next/package.json`, `apps/api/pyproject.toml`,
+     `apps/api/Dockerfile`, and a `node_modules/x/package.json` negative).
+2. **Raise the per-repo file cap** (`maxFilesPerRepo`, currently 40) to 80 and
+   make selection prioritized: Tier-1 manifests → root files → shallowest
+   subdir build manifests → API specs → k8s. Add a test asserting priority
+   order when over cap.
+3. **Mirror in the ADO activity**
+   (`temporal-workflows/internal/activities/ado_scan_activities.go`) — same
+   classification change, extend `ado_scan_activities_test.go`.
+4. **Keep the sync-pair invariant honest:** update `DISCOVERY_FETCH_PATTERNS`
+   in `orbit-www/src/lib/discovery/detectors.ts` (~L39) only if patterns
+   actually change; update the invariant header comments in both files
+   (detectors.ts L33-38, catalog_scan_activities.go L297-301).
+5. **Dedupe check:** confirm `computeDedupeKey`
+   (`orbit-www/src/lib/discovery/import.ts` L84) already includes `path` — it
+   does — so two services in one repo produce distinct `discovered-entities`
+   rows. Add a vitest case in
+   `orbit-www/src/app/api/internal/discovery/ingest/route.test.ts`: one bundle
+   containing two subdir services → two proposals, re-ingest → no dupes.
+
+### Verification
+
+- `cd temporal-workflows && go test -v -race ./...`
+- `cd orbit-www && bunx vitest run src/lib/discovery src/app/api/internal/discovery`
+- Manual: trigger a scan against a monorepo installation and confirm two
+  service proposals with distinct `path` values appear in `/discovery`.
+
+### Implementation notes (2026-07-20, as shipped)
+
+Implemented as planned, plus changes driven by adversarial review + live QA:
+
+- **Anti-noise gate (new):** a non-root directory needs ≥2 signal classes
+  (build manifest / container file / k8s evidence) before `detectService`
+  proposes it — otherwise every workspace package in a pnpm/turbo monorepo
+  becomes a proposal. Root behavior unchanged. A sub-app with only a build
+  manifest can opt in later via a subdir `.orbit.yaml` (Phase 3).
+- **Path-aware Apps (new, critical):** live QA proved approving two proposals
+  from one repo silently collapsed into one App (`findRepoApp` was repo-keyed,
+  second approve no-op'd). Added `repository.path` to `Apps` and keyed
+  `findRepoApp` on (workspace, owner, name, path); legacy path-less apps match
+  root proposals.
+- **Deterministic API→App linking (new):** `importDiscoveredApi` now picks the
+  App whose `repository.path` is the longest segment-boundary ancestor of the
+  spec's directory (`pickNearestApp`), root App as fallback — previously an
+  arbitrary first match, wrong once repos have multiple apps.
+- **k8s anchor fix:** `detectService` anchored `apps/svc/k8s/x.yaml` to `apps`
+  and root `k8s/x.yaml` to a bogus scope; rewritten as a segment scan
+  (pre-existing bug the gate made consequential).
+- **Priority/depth details:** composite fetch priority `class*10 + min(depth,9)`
+  (clamped so class always dominates); TS enforces the same depth-3 subdir
+  bound as Go (`MAX_SUBDIR_SERVICE_DEPTH`); `compose.yml`/`compose.yaml`
+  now matched Go-side; k8s dir sets (`deployments`, `charts`) synced TS↔Go.
+- **Deliberately not done:** case-sensitive filename matching (pre-existing,
+  both sides); deep compose under k8s dirs no longer classified (content was
+  never parsed — inert); `catalog-info.yaml` stays root-only and unparsed.
+
+---
+
+## Phase 2 — Entity fields: `runtime` group + `subtype`
+
+### Tasks
+
+1. **Schema** — `orbit-www/src/collections/catalog/CatalogEntities.ts`:
+   - `subtype`: optional text, index with kind.
+   - `runtime` group: `url` (text, validated URL), `platform` (select:
+     `kubernetes | vps | home-server | paas | serverless | other`), `notes`
+     (textarea).
+2. **CRUD layer** — `orbit-www/src/lib/catalog/entity-crud.ts`:
+   - Add `subtype` and `runtime` to `CURATION_FIELDS` (editable even on
+     projected entities — they're human curation, not projection-owned).
+   - Extend `CreateEntityInput` / `UpdateEntityPatch` + `validateCreateInput` /
+     `validateUpdatePatch` (URL validation mirroring `validateLinks`).
+   - TDD in `orbit-www/src/lib/catalog/entity-crud.test.ts`.
+3. **Form** — `EntityForm` under
+   `orbit-www/src/components/features/catalog/entity-form/` (+
+   `entity-form-ui.ts`): subtype input with per-kind placeholder suggestions
+   (datastore → "postgresql, redis…", resource → "iot-device, bucket…");
+   runtime section with URL/platform/notes.
+4. **Detail view** — `orbit-www/src/components/features/catalog/EntityDetail.tsx`:
+   subtype badge next to `EntityKindBadge`; "Runtime" card on the Overview tab
+   (linked URL, platform label, notes) shown only when populated.
+5. **List** — `EntityListItem.tsx`: subtype as a muted suffix on the kind badge.
+6. **Do not** touch `projection.ts` — both fields are curation-only; verify
+   `mergeProjectionUpdate` leaves them intact (add a case to
+   `orbit-www/src/lib/catalog/projection.test.ts`).
+
+### Verification
+
+- `bunx vitest run src/lib/catalog`
+- `bunx tsc --noEmit` (keep the 0-error baseline)
+- agent-browser (with pre/post-flight pgrep hygiene): create a `datastore`
+  with subtype `postgresql` and a runtime URL at `/catalog/new`, confirm
+  render on detail + list, confirm editing a *projected* entity's
+  subtype/runtime persists across a re-projection.
+
+---
+
+## Phase 3 — Manifest v2: declare a whole system in one file
+
+### Format
+
+```yaml
+apiVersion: orbit.dev/v2
+kind: System
+metadata:
+  name: sprinklergoose
+  description: Self-hosted irrigation control
+spec:
+  owner: drews-team                # optional: team entity slug
+  environment: home-k8s            # optional: environment entity slug → runs-in edges
+  entities:
+    - kind: service
+      name: web-next
+      path: apps/web-next          # scopes health/build detection to this dir
+      runtime: { url: https://sprinklers.example.com, platform: kubernetes }
+      build: { language: typescript, framework: nextjs }
+      dependsOn: [api-executor, sprinklergoose-db]
+      consumesApis: [executor-api]
+    - kind: service
+      name: api-executor
+      path: apps/api
+      health: { endpoint: /healthz, interval: 60 }
+      dependsOn: [sprinklergoose-db, rainbird-controller]
+      exposesApis:
+        - name: executor-api
+          schemaType: openapi
+          specPath: apps/api/openapi.json
+    - kind: datastore
+      name: sprinklergoose-db
+      subtype: postgresql
+    - kind: resource
+      name: rainbird-controller
+      subtype: iot-device
+```
+
+Semantics: the file itself yields a `system` entity; every listed entity gets a
+`part-of` edge to it; `dependsOn` → `depends-on` edges; `exposesApis` →
+`api-schemas` row (when `specPath` resolves) + `exposes-api` edge;
+`consumesApis` → `consumes-api` edge; `environment` → `runs-in` edges from
+each service. Relation targets are names within the file (or existing entity
+slugs in the same workspace). Unresolvable references are validation errors at
+detect time, surfaced as evidence on the proposal — never silently dropped.
+
+### Tasks
+
+1. **Parser** — new `orbit-www/src/lib/app-manifest-v2.ts`: zod schema
+   (`AppManifestV2`), `parseManifest(content)` dispatcher that sniffs
+   `apiVersion` and routes v1 content to the existing `parseAppManifest` in
+   `app-manifest.ts` (untouched). Cross-reference validation (dependsOn/
+   consumesApis names resolve within the file). TDD:
+   `app-manifest-v2.test.ts` — valid full example, unknown kind, dangling
+   dependsOn, v1 passthrough.
+2. **Detector** — `orbit-www/src/lib/discovery/detectors.ts`:
+   - `detectOrbitManifest` (~L244) handles v2: emits one detection per
+     declared entity plus one for the system, all `confidence: 'high'`,
+     Tier-1 authoritative for their `path` (suppressing heuristic duplicates,
+     same as v1 today).
+   - Widen `Detection['kind']` from `'service' | 'api'` to include
+     `'system' | 'datastore' | 'resource'`.
+   - Carry the declared relations on the proposal JSON
+     (`proposal.relations: [{type, targetName}]`).
+3. **Review queue schema** —
+   `orbit-www/src/collections/discovery/DiscoveredEntities.ts`: widen
+   `detectedKind` enum to match; group related proposals visually by a shared
+   `manifestKey` (owner/repo/manifestPath) so a v2 manifest reads as one unit
+   in `/discovery` (`discovery-ui.tsx`, `ProposalRow.tsx`).
+4. **Import** — `orbit-www/src/lib/discovery/import.ts`:
+   - `importDiscovery` switch: `datastore`/`resource`/`system` → direct
+     `catalog-entities` creation (reuse the `importDiscoveredGlobalEntity`
+     shape but workspace-scoped), `source: { type: 'scan' }`, carrying
+     `subtype`/`runtime` from the proposal (Phase 2 fields).
+   - New `materializeRelations(payload, workspaceId, imported)` — after the
+     entities of one manifest are imported, create `catalog-relations` edges
+     (`part-of`, `depends-on`, `runs-in`, `exposes-api`, `consumes-api`),
+     idempotent on `(from, to, type)`. Import order within a manifest:
+     system → non-service entities → services → relations.
+   - TDD in `import.test.ts` (FakePayload — note it hides ObjectId casting;
+     use doc ids for relationships per prior gotcha).
+5. **Apps sync** — `orbit-www/src/collections/Apps.ts` outbound sync and
+   `src/app/actions/apps.ts` inbound: v2 manifests are **sync-exempt in this
+   phase** (outbound sync short-circuits when the file at `manifestPath`
+   parses as v2; log + set `conflictDetected: false`). Bidirectional v2 sync
+   is a follow-up — writing a multi-entity file from single-app state is
+   lossy and needs its own design.
+6. **Subdir v1 manifests** (small bonus): with Phase 1 collecting non-root
+   `.orbit.yaml`, drop the root-only restriction in `detectOrbitManifest` so
+   `apps/api/.orbit.yaml` (v1) proposes a service at that path — an
+   alternative to v2 for people who prefer one file per app.
+7. **Docs** — update README catalog section + add
+   `.agent/SOPs/orbit-manifest.md` documenting both versions.
+
+### Verification
+
+- `bunx vitest run src/lib/app-manifest-v2.test.ts src/lib/discovery`
+- `bunx tsc --noEmit`
+- Manual end-to-end: commit the sprinklergoose v2 manifest above to a test
+  repo, scan, approve the grouped proposals, confirm in `/catalog`: system +
+  2 services + datastore + resource, Relations tab and Neighbourhood graph
+  showing part-of / depends-on / exposes-api edges.
+
+---
+
+## Phase 4 — Public repo import without an installation
+
+### Tasks
+
+1. **Form** — `orbit-www/src/components/features/apps/ImportAppForm.tsx`: add
+   a third source option "Public repository (read-only)" alongside GitHub
+   installations and ADO connections; accepts a `github.com/owner/repo` URL,
+   shows an explicit capability note (no sync, no health checks, no webhooks —
+   one-time scan only) with an "install the GitHub App to upgrade" link.
+2. **Anonymous GitHub client** — new `orbit-www/src/lib/github/public.ts`:
+   `fetchPublicRepoInfo`, `fetchPublicTree`, `fetchPublicFile` via
+   unauthenticated `api.github.com` (reuse `parseGitHubUrl` from
+   `src/lib/github-manifest.ts`). Hard budget: ≤12 requests per import, typed
+   rate-limit error mapped to a friendly "GitHub rate limit — try again in an
+   hour or connect the App" message. Never called from hooks/cron — import
+   action only.
+3. **Server action** — `importRepository` in `orbit-www/src/app/actions/apps.ts`
+   (~L95): when neither `installationId` nor `connectionId` is present and the
+   URL is a valid public GitHub repo, set `origin.type: 'imported'`,
+   `repository.provider: 'github'` with no installation, run the one-shot
+   scan: fetch tree + root/near-root well-known files, build an
+   `EvidenceBundle`, run `runDetectors` **in-process** (no
+   `discovered-entities` rows — import directly, reusing the Phase 3 import
+   helpers). A v1/v2 `.orbit.yaml` in the repo thus works fully on a public
+   repo with zero installation.
+4. **Degraded-state UI** — app detail page: "Not connected" badge where
+   sync/health status normally renders; verify the existing short-circuits
+   (`Apps.ts` outbound sync L87 `!installationId`, health/webhook deletion
+   guards) already no-op cleanly — add a vitest around the sync hook guard.
+5. **TDD:** extend `orbit-www/src/app/actions/__tests__/apps.test.ts`
+   (URL-only import creates app + entities, rate-limit error path) and
+   `ImportAppForm.test.tsx` (third source renders, capability note shown).
+
+### Verification
+
+- `bunx vitest run src/app/actions/__tests__/apps.test.ts src/components/features/apps`
+- agent-browser: import `https://github.com/drewpayment/sprinklergoose` with
+  no installation selected → app appears with "Not connected" badge, catalog
+  entities created from its manifest.
+
+---
+
+## Phase 5 — Personal ownership: one-click personal team
+
+### Tasks
+
+1. **Helper** — new `orbit-www/src/lib/catalog/personal-team.ts`:
+   `ensurePersonalTeam(payload, { workspaceId, userId, userName })` — find-or-
+   create a `catalog-entities` row `kind: 'team'`, slug
+   `personal-<user-slug>`, `source: { type: 'manual' }`, `metadata.personalFor:
+   <userId>`; idempotent per (workspace, user). TDD:
+   `personal-team.test.ts`.
+2. **Owner picker** — in `EntityForm`'s owner select: when the workspace has
+   no team entities (or none owned by the user), render "＋ Create my personal
+   team" which calls a server action wrapping `ensurePersonalTeam` (authz:
+   active workspace member, via existing `canCreateEntity`) and selects the
+   result.
+3. **Import default** — Phase 3/4 import paths: when a manifest declares no
+   `owner` and the importing user confirms, default owner to their personal
+   team (surfaced in the approve dialog, not silent).
+4. Existing `isTeamEntity` validation (`entity-authz.ts` L94) is untouched —
+   personal teams are real `team` entities, so scorecards, `owns` edges, and
+   golden-path checks work unchanged.
+
+### Verification
+
+- `bunx vitest run src/lib/catalog/personal-team.test.ts`
+- agent-browser: fresh workspace with zero teams → create entity → one-click
+  personal team → owner renders on detail; second entity reuses the same team.
+
+---
+
+## Phase 6 — Dogfood: register sprinklergoose end-to-end
+
+Not a code phase — the acceptance test for the whole plan.
+
+1. Add the v2 manifest (Phase 3 format above) to `drewpayment/sprinklergoose`.
+2. Path A (connected): install the GitHub App on the repo, scan, approve the
+   grouped proposals.
+3. Path B (public): remove the app from a test workspace and re-import via the
+   Phase 4 public-URL flow; confirm parity of the resulting entity graph.
+4. Confirm the full graph renders: `system` sprinklergoose; services
+   `web-next` + `api-executor` (`part-of`, `runs-in` home-k8s, runtime URLs);
+   `datastore` subtype `postgresql`; `resource` subtype `iot-device`;
+   `api` executor-api with `exposes-api`/`consumes-api` edges; owner = personal
+   team. Legacy `apps/web` deliberately not manifested (or added with
+   lifecycle `deprecated`).
+5. File any friction found as issues — that output is the point.
+
+---
+
+## Out of scope (explicitly deferred)
+
+- Bidirectional sync of v2 manifests (outbound write-back) — needs its own design.
+- Parsing Backstage `catalog-info.yaml` (Go already fetches it; TS ignores it) —
+  natural follow-up to the v2 parser, tracked separately.
+- Polymorphic (user-valued) `owner` field — rejected in favor of personal teams.
+- New entity kinds (`device`, `website`) — rejected in favor of `subtype`.
+- ADO public-repo parity and the ADO outbound-sync gap (`Apps.ts` L87
+  short-circuits on missing `installationId`, so ADO apps never outbound-sync) —
+  pre-existing, worth its own fix.

--- a/orbit-www/src/app/api/internal/discovery/ingest/route.test.ts
+++ b/orbit-www/src/app/api/internal/discovery/ingest/route.test.ts
@@ -262,6 +262,47 @@ describe('ingestScan', () => {
     expect(row.importedRef).toEqual({ collectionSlug: 'apps', docId: f.collections['apps'][0].id })
   })
 
+  it('creates two distinct proposals for two subdirectory services in one bundle (monorepo), idempotent on re-ingest', async () => {
+    const f = new FakePayload()
+    // A monorepo evidence bundle: two sub-apps, each with a build manifest +
+    // Dockerfile. detectService groups by directory, so this yields one service
+    // detection per sub-app with a distinct `path`.
+    const monorepoBundle = {
+      tree: [
+        'apps/web-next/package.json',
+        'apps/web-next/Dockerfile',
+        'apps/api/pyproject.toml',
+        'apps/api/Dockerfile',
+      ],
+      files: {
+        'apps/web-next/package.json': '{"name":"web-next","dependencies":{"next":"14.0.0"}}',
+        'apps/api/pyproject.toml': '[project]\nname = "api"\ndependencies = ["fastapi"]\n',
+      },
+    }
+
+    const counts = await ingestScan(p(f), body({ bundle: monorepoBundle }))
+
+    expect(counts).toEqual({ proposed: 2, imported: 0, skippedIgnored: 0 })
+    const rows = f.collections['discovered-entities']
+    expect(rows).toHaveLength(2)
+    // Two distinct paths — one proposal per sub-app directory.
+    const paths = rows.map((r) => r.path).sort()
+    expect(paths).toEqual(['apps/api', 'apps/web-next'])
+    // dedupeKey folds in `path`, so the two rows never collide.
+    expect(rows[0].dedupeKey).not.toBe(rows[1].dedupeKey)
+    for (const r of rows) {
+      expect(r.detectedKind).toBe('service')
+      expect(r.status).toBe('proposed')
+    }
+
+    // Re-ingesting the same bundle refreshes the existing rows — no duplicates.
+    await ingestScan(p(f), body({ bundle: monorepoBundle, scanRunId: 'run-2' }))
+    expect(f.collections['discovered-entities']).toHaveLength(2)
+    for (const r of f.collections['discovered-entities']) {
+      expect(r.scanRunId).toBe('run-2')
+    }
+  })
+
   it('creates an api proposal (not auto-imported) for an OpenAPI spec', async () => {
     const f = new FakePayload()
     const counts = await ingestScan(p(f), body({ bundle: apiBundle() }))

--- a/orbit-www/src/collections/Apps.ts
+++ b/orbit-www/src/collections/Apps.ts
@@ -256,6 +256,15 @@ export const Apps: CollectionConfig = {
           type: 'text',
         },
         {
+          name: 'path',
+          type: 'text',
+          admin: {
+            description:
+              'Monorepo sub-app directory relative to the repo root (e.g. "apps/api"). ' +
+              'Empty/absent = repo root. Distinguishes multiple apps discovered from one repo.',
+          },
+        },
+        {
           name: 'url',
           type: 'text',
         },

--- a/orbit-www/src/lib/discovery/detectors.test.ts
+++ b/orbit-www/src/lib/discovery/detectors.test.ts
@@ -273,11 +273,14 @@ describe('detectService', () => {
   })
 
   it('produces one detection per path scope in a monorepo', () => {
+    // Non-root scopes each need ≥2 signal classes to emit (see the subdir
+    // asymmetry test below), so every sub-app here carries a build + container.
     const detections = detectService(
       bundle({
         'services/a/go.mod': 'module a\n',
         'services/a/Dockerfile': 'FROM golang',
         'services/b/package.json': '{"name":"b"}',
+        'services/b/Dockerfile': 'FROM node',
       }),
     )
     const paths = detections.map((d) => d.path).sort()
@@ -291,6 +294,84 @@ describe('detectService', () => {
       bundle({ 'docker-compose.yml': 'services: {}', 'go.mod': 'module x\n' }),
     )
     expect(detections[0].confidence).toBe('high')
+  })
+
+  it('emits nothing for a lone build manifest in a subdirectory (monorepo package noise)', () => {
+    // A pnpm/turbo monorepo has one package.json per workspace package; a lone
+    // subdir manifest must NOT propose a service or /discovery floods.
+    const detections = detectService(bundle({ 'packages/lib-a/package.json': '{"name":"lib-a"}' }))
+    expect(detections).toHaveLength(0)
+  })
+
+  it('still emits for a lone build manifest at the repo root (root asymmetry preserved)', () => {
+    const detections = detectService(bundle({ 'package.json': '{"name":"root-app"}' }))
+    expect(detections).toHaveLength(1)
+    expect(detections[0].path).toBe('')
+    expect(detections[0].confidence).toBe('medium')
+  })
+
+  it('emits for a subdirectory with two signal classes (build + container)', () => {
+    const detections = detectService(
+      bundle({
+        'apps/api/pyproject.toml': '[project]\nname = "api"\n',
+        'apps/api/Dockerfile': 'FROM python:3.12',
+      }),
+    )
+    expect(detections).toHaveLength(1)
+    expect(detections[0].path).toBe('apps/api')
+  })
+
+  it('counts a nested charts/ values file as k8s evidence for its service', () => {
+    // charts/ must be recognised as k8s evidence (K8S_DIR_RE), giving the
+    // service a second signal class alongside its build manifest.
+    const detections = detectService(
+      bundle({
+        'myservice/go.mod': 'module myservice\n',
+        'myservice/charts/app/values.yaml': 'replicaCount: 1\n',
+      }),
+    )
+    const d = detections.find((x) => x.path === 'myservice')!
+    expect(d).toBeDefined()
+    expect(d.evidence.some((e) => e.detector === 'k8s-manifest')).toBe(true)
+  })
+
+  it('anchors a nested k8s/ dir to the sub-app dir, not its first path segment', () => {
+    // apps/svc/k8s/deployment.yaml must anchor at "apps/svc" so it combines with
+    // the sibling build manifest to clear the ≥2-signal gate (regression: it
+    // used to anchor at "apps", stranding the k8s evidence).
+    const detections = detectService(
+      bundle({
+        'apps/svc/package.json': '{"name":"svc"}',
+        'apps/svc/k8s/deployment.yaml': 'kind: Deployment\n',
+      }),
+    )
+    expect(detections).toHaveLength(1)
+    expect(detections[0].path).toBe('apps/svc')
+    expect(detections[0].evidence.some((e) => e.detector === 'k8s-manifest')).toBe(true)
+  })
+
+  it('anchors a root-level k8s/ dir to the repo root ("")', () => {
+    // k8s/deployment.yaml at repo root must anchor at "" (root, gate-exempt) and
+    // still yield one detection — not a bogus "deployment.yaml" scope.
+    const detections = detectService(bundle({ 'k8s/deployment.yaml': 'kind: Deployment\n' }))
+    expect(detections).toHaveLength(1)
+    expect(detections[0].path).toBe('')
+    expect(detections[0].evidence.some((e) => e.detector === 'k8s-manifest')).toBe(true)
+  })
+
+  it('excludes a sub-app deeper than the depth cap (Go never fetches its content)', () => {
+    const detections = detectService(
+      bundle({ 'a/b/c/d/Dockerfile': 'FROM alpine', 'a/b/c/d/package.json': '{"name":"deep"}' }),
+    )
+    expect(detections).toHaveLength(0)
+  })
+
+  it('emits a sub-app exactly at the depth cap (depth 3)', () => {
+    const detections = detectService(
+      bundle({ 'a/b/c/Dockerfile': 'FROM alpine', 'a/b/c/package.json': '{"name":"atcap"}' }),
+    )
+    expect(detections).toHaveLength(1)
+    expect(detections[0].path).toBe('a/b/c')
   })
 })
 
@@ -353,10 +434,12 @@ describe('runDetectors', () => {
   })
 
   it('keeps a heuristic service at a different path from the orbit root manifest', () => {
+    // services/other carries two signal classes so it clears the subdir gate.
     const detections = runDetectors(
       bundle({
         '.orbit.yaml': ORBIT_YAML,
         'services/other/go.mod': 'module github.com/acme/other\n',
+        'services/other/Dockerfile': 'FROM golang',
       }),
     )
     const services = detections.filter((d) => d.kind === 'service')

--- a/orbit-www/src/lib/discovery/detectors.ts
+++ b/orbit-www/src/lib/discovery/detectors.ts
@@ -31,15 +31,25 @@ export interface Detection {
  * Well-known paths/globs the Go scanner must fetch so these detectors have
  * content to work with.
  *
- * KEEP IN SYNC with the fetch list in
+ * KEEP IN SYNC with `classifyWellKnown` in
  * `temporal-workflows/internal/activities/catalog_scan_activities.go`.
  * Any pattern added here must be fetched there, or the corresponding detector
  * silently downgrades to a filename-only (medium) match or misses entirely.
+ *
+ * Monorepo-aware collection: the Go scanner fetches .orbit.yaml/.orbit.yml and
+ * build/container manifests (Dockerfile, package.json, go.mod, pom.xml,
+ * Cargo.toml, pyproject.toml, requirements.txt, docker-compose*) in sub-app
+ * directories, bounded to directory depth 3 (root = depth 0). The recursive
+ * globs below therefore reflect a depth-3 Go-side cap, not unbounded recursion.
+ * catalog-info.yaml stays root-only (fetched but not parsed). API specs and
+ * k8s/Helm yaml are matched at any depth.
  */
 export const DISCOVERY_FETCH_PATTERNS: string[] = [
-  // Tier 1 self-declaring manifests
+  // Tier 1 self-declaring manifests (root + sub-app dirs up to depth 3)
   '.orbit.yaml',
   '.orbit.yml',
+  '**/.orbit.yaml',
+  '**/.orbit.yml',
   // API specs (root + common doc/api locations)
   'openapi.yaml',
   'openapi.yml',
@@ -61,18 +71,24 @@ export const DISCOVERY_FETCH_PATTERNS: string[] = [
   'schema.graphql',
   '**/*.graphql',
   '**/*.gql',
-  // Containerization signals
+  // Containerization signals (Dockerfile + compose; sub-app dirs up to depth 3)
   'Dockerfile',
   '**/Dockerfile',
   'docker-compose.yml',
   'docker-compose.yaml',
+  '**/docker-compose.yml',
+  '**/docker-compose.yaml',
   'compose.yml',
   'compose.yaml',
+  '**/compose.yml',
+  '**/compose.yaml',
   'k8s/**',
   'kubernetes/**',
   'deploy/**',
+  'deployments/**',
   'manifests/**',
-  // Build manifests (language/framework)
+  'charts/**',
+  // Build manifests (language/framework); recursive globs capped at depth 3 Go-side
   'package.json',
   '**/package.json',
   'go.mod',
@@ -474,7 +490,28 @@ function isContainerFile(base: string): boolean {
   )
 }
 
-const K8S_DIR_RE = /(^|\/)(k8s|kubernetes|deploy|manifests)\//
+/**
+ * Directory segments that mark a Kubernetes/Helm manifest tree. Keep in sync
+ * with the Go scanner's k8s branch (classifyWellKnown in
+ * temporal-workflows/internal/activities/catalog_scan_activities.go).
+ */
+const K8S_DIR_SEGMENTS = new Set([
+  'k8s',
+  'kubernetes',
+  'deploy',
+  'deployments',
+  'manifests',
+  'charts',
+])
+
+/**
+ * Maximum non-root directory depth (segments in the scope dir) at which a
+ * heuristic service is proposed. Mirrors the Go scanner's `maxManifestDepth`
+ * (root = depth 0, "a/b/c" = depth 3 allowed, "a/b/c/d" excluded): the Go worker
+ * never fetches build-manifest content below that depth, and the documented
+ * sync-pair invariant bounds discovery at depth 3.
+ */
+export const MAX_SUBDIR_SERVICE_DEPTH = 3
 
 interface ServiceScope {
   container?: EvidenceEntry
@@ -505,10 +542,16 @@ export function detectService(bundle: EvidenceBundle): Detection[] {
         const scope = scopeOf(path)
         if (!scope.build) scope.build = { entry: { detector: 'build-manifest', file: path }, info }
       }
-    } else if (K8S_DIR_RE.test(path)) {
-      // Anchor a k8s scope at the parent of the k8s/… directory.
-      const dir = path.replace(K8S_DIR_RE, (m, p1) => (p1 ? p1 : '')).replace(/\/.*$/, '')
-      const anchor = dir === path ? dirOf(path) : dir
+    } else {
+      // A k8s/Helm manifest lives under a recognised directory segment (never
+      // the filename). Anchor the service scope at the path prefix BEFORE that
+      // marker segment: apps/svc/k8s/x.yaml → "apps/svc"; k8s/x.yaml → "" (root).
+      const segs = path.split('/')
+      const markerIdx = segs.findIndex(
+        (s, i) => i < segs.length - 1 && K8S_DIR_SEGMENTS.has(s),
+      )
+      if (markerIdx === -1) continue
+      const anchor = segs.slice(0, markerIdx).join('/')
       let scope = scopes.get(anchor)
       if (!scope) {
         scope = {}
@@ -523,6 +566,22 @@ export function detectService(bundle: EvidenceBundle): Detection[] {
     const hasContainer = !!scope.container || !!scope.k8s
     const hasBuild = !!scope.build
     if (!hasContainer && !hasBuild) continue
+
+    // Root-vs-subdir asymmetry. A single signal at the repo root is a strong
+    // service hint — that directory IS the app. But a lone build manifest in a
+    // subdirectory is usually just a workspace package in a pnpm/turbo monorepo;
+    // emitting one proposal per package would flood /discovery. So a non-root
+    // scope must show ≥2 distinct signal classes (build manifest, container
+    // file, k8s-dir evidence) before it proposes a service, and must sit within
+    // the depth cap the Go scanner fetches (MAX_SUBDIR_SERVICE_DEPTH). Root
+    // behavior is unchanged.
+    if (dir !== '') {
+      const depth = dir.split('/').length
+      if (depth > MAX_SUBDIR_SERVICE_DEPTH) continue
+      const signalClasses =
+        (scope.build ? 1 : 0) + (scope.container ? 1 : 0) + (scope.k8s ? 1 : 0)
+      if (signalClasses < 2) continue
+    }
 
     const evidence: EvidenceEntry[] = []
     if (scope.container) evidence.push(scope.container)

--- a/orbit-www/src/lib/discovery/import.test.ts
+++ b/orbit-www/src/lib/discovery/import.test.ts
@@ -7,6 +7,7 @@ import {
   importDiscoveredApi,
   importDiscoveredGlobalEntity,
   importDiscovery,
+  pickNearestApp,
 } from './import'
 
 // --- FakePayload -------------------------------------------------------------
@@ -97,6 +98,9 @@ function matchesWhere(doc: Doc, where: unknown): boolean {
       if (actualId !== cond.equals) return false
     } else if ('in' in cond) {
       if (!(cond.in as unknown[]).includes(actualId)) return false
+    } else if ('exists' in cond) {
+      const present = actualId !== undefined && actualId !== null
+      if (present !== cond.exists) return false
     }
   }
   return true
@@ -206,6 +210,97 @@ describe('importDiscoveredService', () => {
 
     expect(res).toEqual({ imported: true, ref: { collection: 'apps', id: 'app-x' } })
     expect(f.collections['apps']).toHaveLength(0)
+  })
+
+  it('creates a separate App per sub-app path from one monorepo repo (QA repro — no silent link to the first app)', async () => {
+    const f = fp()
+    const web = discovery({ id: 'disc-web', path: 'apps/web-next', proposal: { name: 'web-next' } })
+    const api = discovery({ id: 'disc-api', path: 'apps/api', proposal: { name: 'api' } })
+    f.collections['discovered-entities'] = [{ ...web } as Doc, { ...api } as Doc]
+
+    const r1 = await importDiscoveredService(payloadOf(f), web)
+    const r2 = await importDiscoveredService(payloadOf(f), api)
+
+    // Two distinct apps, one per sub-app dir.
+    expect(f.collections['apps']).toHaveLength(2)
+    expect(r1.ref!.id).not.toBe(r2.ref!.id)
+    const webApp = f.collections['apps'].find(
+      (a) => (a.repository as Record<string, unknown>).path === 'apps/web-next',
+    )!
+    const apiApp = f.collections['apps'].find(
+      (a) => (a.repository as Record<string, unknown>).path === 'apps/api',
+    )!
+    expect(webApp).toBeDefined()
+    expect(apiApp).toBeDefined()
+    // Each discovery row links to its OWN app.
+    const webRow = f.collections['discovered-entities'].find((r) => r.id === 'disc-web')!
+    const apiRow = f.collections['discovered-entities'].find((r) => r.id === 'disc-api')!
+    expect((webRow.importedRef as Record<string, unknown>).docId).toBe(webApp.id)
+    expect((apiRow.importedRef as Record<string, unknown>).docId).toBe(apiApp.id)
+  })
+
+  it('a sub-app proposal never links to the repo-root App (the data-loss bug)', async () => {
+    const f = fp()
+    // Legacy repo-root App with no repository.path.
+    f.collections['apps'] = [
+      { id: 'app-root', workspace: 'ws1', name: 'billing', repository: { owner: 'acme', name: 'billing' } },
+    ]
+    const api = discovery({ id: 'disc-api', path: 'apps/api', proposal: { name: 'api' } })
+    f.collections['discovered-entities'] = [{ ...api } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), api)
+
+    expect(res.ref!.id).not.toBe('app-root')
+    expect(f.collections['apps']).toHaveLength(2)
+    const created = f.collections['apps'].find((a) => a.id === res.ref!.id)!
+    expect((created.repository as Record<string, unknown>).path).toBe('apps/api')
+  })
+
+  it('same-path proposal links to the existing sub-app App, no duplicate', async () => {
+    const f = fp()
+    f.collections['apps'] = [
+      {
+        id: 'app-api',
+        workspace: 'ws1',
+        name: 'api',
+        repository: { owner: 'acme', name: 'billing', path: 'apps/api' },
+      },
+    ]
+    const api = discovery({ id: 'disc-api', path: 'apps/api', proposal: { name: 'api' } })
+    f.collections['discovered-entities'] = [{ ...api } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), api)
+
+    expect(res.ref).toEqual({ collection: 'apps', id: 'app-api' })
+    expect(f.collections['apps']).toHaveLength(1)
+    expect(f.collections['discovered-entities'][0].importedRef).toEqual({
+      collectionSlug: 'apps',
+      docId: 'app-api',
+    })
+  })
+
+  it('legacy App without repository.path is matched by a root-path proposal', async () => {
+    const f = fp()
+    f.collections['apps'] = [
+      { id: 'app-legacy', workspace: 'ws1', name: 'billing', repository: { owner: 'acme', name: 'billing' } },
+    ]
+    const root = discovery({ id: 'disc-root', path: '', proposal: { name: 'billing-svc' } })
+    f.collections['discovered-entities'] = [{ ...root } as Doc]
+
+    const res = await importDiscoveredService(payloadOf(f), root)
+
+    expect(res.ref).toEqual({ collection: 'apps', id: 'app-legacy' })
+    expect(f.collections['apps']).toHaveLength(1)
+  })
+
+  it('writes the sub-app path onto the created App repository group', async () => {
+    const f = fp()
+    const api = discovery({ id: 'disc-api', path: 'apps/api', proposal: { name: 'api' } })
+    f.collections['discovered-entities'] = [{ ...api } as Doc]
+
+    await importDiscoveredService(payloadOf(f), api)
+
+    expect((f.collections['apps'][0].repository as Record<string, unknown>).path).toBe('apps/api')
   })
 
   it('legacy imported row (collectionSlug only, no docId) backfills docId via the dedupe/App lookup', async () => {
@@ -344,6 +439,47 @@ describe('importDiscoveredService', () => {
     const repo = f.collections['apps'][0].repository as Record<string, unknown>
     expect(repo.provider).toBeUndefined()
     expect(repo.owner).toBe('my-project')
+  })
+})
+
+// --- pickNearestApp ----------------------------------------------------------
+
+describe('pickNearestApp', () => {
+  const monorepo = [
+    { id: 'root', path: '' },
+    { id: 'api', path: 'apps/api' },
+  ]
+
+  it('picks the nearest-ancestor app by longest path-segment prefix', () => {
+    expect(pickNearestApp(monorepo, 'apps/api')).toBe('api')
+    expect(pickNearestApp(monorepo, 'apps/api/docs')).toBe('api')
+  })
+
+  it('falls back to the root app when no deeper app is an ancestor', () => {
+    expect(pickNearestApp(monorepo, 'apps/web-next')).toBe('root')
+    expect(pickNearestApp(monorepo, '')).toBe('root')
+  })
+
+  it('respects segment boundaries — apps/api is not a prefix of apps/api2', () => {
+    expect(pickNearestApp(monorepo, 'apps/api2')).toBe('root')
+  })
+
+  it('returns undefined when there is no ancestor and no root app', () => {
+    expect(pickNearestApp([{ id: 'api', path: 'apps/api' }], 'apps/web-next')).toBeUndefined()
+  })
+
+  it('treats an absent/null path as the repo root', () => {
+    expect(pickNearestApp([{ id: 'legacy' }], 'apps/api')).toBe('legacy')
+    expect(pickNearestApp([{ id: 'legacy', path: null }], 'apps/api')).toBe('legacy')
+  })
+
+  it('picks the deepest among multiple ancestor apps', () => {
+    const apps = [
+      { id: 'root', path: '' },
+      { id: 'apps', path: 'apps' },
+      { id: 'api', path: 'apps/api' },
+    ]
+    expect(pickNearestApp(apps, 'apps/api/v1')).toBe('api')
   })
 })
 
@@ -506,6 +642,25 @@ describe('importDiscoveredApi', () => {
 
     expect(res).toEqual({ imported: true, ref: { collection: 'api-schemas', id: 'schema-x' } })
     expect(f.collections['api-schemas']).toHaveLength(0)
+  })
+
+  it('attaches a spec to the nearest-ancestor sub-app App, never another sub-app of the repo', async () => {
+    const f = fp()
+    f.collections['apps'] = [
+      { id: 'app-web', workspace: 'ws1', repository: { owner: 'acme', name: 'billing', path: 'apps/web-next' } },
+      { id: 'app-api', workspace: 'ws1', repository: { owner: 'acme', name: 'billing', path: 'apps/api' } },
+    ]
+    const d = discovery({
+      detectedKind: 'api',
+      path: 'apps/api',
+      proposal: { schemaType: 'openapi', specPath: 'apps/api/openapi.json', rawContent: 'openapi: 3.0.0' },
+    })
+    f.collections['discovered-entities'] = [{ ...d } as Doc]
+
+    const res = await importDiscoveredApi(payloadOf(f), d, { actorUserId: 'user-1' })
+
+    expect(res.imported).toBe(true)
+    expect(f.collections['api-schemas'][0].repository).toBe('app-api')
   })
 
   it('ADO: links the repository rel by resolved org, not the raw discovered project owner', async () => {

--- a/orbit-www/src/lib/discovery/import.ts
+++ b/orbit-www/src/lib/discovery/import.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import type { Payload } from 'payload'
+import type { Payload, Where } from 'payload'
 import type { DiscoveredEntity } from '@/payload-types'
 
 /**
@@ -161,13 +161,60 @@ async function resolveProviderInfo(
   return { owner: discovery.repo.owner }
 }
 
-/** Find the App that represents a repo in a workspace (Phase 1: repo-scoped). */
+/**
+ * Find the App that represents a repo (optionally a specific monorepo sub-app
+ * dir) in a workspace.
+ *
+ * When `path` is supplied, the lookup is path-scoped so two sub-apps discovered
+ * from one repo map to two distinct Apps (a root proposal keying only on
+ * owner+name would otherwise silently link the second proposal to the first
+ * proposal's App — silent data loss). A missing/'' `path` means the repo root:
+ * it matches both an App whose `repository.path` is '' and a legacy App created
+ * before this field existed (`repository.path` absent), so legacy root Apps keep
+ * matching root proposals. When `path` is `undefined` the lookup is repo-scoped
+ * (owner+name only) — the API import path, whose App linkage is not sub-app
+ * aware.
+ */
 async function findRepoApp(
   payload: Payload,
   workspaceId: string,
   owner: string,
   name: string,
+  path?: string,
 ): Promise<string | undefined> {
+  const and: Where[] = [
+    { workspace: { equals: workspaceId } },
+    { 'repository.owner': { equals: owner } },
+    { 'repository.name': { equals: name } },
+  ]
+  if (path !== undefined) {
+    and.push(
+      path === ''
+        ? { or: [{ 'repository.path': { equals: '' } }, { 'repository.path': { exists: false } }] }
+        : { 'repository.path': { equals: path } },
+    )
+  }
+  const res = await payload.find({
+    collection: 'apps',
+    where: { and },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+  return res.docs.length > 0 ? String(res.docs[0].id) : undefined
+}
+
+/**
+ * Fetch every App backing a repo in a workspace, with each App's monorepo
+ * sub-app `path` ('' = repo root). Feeds `pickNearestApp` so an API spec attaches
+ * to the App that actually owns its directory rather than an arbitrary sibling.
+ */
+async function findRepoApps(
+  payload: Payload,
+  workspaceId: string,
+  owner: string,
+  name: string,
+): Promise<{ id: string; path: string }[]> {
   const res = await payload.find({
     collection: 'apps',
     where: {
@@ -177,11 +224,52 @@ async function findRepoApp(
         { 'repository.name': { equals: name } },
       ],
     },
-    limit: 1,
+    limit: 100,
     depth: 0,
     overrideAccess: true,
   })
-  return res.docs.length > 0 ? String(res.docs[0].id) : undefined
+  return res.docs.map((d) => ({
+    id: String(d.id),
+    path: (d as { repository?: { path?: string | null } }).repository?.path ?? '',
+  }))
+}
+
+/**
+ * Whether `prefix` is a path-segment-boundary ancestor of `dir`: equal, or `dir`
+ * begins with `prefix + '/'`. So 'apps/api' is an ancestor of 'apps/api' and
+ * 'apps/api/docs' but NOT 'apps/api2'.
+ */
+function isPathAncestor(prefix: string, dir: string): boolean {
+  return dir === prefix || dir.startsWith(prefix + '/')
+}
+
+/**
+ * Pick the App a spec at `specDir` belongs to by nearest-ancestor match: the
+ * App whose sub-app `path` is the LONGEST segment-boundary prefix of `specDir`.
+ * A root App (path '' or absent) is an ancestor of everything and is the
+ * fallback when no deeper App matches; `undefined` when neither applies (the
+ * caller then creates an unlinked spec, matching the pre-monorepo behavior).
+ *
+ * Exported for direct unit testing — it is pure (no Payload).
+ */
+export function pickNearestApp(
+  apps: { id: string; path?: string | null }[],
+  specDir: string,
+): string | undefined {
+  let best: { id: string; depth: number } | undefined
+  let rootId: string | undefined
+  for (const app of apps) {
+    const p = app.path ?? ''
+    if (p === '') {
+      if (rootId === undefined) rootId = app.id
+      continue
+    }
+    if (isPathAncestor(p, specDir)) {
+      const depth = p.split('/').length
+      if (!best || depth > best.depth) best = { id: app.id, depth }
+    }
+  }
+  return best ? best.id : rootId
 }
 
 /**
@@ -206,9 +294,13 @@ export async function importDiscoveredService(
 
   const proposal = asRecord(discovery.proposal)
   const { name: repoName, url, defaultBranch } = discovery.repo
+  // The detection path is the monorepo sub-app dir ('' = repo root). It scopes
+  // both the App lookup and the App's stored repository.path so each sub-app in
+  // one repo becomes its own App instead of clobbering the first one.
+  const subPath = discovery.path || ''
   const providerInfo = await resolveProviderInfo(payload, discovery)
 
-  let appId = await findRepoApp(payload, workspaceId, providerInfo.owner, repoName)
+  let appId = await findRepoApp(payload, workspaceId, providerInfo.owner, repoName, subPath)
   if (!appId) {
     const installationId = relId(discovery.installation)
     const buildConfig = asRecord(proposal.buildConfig)
@@ -222,6 +314,7 @@ export async function importDiscoveredService(
         repository: {
           owner: providerInfo.owner,
           name: repoName,
+          ...(subPath ? { path: subPath } : {}),
           ...(url ? { url } : {}),
           ...(installationId ? { installationId } : {}),
           ...(providerInfo.provider ? { provider: providerInfo.provider } : {}),
@@ -297,7 +390,12 @@ export async function importDiscoveredApi(
   // attribution lives entirely on the linked App, so only the lookup owner
   // needs the ADO org (not the discovered project) to find the right App.
   const providerInfo = await resolveProviderInfo(payload, discovery)
-  const appId = await findRepoApp(payload, workspaceId, providerInfo.owner, repoName)
+  // A monorepo repo can back several sub-app Apps; attach the spec to the App
+  // that owns the spec's directory (nearest-ancestor path), not an arbitrary
+  // sibling. specDir is the spec's parent dir ('' at the repo root).
+  const specDir = specPath.includes('/') ? specPath.slice(0, specPath.lastIndexOf('/')) : ''
+  const appsForRepo = await findRepoApps(payload, workspaceId, providerInfo.owner, repoName)
+  const appId = pickNearestApp(appsForRepo, specDir)
 
   const existing = await payload.find({
     collection: 'api-schemas',

--- a/orbit-www/src/payload-types.ts
+++ b/orbit-www/src/payload-types.ts
@@ -279,6 +279,9 @@ export interface User {
    * If checked, user can log in immediately after approval without verifying their email.
    */
   skipEmailVerification?: boolean | null;
+  /**
+   * Set when an admin creates this user via an invite link; distinguishes invited users from self-registered ones.
+   */
   invitedAt?: string | null;
   registrationApprovedAt?: string | null;
   registrationApprovedBy?: (string | null) | User;
@@ -841,6 +844,10 @@ export interface App {
      */
     owner?: string | null;
     name?: string | null;
+    /**
+     * Monorepo sub-app directory relative to the repo root (e.g. "apps/api"). Empty/absent = repo root. Distinguishes multiple apps discovered from one repo.
+     */
+    path?: string | null;
     url?: string | null;
     /**
      * GitHub App installation ID (GitHub rows only).
@@ -4603,6 +4610,7 @@ export interface UsersSelect<T extends boolean = true> {
   role?: T;
   betterAuthId?: T;
   skipEmailVerification?: T;
+  invitedAt?: T;
   registrationApprovedAt?: T;
   registrationApprovedBy?: T;
   updatedAt?: T;
@@ -4888,6 +4896,7 @@ export interface AppsSelect<T extends boolean = true> {
         provider?: T;
         owner?: T;
         name?: T;
+        path?: T;
         url?: T;
         installationId?: T;
         connection?: T;

--- a/temporal-workflows/internal/activities/ado_scan_activities_test.go
+++ b/temporal-workflows/internal/activities/ado_scan_activities_test.go
@@ -57,6 +57,30 @@ func TestADOItemsToEntriesFeedsSelection(t *testing.T) {
 	require.Equal(t, []string{".orbit.yaml", "docs/openapi.yaml", "Dockerfile"}, sel.Paths)
 }
 
+// TestADOMonorepoSelection proves the shared monorepo-aware selection applies to
+// ADO items too: sub-app orbit manifests and build manifests up to depth 3 are
+// collected, vendored and too-deep paths excluded, shallow files sort first.
+func TestADOMonorepoSelection(t *testing.T) {
+	items := []adoItem{
+		{Path: "/.orbit.yaml", IsFolder: false},
+		{Path: "/apps/api/.orbit.yaml", IsFolder: false},
+		{Path: "/apps/api/pyproject.toml", IsFolder: false},
+		{Path: "/apps/api/Dockerfile", IsFolder: false},
+		{Path: "/apps/web-next/package.json", IsFolder: false},
+		{Path: "/node_modules/dep/package.json", IsFolder: false}, // vendored → excluded
+		{Path: "/a/b/c/d/package.json", IsFolder: false},          // depth 4 → excluded
+	}
+	sel := selectWellKnownFiles(adoItemsToEntries(items), maxFilesPerRepo, maxFileBytes)
+	require.Equal(t, []string{
+		".orbit.yaml",          // manifest depth 0
+		"apps/api/.orbit.yaml", // manifest depth 2
+		// service depth 2 (equal score) → lexical
+		"apps/api/Dockerfile",
+		"apps/api/pyproject.toml",
+		"apps/web-next/package.json",
+	}, sel.Paths)
+}
+
 // adoTestServer is a single httptest server standing in for both orbit-www (the
 // token + ingest routes) and the Azure DevOps REST API. The token route returns
 // baseUrl == the server's own URL so every ADO call loops back here.

--- a/temporal-workflows/internal/activities/catalog_scan_activities.go
+++ b/temporal-workflows/internal/activities/catalog_scan_activities.go
@@ -31,8 +31,11 @@ import (
 
 const (
 	// maxFilesPerRepo caps how many well-known files a single repo scan will
-	// fetch and ship in the evidence bundle.
-	maxFilesPerRepo = 40
+	// fetch and ship in the evidence bundle. Raised to 80 for monorepo-aware
+	// collection: one repo can now yield build/orbit manifests for several
+	// sub-apps (up to maxManifestDepth) plus API/k8s specs, so the old cap of 40
+	// could crowd out a real sub-app under a large tree.
+	maxFilesPerRepo = 80
 	// maxFileBytes is the per-file size ceiling. Larger blobs are skipped
 	// (their paths are noted in the bundle) rather than fetched.
 	maxFileBytes int64 = 256 * 1024
@@ -296,9 +299,11 @@ type fileSelection struct {
 
 // selectWellKnownFiles picks the discovery-relevant files out of a repo tree.
 // It is the Go mirror of orbit-www's DISCOVERY_FETCH_PATTERNS — keep the two in
-// sync (see lib/discovery/detectors.ts). Higher-signal files (Tier 1 manifests,
-// API specs) sort ahead of lower-signal ones so the cap never crowds out an
-// .orbit.yaml.
+// sync (see lib/discovery/detectors.ts). The composite priority (class + depth)
+// from classifyWellKnown means higher-signal classes (Tier 1 manifests, API
+// specs) sort ahead of lower-signal ones and, within a class, shallower paths
+// sort ahead of deeper sub-app files — so the cap never crowds out an
+// .orbit.yaml or a root manifest in favour of a nested one.
 func selectWellKnownFiles(entries []treeEntry, maxFiles int, maxBytes int64) fileSelection {
 	type candidate struct {
 		path     string
@@ -370,13 +375,44 @@ func buildBundleTreePaths(entries []treeEntry, alreadyTruncated bool) (paths []s
 	return paths, truncated
 }
 
-// Detection priorities (lower = higher signal, fetched first).
+// Detection priority classes (lower = higher signal). classifyWellKnown does not
+// return these directly — it returns a composite score (prioScore) that folds in
+// the path's directory depth, so within a class shallower paths sort ahead of
+// deeper ones (root files keep winning under the file cap) while the class order
+// (manifest < apispec < service < k8s) stays intact.
 const (
-	prioManifest = iota // .orbit.yaml / catalog-info.yaml
-	prioAPISpec         // openapi/swagger/asyncapi/graphql
-	prioService         // Dockerfile, compose, build manifests, CODEOWNERS
-	prioK8s             // yaml under k8s manifest dirs
+	prioManifest = iota // .orbit.yaml (depth ≤ maxManifestDepth) / catalog-info.yaml (root)
+	prioAPISpec         // openapi/swagger/asyncapi/graphql (anywhere)
+	prioService         // Dockerfile, compose, build manifests (depth ≤ maxManifestDepth), CODEOWNERS
+	prioK8s             // yaml under k8s manifest dirs (anywhere)
 )
+
+// maxManifestDepth bounds how deep a sub-app build/orbit manifest may sit and
+// still be collected. Root file = depth 0, apps/api/.orbit.yaml = depth 2. This
+// keeps monorepo sub-apps in range while excluding deeply nested noise.
+const maxManifestDepth = 3
+
+// prioScore combines a priority class with a path's directory depth into the
+// sort key returned by classifyWellKnown: class*10 + min(depth, 9). The depth
+// clamp is what guarantees class dominance: build/orbit manifests are already
+// capped at maxManifestDepth, but API-spec and k8s classes match at any depth,
+// so without the clamp a spec 10+ dirs deep could reach the next class's score.
+// Clamping keeps every score within its class's [class*10, class*10+9] band.
+func prioScore(class, depth int) int {
+	return class*10 + min(depth, 9)
+}
+
+// pathDepth is the number of directory segments above a file: a root file is
+// depth 0, "apps/api/.orbit.yaml" is depth 2. Leading/trailing slashes are
+// stripped first so a defensive "/apps/api/x" input counts the same as
+// "apps/api/x".
+func pathDepth(p string) int {
+	dir := strings.Trim(path.Dir(p), "/")
+	if dir == "." || dir == "" {
+		return 0
+	}
+	return strings.Count(dir, "/") + 1
+}
 
 // vendoredSegments are directory names whose contents must never be scanned or
 // shipped — vendored dependencies and generated output. Keep in sync with
@@ -400,9 +436,21 @@ func isVendoredPath(p string) bool {
 }
 
 // classifyWellKnown reports whether a path is a discovery-relevant file and, if
-// so, its fetch priority. Build manifests and container files are matched at the
-// repo root only (to avoid node_modules / vendored noise); API specs and k8s
-// manifests are matched anywhere in the tree. Vendored paths never classify.
+// so, its composite fetch priority (prioScore: class + directory depth).
+//
+// Monorepo-aware collection (keep in sync with DISCOVERY_FETCH_PATTERNS in
+// orbit-www/src/lib/discovery/detectors.ts):
+//   - .orbit.yaml/.orbit.yml: root and sub-app dirs up to maxManifestDepth.
+//   - catalog-info.yaml/.yml: root only (Backstage descriptor we don't parse).
+//   - Build manifests + container files (Dockerfile, package.json, go.mod,
+//     pom.xml, Cargo.toml, pyproject.toml, requirements.txt, docker-compose*):
+//     root and sub-app dirs up to maxManifestDepth.
+//   - API specs (openapi/swagger/asyncapi/graphql): anywhere.
+//   - CODEOWNERS: root, .github, docs.
+//   - k8s/Helm yaml: anywhere under a recognised top-level dir.
+//
+// Vendored paths never classify; anything deeper than maxManifestDepth in the
+// depth-bounded classes does not classify.
 func classifyWellKnown(p string) (int, bool) {
 	if isVendoredPath(p) {
 		return 0, false
@@ -413,41 +461,58 @@ func classifyWellKnown(p string) (int, bool) {
 	dir := path.Dir(p) // "." at the repo root
 	isRoot := dir == "."
 	ext := strings.ToLower(path.Ext(p))
+	depth := pathDepth(p)
 
-	// Tier 1 self-declaring manifests (root only).
-	if isRoot {
-		switch base {
-		case ".orbit.yaml", ".orbit.yml", "catalog-info.yaml", "catalog-info.yml":
-			return prioManifest, true
+	// Tier 1 self-declaring manifests.
+	switch base {
+	case ".orbit.yaml", ".orbit.yml":
+		// Orbit manifests may live in a sub-app dir (monorepo), bounded by depth.
+		if depth <= maxManifestDepth {
+			return prioScore(prioManifest, depth), true
 		}
+		return 0, false
+	case "catalog-info.yaml", "catalog-info.yml":
+		// Backstage descriptor we don't parse — root only, avoid scope creep.
+		if isRoot {
+			return prioScore(prioManifest, depth), true
+		}
+		return 0, false
 	}
 
 	// API specs (anywhere in the tree).
 	if ext == ".graphql" || ext == ".graphqls" || ext == ".gql" {
-		return prioAPISpec, true
+		return prioScore(prioAPISpec, depth), true
 	}
 	if ext == ".json" || ext == ".yaml" || ext == ".yml" {
 		if strings.Contains(lowerBase, "openapi") ||
 			strings.Contains(lowerBase, "swagger") ||
 			strings.Contains(lowerBase, "asyncapi") {
-			return prioAPISpec, true
+			return prioScore(prioAPISpec, depth), true
 		}
 	}
 
-	// Build manifests + container files (root only).
-	if isRoot {
-		switch base {
-		case "Dockerfile", "package.json", "go.mod", "pom.xml", "Cargo.toml", "pyproject.toml", "requirements.txt":
-			return prioService, true
+	// Build manifests + container files (root and sub-app dirs up to depth cap).
+	switch base {
+	case "Dockerfile", "package.json", "go.mod", "pom.xml", "Cargo.toml", "pyproject.toml", "requirements.txt":
+		if depth <= maxManifestDepth {
+			return prioScore(prioService, depth), true
 		}
-		if strings.HasPrefix(lowerBase, "docker-compose") && (ext == ".yml" || ext == ".yaml") {
-			return prioService, true
+		return 0, false
+	}
+	// Compose files: docker-compose*.ya?ml plus the Compose Spec canonical
+	// basenames compose.yml/compose.yaml, same depth rule as build manifests.
+	isCompose := (strings.HasPrefix(lowerBase, "docker-compose") && (ext == ".yml" || ext == ".yaml")) ||
+		lowerBase == "compose.yml" || lowerBase == "compose.yaml"
+	if isCompose {
+		if depth <= maxManifestDepth {
+			return prioScore(prioService, depth), true
 		}
+		return 0, false
 	}
 
 	// CODEOWNERS in the conventional locations.
 	if base == "CODEOWNERS" && (isRoot || dir == ".github" || dir == "docs") {
-		return prioService, true
+		return prioScore(prioService, depth), true
 	}
 
 	// Kubernetes/Helm manifests under a recognised top-level directory.
@@ -458,7 +523,7 @@ func classifyWellKnown(p string) (int, bool) {
 		}
 		switch top {
 		case "k8s", "kubernetes", "manifests", "deploy", "deployments", "charts":
-			return prioK8s, true
+			return prioScore(prioK8s, depth), true
 		}
 	}
 

--- a/temporal-workflows/internal/activities/catalog_scan_activities_test.go
+++ b/temporal-workflows/internal/activities/catalog_scan_activities_test.go
@@ -71,18 +71,24 @@ func TestSelectWellKnownFiles(t *testing.T) {
 			wantTruncated: false,
 		},
 		{
-			name: "build manifests are matched at repo root only",
+			name: "build manifests matched at root and sub-app dirs; vendored excluded",
 			entries: []treeEntry{
-				blob("package.json", 100),          // root — matched
-				blob("frontend/package.json", 100), // nested — ignored
-				blob("vendor/go.mod", 100),         // nested — ignored
+				blob("package.json", 100),            // root, depth 0
+				blob("frontend/package.json", 100),   // depth 1 — now matched
+				blob("apps/api/pyproject.toml", 100), // depth 2 — now matched
+				blob("vendor/go.mod", 100),           // vendored — excluded
 			},
-			maxFiles:  40,
-			maxBytes:  maxFileBytes,
-			wantPaths: []string{"package.json"},
+			maxFiles: 40,
+			maxBytes: maxFileBytes,
+			// Same priority class (service); shallower sorts first, then lexical.
+			wantPaths: []string{
+				"package.json",
+				"frontend/package.json",
+				"apps/api/pyproject.toml",
+			},
 		},
 		{
-			name: "api specs and k8s manifests matched anywhere; specs sort ahead of k8s",
+			name: "api specs and k8s manifests matched anywhere; specs sort ahead of k8s, shallow first",
 			entries: []treeEntry{
 				blob("k8s/deployment.yaml", 100),
 				blob("kubernetes/service.yml", 100),
@@ -95,18 +101,18 @@ func TestSelectWellKnownFiles(t *testing.T) {
 			maxFiles: 40,
 			maxBytes: maxFileBytes,
 			wantPaths: []string{
-				// prioAPISpec sorted lexically by full path
-				"api/v1/swagger.json",
-				"events/asyncapi.yaml",
-				"schema.graphql",
-				// prioK8s sorted lexically by full path
-				"charts/app/values.yaml",
-				"k8s/deployment.yaml",
-				"kubernetes/service.yml",
+				// prioAPISpec: shallower depth first, then lexical
+				"schema.graphql",       // depth 0
+				"events/asyncapi.yaml", // depth 1
+				"api/v1/swagger.json",  // depth 2
+				// prioK8s: shallower depth first, then lexical
+				"k8s/deployment.yaml",    // depth 1
+				"kubernetes/service.yml", // depth 1
+				"charts/app/values.yaml", // depth 2
 			},
 		},
 		{
-			name: "CODEOWNERS matched in root, .github and docs only",
+			name: "CODEOWNERS matched in root, .github and docs only; root sorts first",
 			entries: []treeEntry{
 				blob("CODEOWNERS", 100),
 				blob(".github/CODEOWNERS", 100),
@@ -116,9 +122,9 @@ func TestSelectWellKnownFiles(t *testing.T) {
 			maxFiles: 40,
 			maxBytes: maxFileBytes,
 			wantPaths: []string{
-				".github/CODEOWNERS",
-				"CODEOWNERS",
-				"docs/CODEOWNERS",
+				"CODEOWNERS",         // depth 0
+				".github/CODEOWNERS", // depth 1
+				"docs/CODEOWNERS",    // depth 1
 			},
 		},
 		{
@@ -146,20 +152,59 @@ func TestSelectWellKnownFiles(t *testing.T) {
 			wantTruncated: true,
 		},
 		{
-			name: "docker-compose variants at root are matched",
+			name: "docker-compose variants at root and sub-app dirs are matched",
 			entries: []treeEntry{
 				blob("docker-compose.yml", 100),
 				blob("docker-compose.prod.yaml", 100),
-				blob("deploy/docker-compose.yml", 100), // deploy dir → matched as k8s yaml
+				blob("deploy/docker-compose.yml", 100), // depth 1 compose (service class)
 			},
 			maxFiles: 40,
 			maxBytes: maxFileBytes,
 			wantPaths: []string{
-				// service priority (root compose) sorts ahead of k8s-dir yaml
+				// root composes (depth 0) sort ahead of the depth-1 compose.
 				"docker-compose.prod.yaml",
 				"docker-compose.yml",
 				"deploy/docker-compose.yml",
 			},
+		},
+		{
+			name: "monorepo: sub-app manifests and orbit files collected up to depth 3; vendored and too-deep excluded",
+			entries: []treeEntry{
+				blob(".orbit.yaml", 100),                   // manifest, depth 0
+				blob("apps/api/.orbit.yaml", 100),          // manifest, depth 2
+				blob("apps/web-next/package.json", 100),    // service, depth 2
+				blob("apps/api/pyproject.toml", 100),       // service, depth 2
+				blob("apps/api/Dockerfile", 100),           // service, depth 2
+				blob("services/x/docker-compose.yml", 100), // service, depth 2
+				blob("package.json", 100),                  // service, depth 0
+				blob("node_modules/x/package.json", 100),   // vendored — excluded
+				blob("a/b/c/d/package.json", 100),          // depth 4 — excluded
+				blob("nested/catalog-info.yaml", 100),      // non-root catalog-info — excluded
+			},
+			maxFiles: maxFilesPerRepo,
+			maxBytes: maxFileBytes,
+			wantPaths: []string{
+				".orbit.yaml",          // manifest depth 0
+				"apps/api/.orbit.yaml", // manifest depth 2
+				"package.json",         // service depth 0
+				// service depth 2 (equal score) → lexical
+				"apps/api/Dockerfile",
+				"apps/api/pyproject.toml",
+				"apps/web-next/package.json",
+				"services/x/docker-compose.yml",
+			},
+		},
+		{
+			name: "over-cap selection keeps shallow/high-priority files and truncates",
+			entries: []treeEntry{
+				blob("apps/api/package.json", 100), // service depth 2
+				blob("package.json", 100),          // service depth 0
+				blob(".orbit.yaml", 100),           // manifest depth 0
+			},
+			maxFiles:      2,
+			maxBytes:      maxFileBytes,
+			wantPaths:     []string{".orbit.yaml", "package.json"},
+			wantTruncated: true,
 		},
 		{
 			name:      "no matches yields empty selection",
@@ -190,19 +235,39 @@ func TestClassifyWellKnown(t *testing.T) {
 		wantPrio int
 		wantOK   bool
 	}{
-		{".orbit.yaml", prioManifest, true},
-		{"catalog-info.yaml", prioManifest, true},
-		{"nested/.orbit.yaml", 0, false}, // manifest is root-only
-		{"docs/openapi.yaml", prioAPISpec, true},
-		{"schema.graphqls", prioAPISpec, true},
-		{"Dockerfile", prioService, true},
-		{"go.mod", prioService, true},
-		{"pkg/go.mod", 0, false}, // build manifest is root-only
-		{"docker-compose.yml", prioService, true},
-		{".github/CODEOWNERS", prioService, true},
+		// Tier-1 orbit manifests: root and sub-app dirs up to depth 3 (monorepo).
+		{".orbit.yaml", prioScore(prioManifest, 0), true},
+		{"apps/api/.orbit.yaml", prioScore(prioManifest, 2), true},
+		{"a/b/c/.orbit.yaml", prioScore(prioManifest, 3), true},
+		{"a/b/c/d/.orbit.yaml", 0, false}, // depth 4 — too deep
+		// Backstage descriptor stays root-only (we don't parse it).
+		{"catalog-info.yaml", prioScore(prioManifest, 0), true},
+		{"nested/catalog-info.yaml", 0, false},
+		// API specs anywhere in the tree; depth folds into the sort key.
+		{"docs/openapi.yaml", prioScore(prioAPISpec, 1), true},
+		{"schema.graphqls", prioScore(prioAPISpec, 0), true},
+		// A very deep API spec clamps its depth to 9 so its composite score
+		// (prioScore(prioAPISpec, 9) = 19) stays below the shallowest service
+		// score (prioScore(prioService, 0) = 20) — class dominance preserved.
+		{"a/b/c/d/e/f/g/h/i/j/openapi.yaml", prioScore(prioAPISpec, 9), true},
+		// Build + container manifests: root and sub-app dirs up to depth 3.
+		{"Dockerfile", prioScore(prioService, 0), true},
+		{"go.mod", prioScore(prioService, 0), true},
+		{"apps/web-next/package.json", prioScore(prioService, 2), true},
+		{"apps/api/pyproject.toml", prioScore(prioService, 2), true},
+		{"apps/api/Dockerfile", prioScore(prioService, 2), true},
+		{"services/x/docker-compose.yml", prioScore(prioService, 2), true},
+		{"a/b/c/d/package.json", 0, false},        // depth 4 — too deep
+		{"node_modules/x/package.json", 0, false}, // vendored
+		{"docker-compose.yml", prioScore(prioService, 0), true},
+		// Compose Spec canonical basenames match the same service class + depth rule.
+		{"compose.yaml", prioScore(prioService, 0), true},
+		{"apps/api/compose.yaml", prioScore(prioService, 2), true},
+		{"compose.yml", prioScore(prioService, 0), true},
+		{".github/CODEOWNERS", prioScore(prioService, 1), true},
 		{"src/CODEOWNERS", 0, false},
-		{"k8s/deploy.yaml", prioK8s, true},
-		{"manifests/app.yml", prioK8s, true},
+		{"k8s/deploy.yaml", prioScore(prioK8s, 1), true},
+		{"manifests/app.yml", prioScore(prioK8s, 1), true},
 		{"src/config.yaml", 0, false},
 		{"README.md", 0, false},
 	}
@@ -214,6 +279,25 @@ func TestClassifyWellKnown(t *testing.T) {
 				require.Equal(t, tt.wantPrio, prio)
 			}
 		})
+	}
+}
+
+func TestPathDepth(t *testing.T) {
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"README.md", 0},                  // root file
+		{"apps/api/.orbit.yaml", 2},       // two dir segments
+		{"a/b/c/d/package.json", 4},       // four dir segments
+		{"/apps/api/pyproject.toml", 2},   // defensive: leading slash stripped
+		{"/README.md", 0},                 // leading-slash root file
+		{"apps/web-next/package.json", 2}, // hyphenated segment
+	}
+	for _, c := range cases {
+		if got := pathDepth(c.path); got != c.want {
+			t.Errorf("pathDepth(%q) = %d, want %d", c.path, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the [catalog representation gaps plan](docs/plans/2026-07-19-catalog-representation-gaps.md) (plan doc included in this PR): one repository can now yield **multiple** catalog entities, so monorepos like `drewpayment/sprinklergoose` (Next.js UI + FastAPI executor in one repo) scan as two services instead of one flattened proposal.

### Go scan worker (shared GitHub + ADO)
- `classifyWellKnown` collects build/container manifests and `.orbit.yaml` in subdirectories up to depth 3 (was root-only); `compose.yml`/`compose.yaml` now matched; `catalog-info.yaml` stays root-only
- Composite fetch priority `class*10 + min(depth, 9)` — shallower files win within a class; `maxFilesPerRepo` 40 → 80

### TS detectors
- **Anti-noise gate:** non-root directories need ≥2 signal classes (build manifest / container / k8s) to propose a service — a pnpm/turbo monorepo's 30 workspace packages no longer flood `/discovery`
- k8s evidence anchor fixed (`apps/svc/k8s/x.yaml` → scope `apps/svc`; root `k8s/` → repo root) — pre-existing bug the new gate made consequential
- Subdir depth bound enforced TS-side to match Go; k8s dir sets + fetch patterns re-synced

### Import — critical fix found by live QA
- Approving two proposals from one repo previously **silently collapsed into one App** (`findRepoApp` was repo-keyed; the second approve no-op'd while reporting success). `Apps` gains `repository.path` and the lookup keys on it; legacy path-less apps still match root proposals
- `importDiscoveredApi` now attributes a spec to the **nearest-ancestor App by path** (`pickNearestApp`) instead of an arbitrary first match — a FastAPI spec at `apps/api/openapi.json` links to the `apps/api` App, never `web-next`

`payload-types.ts` regen also syncs pre-existing `invitedAt` drift from PR #87.

## Review process

Implemented TDD (all new tests watched red first), adversarially reviewed (depth-clamp, compose sync-invariant, and noise-gate findings applied; deep-compose-under-k8s-dir confirmed inert and declined), and live-QA'd end-to-end.

## Test plan

- [x] `go test -race ./internal/activities/...` — all scan/discovery/ADO tests green (9 pre-existing failures verified identical on base tree via stash)
- [x] `bunx vitest run src/lib/discovery src/app/api/internal/discovery` — 151/151
- [x] `bunx tsc --noEmit` — 0 errors (baseline held)
- [x] Live e2e (dev env, agent-browser): synthetic monorepo bundle → ingest 200 with 2 service + 1 api proposals; library-only package correctly excluded; re-ingest dedupes; approving both services creates **two** Apps with distinct `repository.path` and correct `importedRef`s; API schema attaches to the `apps/api` App; catalog projections + exposes-api relation correct; all synthetic data removed

Known follow-ups (out of scope, documented in plan): case-sensitive filename matching (pre-existing), `catalog-info.yaml` parsing, admin-UI bulk-delete papercut on the discovered-entities list view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjAyrKghEcE6ateAHcvtUs