### PR TITLE
feat(catalog): subtype + runtime curation fields on entities (Phase 2)

### DIFF
--- a/orbit-www/src/app/(frontend)/catalog/entity-actions.ts
+++ b/orbit-www/src/app/(frontend)/catalog/entity-actions.ts
@@ -24,6 +24,7 @@ import {
   type RelationInput,
   type EntityFormOptions,
   type EntityOption,
+  type EntityRuntime,
 } from '@/lib/catalog/entity-crud'
 import type { EntityKind } from '@/collections/catalog/constants'
 import type { CatalogEntity } from '@/payload-types'
@@ -72,6 +73,15 @@ function refId(ref: unknown): string | null {
 /** Where-clause fragment matching a specific workspace, or the global (no-workspace) set. */
 function workspaceClause(workspaceId: string | null): Where {
   return workspaceId ? { workspace: { equals: workspaceId } } : { workspace: { exists: false } }
+}
+
+/**
+ * Normalize a runtime value for a Payload write. A `null` (caller clearing the
+ * group) becomes an all-null-subfields object — Payload's generated group type
+ * has no null form, so clearing is expressed by emptying each sub-field.
+ */
+function normalizeRuntimeWrite(runtime: EntityRuntime | null): EntityRuntime {
+  return runtime ?? { url: null, platform: null, notes: null }
 }
 
 /**
@@ -153,6 +163,8 @@ export async function createCatalogEntity(input: CreateEntityInput): Promise<{ i
       ...(input.description !== undefined ? { description: input.description } : {}),
       ...(input.lifecycle ? { lifecycle: input.lifecycle } : {}),
       ...(input.tier ? { tier: input.tier } : {}),
+      ...(input.subtype !== undefined ? { subtype: input.subtype?.trim() || null } : {}),
+      ...(input.runtime !== undefined ? { runtime: normalizeRuntimeWrite(input.runtime) } : {}),
       ...(input.ownerId ? { owner: input.ownerId } : {}),
       ...(input.links ? { links: input.links } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
@@ -208,6 +220,8 @@ export async function updateCatalogEntity(id: string, patch: UpdateEntityPatch):
       ...(patch.description !== undefined ? { description: patch.description } : {}),
       ...(patch.lifecycle !== undefined ? { lifecycle: patch.lifecycle } : {}),
       ...(patch.tier !== undefined ? { tier: patch.tier } : {}),
+      ...(patch.subtype !== undefined ? { subtype: patch.subtype?.trim() || null } : {}),
+      ...(patch.runtime !== undefined ? { runtime: normalizeRuntimeWrite(patch.runtime) } : {}),
       ...(patch.ownerId !== undefined ? { owner: patch.ownerId } : {}),
       ...(patch.links !== undefined ? { links: patch.links } : {}),
       ...(patch.metadata !== undefined ? { metadata: patch.metadata } : {}),

--- a/orbit-www/src/collections/catalog/CatalogEntities.ts
+++ b/orbit-www/src/collections/catalog/CatalogEntities.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from 'payload'
-import { ENTITY_KINDS } from './constants'
+import { ENTITY_KINDS, RUNTIME_PLATFORM_OPTIONS } from './constants'
+import { SUBTYPE_MAX_LENGTH } from '@/lib/catalog/entity-crud'
 import { canCreateEntity, canManageEntity, canDeleteEntity } from '@/lib/catalog/entity-authz'
 import { isPlatformAdmin } from '@/lib/access/workspace-access'
 
@@ -129,6 +130,16 @@ export const CatalogEntities: CollectionConfig = {
       options: ENTITY_KINDS.map((k) => ({ label: k, value: k })),
     },
     {
+      name: 'subtype',
+      type: 'text',
+      index: true,
+      maxLength: SUBTYPE_MAX_LENGTH,
+      admin: {
+        description:
+          'Free-form refinement of kind, e.g. postgresql (datastore), iot-device (resource), website (service).',
+      },
+    },
+    {
       name: 'workspace',
       type: 'relationship',
       relationTo: 'workspaces',
@@ -193,6 +204,32 @@ export const CatalogEntities: CollectionConfig = {
       ],
     },
     {
+      name: 'runtime',
+      type: 'group',
+      admin: {
+        description:
+          'Where this entity runs and how to reach it. Topology lives in runs-in relations; this is the human-facing pointer.',
+      },
+      fields: [
+        {
+          name: 'url',
+          type: 'text',
+          admin: { description: 'Deployed URL — where to reach this entity.' },
+        },
+        {
+          name: 'platform',
+          type: 'select',
+          options: RUNTIME_PLATFORM_OPTIONS,
+          admin: { description: 'Hosting substrate (kubernetes, vps, home-server, …).' },
+        },
+        {
+          name: 'notes',
+          type: 'textarea',
+          admin: { description: 'Free-form operational notes (access, quirks).' },
+        },
+      ],
+    },
+    {
       name: 'source',
       type: 'group',
       admin: {
@@ -252,6 +289,8 @@ export const CatalogEntities: CollectionConfig = {
   ],
   indexes: [
     { fields: ['workspace', 'kind'] },
+    // Refinement lookups (e.g. "all datastores of subtype postgresql").
+    { fields: ['kind', 'subtype'] },
     // Non-unique: slug may be absent on freshly-projected rows, and a compound
     // unique index collides on multiple nulls in MongoDB. Slug uniqueness within
     // a workspace and projection idempotency (one row per source) are enforced

--- a/orbit-www/src/collections/catalog/constants.ts
+++ b/orbit-www/src/collections/catalog/constants.ts
@@ -38,3 +38,30 @@ export const RELATION_TYPES = [
 
 export type EntityKind = (typeof ENTITY_KINDS)[number]
 export type RelationType = (typeof RELATION_TYPES)[number]
+
+/**
+ * Where a catalog entity actually runs / how to reach it (the `runtime.platform`
+ * vocabulary). This is the human-facing "where does this live" pointer — graph
+ * topology (runs-in relations to environment entities) is complementary. Single
+ * source for the collection select, the `entity-crud` validator, and the form.
+ */
+export const RUNTIME_PLATFORMS = [
+  'kubernetes',
+  'vps',
+  'home-server',
+  'paas',
+  'serverless',
+  'other',
+] as const
+
+export type RuntimePlatform = (typeof RUNTIME_PLATFORMS)[number]
+
+/** Platform values paired with their human labels (schema select + form select). */
+export const RUNTIME_PLATFORM_OPTIONS: { value: RuntimePlatform; label: string }[] = [
+  { value: 'kubernetes', label: 'Kubernetes' },
+  { value: 'vps', label: 'VPS' },
+  { value: 'home-server', label: 'Home server' },
+  { value: 'paas', label: 'PaaS' },
+  { value: 'serverless', label: 'Serverless' },
+  { value: 'other', label: 'Other' },
+]

--- a/orbit-www/src/components/features/catalog/EntityDetail.tsx
+++ b/orbit-www/src/components/features/catalog/EntityDetail.tsx
@@ -11,8 +11,10 @@ import {
   GitBranch,
   Link2,
   Pencil,
+  Server,
   Users,
 } from 'lucide-react'
+import { RUNTIME_PLATFORM_OPTIONS } from '@/collections/catalog/constants'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -59,6 +61,11 @@ const linkTypeIcon: Record<string, typeof BookText> = {
   other: Link2,
 }
 
+/** Human label for a runtime platform value ("home-server" → "Home server"). */
+function runtimePlatformLabel(platform: string): string {
+  return RUNTIME_PLATFORM_OPTIONS.find((o) => o.value === platform)?.label ?? platform
+}
+
 function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-4 py-2 text-sm">
@@ -76,6 +83,11 @@ export function EntityDetail({ entity, relations, docs, canManage }: EntityDetai
   const health = entity.health ?? 'unknown'
   const owner = entity.owner && typeof entity.owner === 'object' ? entity.owner : null
   const links = entity.links ?? []
+  const runtime = entity.runtime ?? null
+  const hasRuntime = !!(
+    runtime &&
+    (runtime.url?.trim() || runtime.platform || runtime.notes?.trim())
+  )
 
   // Overall entity score (Entity Scores & Golden Paths) — fetched once here
   // so it can be surfaced prominently in the header, and handed down to the
@@ -133,6 +145,9 @@ export function EntityDetail({ entity, relations, docs, canManage }: EntityDetai
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant="outline">{meta.label}</Badge>
+            {entity.subtype && (
+              <span className="text-sm text-muted-foreground">{entity.subtype}</span>
+            )}
             {lifecycle && (
               <Badge variant={lifecycleVariant[lifecycle] ?? 'secondary'} className="capitalize">
                 {lifecycle}
@@ -242,6 +257,43 @@ export function EntityDetail({ entity, relations, docs, canManage }: EntityDetai
               </CardContent>
             </Card>
           </div>
+
+          {hasRuntime && runtime && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <Server className="h-4 w-4 text-muted-foreground" />
+                  Runtime
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y">
+                {runtime.url?.trim() && (
+                  <MetaRow label="URL">
+                    <a
+                      href={runtime.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-primary hover:underline"
+                    >
+                      <span className="truncate">{runtime.url}</span>
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                    </a>
+                  </MetaRow>
+                )}
+                {runtime.platform && (
+                  <MetaRow label="Platform">
+                    <span>{runtimePlatformLabel(runtime.platform)}</span>
+                  </MetaRow>
+                )}
+                {runtime.notes && (
+                  <div className="py-2 text-sm">
+                    <p className="mb-1 text-muted-foreground">Notes</p>
+                    <p className="whitespace-pre-wrap">{runtime.notes}</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           <div className="space-y-2">
             <h2 className="text-sm font-medium text-muted-foreground">Neighbourhood</h2>

--- a/orbit-www/src/components/features/catalog/EntityListItem.tsx
+++ b/orbit-www/src/components/features/catalog/EntityListItem.tsx
@@ -74,7 +74,12 @@ export function EntityListItem({
             />
           </div>
           <div className="flex flex-wrap items-center gap-1.5">
-            <EntityKindBadge kind={entity.kind} />
+            <span className="inline-flex items-center gap-1">
+              <EntityKindBadge kind={entity.kind} />
+              {entity.subtype && (
+                <span className="text-xs text-muted-foreground">· {entity.subtype}</span>
+              )}
+            </span>
             {entity.lifecycle && (
               <Badge variant={LIFECYCLE_VARIANT[entity.lifecycle]} className="font-normal capitalize">
                 {entity.lifecycle}

--- a/orbit-www/src/components/features/catalog/entity-form/EntityForm.tsx
+++ b/orbit-www/src/components/features/catalog/entity-form/EntityForm.tsx
@@ -28,6 +28,7 @@ import { EntityLinksEditor } from './EntityLinksEditor'
 import {
   LIFECYCLE_OPTIONS,
   TIER_OPTIONS,
+  RUNTIME_PLATFORM_OPTIONS,
   buildWorkspaceOptions,
   collectLinkErrors,
   idToWorkspaceSelection,
@@ -36,6 +37,7 @@ import {
   newLinkRow,
   rowsToLinks,
   sourceProvenanceLabel,
+  subtypePlaceholder,
   workspaceSelectionToId,
   type EntityFormOptions,
   type LinkRow,
@@ -43,6 +45,8 @@ import {
   type PickerEntity,
   type Tier,
 } from './entity-form-ui'
+import type { RuntimePlatform } from '@/collections/catalog/constants'
+import { SUBTYPE_MAX_LENGTH } from '@/lib/catalog/entity-crud'
 
 /** Sentinel `<Select>` value for an unset optional field (lifecycle/tier). */
 const NONE = '__none__'
@@ -118,6 +122,12 @@ export function EntityForm({
     return workspaceOptions[0]?.value ?? ''
   })
   const [description, setDescription] = useState(entity?.description ?? '')
+  const [subtype, setSubtype] = useState(entity?.subtype ?? '')
+  const [runtimeUrl, setRuntimeUrl] = useState(entity?.runtime?.url ?? '')
+  const [runtimePlatform, setRuntimePlatform] = useState<RuntimePlatform | typeof NONE>(
+    entity?.runtime?.platform ?? NONE,
+  )
+  const [runtimeNotes, setRuntimeNotes] = useState(entity?.runtime?.notes ?? '')
   const [lifecycle, setLifecycle] = useState<Lifecycle | typeof NONE>(entity?.lifecycle ?? NONE)
   const [tier, setTier] = useState<Tier | typeof NONE>(entity?.tier ?? NONE)
   const [owner, setOwner] = useState<PickerEntity | null>(ownerOf(entity))
@@ -155,6 +165,13 @@ export function EntityForm({
     const links = rowsToLinks(linkRows)
     const lifecycleValue = lifecycle === NONE ? null : lifecycle
     const tierValue = tier === NONE ? null : tier
+    const subtypeValue = subtype.trim()
+    const runtime = {
+      url: runtimeUrl.trim() || null,
+      platform: runtimePlatform === NONE ? null : runtimePlatform,
+      notes: runtimeNotes.trim() || null,
+    }
+    const hasRuntime = !!(runtime.url || runtime.platform || runtime.notes)
 
     setSubmitting(true)
     try {
@@ -164,6 +181,8 @@ export function EntityForm({
           name: trimmedName,
           workspaceId: workspaceSelectionToId(workspaceSelection),
           description: description.trim() || undefined,
+          subtype: subtypeValue || undefined,
+          runtime: hasRuntime ? runtime : undefined,
           lifecycle: lifecycleValue ?? undefined,
           tier: tierValue ?? undefined,
           ownerId: owner?.id ?? undefined,
@@ -177,6 +196,9 @@ export function EntityForm({
           // rejects them on projected entities regardless.
           ...(locked ? {} : { name: trimmedName, kind }),
           description: description.trim() || null,
+          // subtype + runtime are curation fields — editable even when locked.
+          subtype: subtypeValue || null,
+          runtime,
           lifecycle: lifecycleValue,
           tier: tierValue,
           ownerId: owner?.id ?? null,
@@ -272,6 +294,21 @@ export function EntityForm({
         />
       </div>
 
+      <div className="space-y-1.5">
+        <Label htmlFor="entity-subtype">Subtype</Label>
+        <Input
+          id="entity-subtype"
+          value={subtype}
+          onChange={(e) => setSubtype(e.target.value)}
+          placeholder={subtypePlaceholder(kind)}
+          maxLength={SUBTYPE_MAX_LENGTH}
+          disabled={submitting}
+        />
+        <p className="text-xs text-muted-foreground">
+          A free-form refinement of the kind — no new entity type needed.
+        </p>
+      </div>
+
       <div className="grid gap-5 sm:grid-cols-2">
         <div className="space-y-1.5">
           <Label htmlFor="entity-lifecycle">Lifecycle</Label>
@@ -331,6 +368,59 @@ export function EntityForm({
         <p className="text-xs text-muted-foreground">
           The team entity that owns this. Create team entities from a workspace to populate this.
         </p>
+      </div>
+
+      <div className="space-y-3 rounded-md border p-4">
+        <div className="space-y-0.5">
+          <h3 className="text-sm font-medium">Runtime</h3>
+          <p className="text-xs text-muted-foreground">
+            Where this entity runs and how to reach it. Topology lives in relations; this is the
+            human-facing pointer.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="entity-runtime-url">URL</Label>
+            <Input
+              id="entity-runtime-url"
+              type="url"
+              value={runtimeUrl}
+              onChange={(e) => setRuntimeUrl(e.target.value)}
+              placeholder="https://app.example.com"
+              disabled={submitting}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="entity-runtime-platform">Platform</Label>
+            <Select
+              value={runtimePlatform}
+              onValueChange={(v) => setRuntimePlatform(v as RuntimePlatform | typeof NONE)}
+              disabled={submitting}
+            >
+              <SelectTrigger id="entity-runtime-platform">
+                <SelectValue placeholder="Select a platform" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>—</SelectItem>
+                {RUNTIME_PLATFORM_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="entity-runtime-notes">Notes</Label>
+          <Textarea
+            id="entity-runtime-notes"
+            value={runtimeNotes}
+            onChange={(e) => setRuntimeNotes(e.target.value)}
+            placeholder="Access details, quirks, how to reach it."
+            disabled={submitting}
+          />
+        </div>
       </div>
 
       <EntityLinksEditor rows={linkRows} onChange={setLinkRows} disabled={submitting} />

--- a/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.test.ts
+++ b/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.test.ts
@@ -3,6 +3,7 @@ import {
   LIFECYCLE_OPTIONS,
   TIER_OPTIONS,
   LINK_TYPE_OPTIONS,
+  RUNTIME_PLATFORM_OPTIONS,
   GLOBAL_WORKSPACE_VALUE,
   newLinkRow,
   linksToRows,
@@ -12,6 +13,7 @@ import {
   rowsToLinks,
   isSourceLocked,
   sourceProvenanceLabel,
+  subtypePlaceholder,
   buildWorkspaceOptions,
   workspaceSelectionToId,
   idToWorkspaceSelection,
@@ -39,6 +41,35 @@ describe('option lists', () => {
       'repository',
       'other',
     ])
+  })
+
+  it('exposes the six runtime platforms with human labels', () => {
+    expect(RUNTIME_PLATFORM_OPTIONS.map((o) => o.value)).toEqual([
+      'kubernetes',
+      'vps',
+      'home-server',
+      'paas',
+      'serverless',
+      'other',
+    ])
+    expect(RUNTIME_PLATFORM_OPTIONS.find((o) => o.value === 'home-server')?.label).toBe(
+      'Home server',
+    )
+    expect(RUNTIME_PLATFORM_OPTIONS.every((o) => o.label.length > 0)).toBe(true)
+  })
+})
+
+describe('subtypePlaceholder', () => {
+  it('suggests per-kind examples for the kinds with curated hints', () => {
+    expect(subtypePlaceholder('datastore')).toMatch(/postgresql/i)
+    expect(subtypePlaceholder('resource')).toMatch(/iot-device/i)
+    expect(subtypePlaceholder('service')).toMatch(/website/i)
+  })
+
+  it('falls back to a generic hint for other kinds', () => {
+    const generic = subtypePlaceholder('team')
+    expect(generic.length).toBeGreaterThan(0)
+    expect(generic).not.toMatch(/postgresql/i)
   })
 })
 

--- a/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.ts
+++ b/orbit-www/src/components/features/catalog/entity-form/entity-form-ui.ts
@@ -1,5 +1,6 @@
 import type { CatalogEntity } from '@/payload-types'
 import type { EntityKind } from '@/collections/catalog/constants'
+import { RUNTIME_PLATFORM_OPTIONS } from '@/collections/catalog/constants'
 
 /**
  * Pure, React-free helpers for the catalog EntityForm (WP2). Kept out of the
@@ -37,6 +38,22 @@ export const LINK_TYPE_OPTIONS: { value: EntityLinkType; label: string }[] = [
   { value: 'repository', label: 'Repository' },
   { value: 'other', label: 'Other' },
 ]
+
+// Re-export the runtime-platform vocabulary from the framework-light constants
+// so the form imports one thing from here (mirrors LIFECYCLE/TIER co-location).
+export { RUNTIME_PLATFORM_OPTIONS }
+
+/** Per-kind subtype placeholder hints; falls back to a generic suggestion. */
+const SUBTYPE_PLACEHOLDERS: Partial<Record<EntityKind, string>> = {
+  datastore: 'postgresql, redis, s3…',
+  resource: 'iot-device, bucket, queue…',
+  service: 'website, worker, cron…',
+}
+
+/** Example subtype text for a kind (drives the form input placeholder). */
+export function subtypePlaceholder(kind: EntityKind): string {
+  return SUBTYPE_PLACEHOLDERS[kind] ?? 'A short refinement of the kind'
+}
 
 /**
  * Sentinel `<Select>` value for the "Global (no workspace)" option. A select

--- a/orbit-www/src/components/features/scorecards/rule-builder.test.ts
+++ b/orbit-www/src/components/features/scorecards/rule-builder.test.ts
@@ -434,6 +434,7 @@ describe('scoreable-field catalog', () => {
     expect(fieldByPath('lifecycle')?.enumOptions).toContain('production')
     expect(fieldByPath('owner')?.valueType).toBe('relationship')
     expect(fieldByPath('name')?.valueType).toBe('text')
+    expect(fieldByPath('subtype')?.valueType).toBe('text')
     expect(fieldByPath('metadata.costCenter')).toBeUndefined()
   })
 

--- a/orbit-www/src/components/features/scorecards/rule-builder.ts
+++ b/orbit-www/src/components/features/scorecards/rule-builder.ts
@@ -129,6 +129,12 @@ export const SCOREABLE_FIELDS: ScoreableField[] = [
   { path: 'slug', label: 'Slug', valueType: 'text' },
   { path: 'description', label: 'Description', valueType: 'text' },
   {
+    path: 'subtype',
+    label: 'Subtype',
+    valueType: 'text',
+    help: 'Free-form refinement of kind (e.g. postgresql, iot-device).',
+  },
+  {
     path: 'owner',
     label: 'Owning team',
     valueType: 'relationship',

--- a/orbit-www/src/lib/catalog/entity-crud.test.ts
+++ b/orbit-www/src/lib/catalog/entity-crud.test.ts
@@ -3,11 +3,14 @@ import {
   slugify,
   uniqueSlug,
   validateLinks,
+  validateSubtype,
+  validateRuntime,
   validateCreateInput,
   validateUpdatePatch,
   validateRelationInput,
   PROJECTION_LOCKED_FIELDS,
   CURATION_FIELDS,
+  SUBTYPE_MAX_LENGTH,
   type CreateEntityInput,
 } from './entity-crud'
 
@@ -60,6 +63,52 @@ describe('field-ownership constants', () => {
     )
     expect(overlap).toEqual([])
   })
+
+  it('treats subtype and runtime as curation fields (editable on projected entities)', () => {
+    expect(CURATION_FIELDS).toContain('subtype')
+    expect(CURATION_FIELDS).toContain('runtime')
+  })
+})
+
+describe('validateSubtype', () => {
+  it('passes for absent / empty subtype', () => {
+    expect(validateSubtype(undefined)).toBeNull()
+    expect(validateSubtype(null)).toBeNull()
+    expect(validateSubtype('')).toBeNull()
+  })
+
+  it('passes for a free-text value within the length cap', () => {
+    expect(validateSubtype('postgresql')).toBeNull()
+    expect(validateSubtype('iot-device')).toBeNull()
+    expect(validateSubtype('x'.repeat(SUBTYPE_MAX_LENGTH))).toBeNull()
+  })
+
+  it('rejects an over-length subtype (trimmed)', () => {
+    expect(validateSubtype('x'.repeat(SUBTYPE_MAX_LENGTH + 1))).toMatch(/subtype/i)
+  })
+})
+
+describe('validateRuntime', () => {
+  it('passes for absent runtime or an empty group', () => {
+    expect(validateRuntime(undefined)).toBeNull()
+    expect(validateRuntime(null)).toBeNull()
+    expect(validateRuntime({})).toBeNull()
+  })
+
+  it('passes for a valid url + platform', () => {
+    expect(validateRuntime({ url: 'https://app.example.com', platform: 'kubernetes' })).toBeNull()
+    expect(validateRuntime({ platform: 'home-server', notes: 'rack in the closet' })).toBeNull()
+  })
+
+  it('rejects a non-http(s) runtime url', () => {
+    expect(validateRuntime({ url: 'ftp://x.dev' })).toMatch(/http/i)
+  })
+
+  it('rejects an unknown platform', () => {
+    expect(
+      validateRuntime({ platform: 'mainframe' as never }),
+    ).toMatch(/platform/i)
+  })
 })
 
 describe('validateLinks', () => {
@@ -107,6 +156,33 @@ describe('validateCreateInput', () => {
   it('surfaces link errors', () => {
     expect(validateCreateInput({ ...base, links: [{ label: 'x', url: 'nope' }] })).toMatch(/http/i)
   })
+
+  it('passes for a valid create carrying subtype + runtime', () => {
+    expect(
+      validateCreateInput({
+        ...base,
+        kind: 'datastore',
+        subtype: 'postgresql',
+        runtime: { url: 'https://db.internal:5432', platform: 'home-server', notes: 'primary' },
+      }),
+    ).toBeNull()
+  })
+
+  it('surfaces an over-length subtype', () => {
+    expect(
+      validateCreateInput({ ...base, subtype: 'x'.repeat(SUBTYPE_MAX_LENGTH + 1) }),
+    ).toMatch(/subtype/i)
+  })
+
+  it('surfaces an invalid runtime url', () => {
+    expect(validateCreateInput({ ...base, runtime: { url: 'not-a-url' } })).toMatch(/http/i)
+  })
+
+  it('surfaces an invalid runtime platform', () => {
+    expect(
+      validateCreateInput({ ...base, runtime: { platform: 'mainframe' as never } }),
+    ).toMatch(/platform/i)
+  })
 })
 
 describe('validateUpdatePatch', () => {
@@ -125,6 +201,22 @@ describe('validateUpdatePatch', () => {
     expect(
       validateUpdatePatch('apps', { description: 'human note', links: [], tier: 'tier-1' }),
     ).toBeNull()
+  })
+
+  it('allows subtype + runtime curation on a projected (apps) entity', () => {
+    expect(
+      validateUpdatePatch('apps', {
+        subtype: 'website',
+        runtime: { url: 'https://acme.dev', platform: 'paas' },
+      }),
+    ).toBeNull()
+  })
+
+  it('rejects invalid subtype / runtime on any entity', () => {
+    expect(
+      validateUpdatePatch('manual', { subtype: 'x'.repeat(SUBTYPE_MAX_LENGTH + 1) }),
+    ).toMatch(/subtype/i)
+    expect(validateUpdatePatch('manual', { runtime: { url: 'nope' } })).toMatch(/http/i)
   })
 
   it('rejects an empty name on a manual entity', () => {

--- a/orbit-www/src/lib/catalog/entity-crud.ts
+++ b/orbit-www/src/lib/catalog/entity-crud.ts
@@ -1,5 +1,5 @@
-import type { EntityKind, RelationType } from '@/collections/catalog/constants'
-import { ENTITY_KINDS, RELATION_TYPES } from '@/collections/catalog/constants'
+import type { EntityKind, RelationType, RuntimePlatform } from '@/collections/catalog/constants'
+import { ENTITY_KINDS, RELATION_TYPES, RUNTIME_PLATFORMS } from '@/collections/catalog/constants'
 
 /**
  * Catalog entity CRUD — pure, framework-light input types + validators
@@ -44,6 +44,11 @@ export const CURATION_FIELDS = [
   'owner',
   'links',
   'metadata',
+  // Curation refinements (catalog-representation-gaps P2): a free-form `subtype`
+  // and a `runtime` pointer stay editable even on a projected entity — the
+  // source owns identity, humans own the descriptive/operational overlay.
+  'subtype',
+  'runtime',
 ] as const
 
 // ---------------------------------------------------------------------------
@@ -61,6 +66,17 @@ export interface EntityLink {
   type?: LinkType
 }
 
+/**
+ * Where an entity runs and how to reach it. `url` is the human-facing deployed
+ * pointer, `platform` the hosting substrate; topology (runs-in relations to
+ * environment entities) is complementary and lives in the graph, not here.
+ */
+export interface EntityRuntime {
+  url?: string | null
+  platform?: RuntimePlatform | null
+  notes?: string | null
+}
+
 /** Payload for creating a new manual entity. `workspaceId: null` = Global. */
 export interface CreateEntityInput {
   kind: EntityKind
@@ -70,6 +86,10 @@ export interface CreateEntityInput {
   description?: string | null
   lifecycle?: EntityLifecycle | null
   tier?: EntityTier | null
+  /** Free-form refinement of kind (e.g. `postgresql`, `iot-device`, `website`). */
+  subtype?: string | null
+  /** Where this entity runs / how to reach it. */
+  runtime?: EntityRuntime | null
   /** Owning team entity id (a catalog entity of kind `team`). */
   ownerId?: string | null
   links?: EntityLink[]
@@ -87,6 +107,8 @@ export interface UpdateEntityPatch {
   description?: string | null
   lifecycle?: EntityLifecycle | null
   tier?: EntityTier | null
+  subtype?: string | null
+  runtime?: EntityRuntime | null
   ownerId?: string | null
   links?: EntityLink[]
   metadata?: Record<string, unknown> | null
@@ -162,12 +184,49 @@ export function uniqueSlug(base: string, taken: Iterable<string>): string {
 
 const HTTP_URL = /^https?:\/\//i
 
+/** Max length of the free-form `subtype` refinement. */
+export const SUBTYPE_MAX_LENGTH = 50
+
 function isEntityKind(value: unknown): value is EntityKind {
   return typeof value === 'string' && (ENTITY_KINDS as readonly string[]).includes(value)
 }
 
 function isRelationType(value: unknown): value is RelationType {
   return typeof value === 'string' && (RELATION_TYPES as readonly string[]).includes(value)
+}
+
+function isRuntimePlatform(value: unknown): value is RuntimePlatform {
+  return typeof value === 'string' && (RUNTIME_PLATFORMS as readonly string[]).includes(value)
+}
+
+/**
+ * Validate the free-form `subtype`: trimmed, capped at {@link SUBTYPE_MAX_LENGTH}.
+ * No vocabulary check — it is an intentionally open refinement of `kind`.
+ * Returns an error message, or null when valid (or absent).
+ */
+export function validateSubtype(subtype: string | null | undefined): string | null {
+  if (subtype == null) return null
+  if (subtype.trim().length > SUBTYPE_MAX_LENGTH) {
+    return `Subtype must be ${SUBTYPE_MAX_LENGTH} characters or fewer.`
+  }
+  return null
+}
+
+/**
+ * Validate the `runtime` group: `url` (when present) must be an http(s) URL and
+ * `platform` (when present) must be a known {@link RUNTIME_PLATFORMS} value.
+ * Returns an error message, or null when valid (or absent).
+ */
+export function validateRuntime(runtime: EntityRuntime | null | undefined): string | null {
+  if (!runtime) return null
+  const url = runtime.url?.trim()
+  if (url && !HTTP_URL.test(url)) {
+    return 'The runtime URL must start with http:// or https://.'
+  }
+  if (runtime.platform != null && !isRuntimePlatform(runtime.platform)) {
+    return 'A valid runtime platform is required.'
+  }
+  return null
 }
 
 /**
@@ -193,6 +252,10 @@ export function validateCreateInput(input: CreateEntityInput): string | null {
   if (!isEntityKind(input.kind)) return 'A valid entity kind is required.'
   const linkError = validateLinks(input.links)
   if (linkError) return linkError
+  const subtypeError = validateSubtype(input.subtype)
+  if (subtypeError) return subtypeError
+  const runtimeError = validateRuntime(input.runtime)
+  if (runtimeError) return runtimeError
   return null
 }
 
@@ -216,6 +279,10 @@ export function validateUpdatePatch(sourceType: string, patch: UpdateEntityPatch
   if (patch.kind !== undefined && !isEntityKind(patch.kind)) return 'A valid entity kind is required.'
   const linkError = validateLinks(patch.links)
   if (linkError) return linkError
+  const subtypeError = validateSubtype(patch.subtype)
+  if (subtypeError) return subtypeError
+  const runtimeError = validateRuntime(patch.runtime)
+  if (runtimeError) return runtimeError
   return null
 }
 

--- a/orbit-www/src/lib/catalog/projection.test.ts
+++ b/orbit-www/src/lib/catalog/projection.test.ts
@@ -415,4 +415,17 @@ describe('mergeProjectionUpdate (field-ownership / set-if-absent)', () => {
     const out = mergeProjectionUpdate({}, incoming)
     expect('source' in out).toBe(false)
   })
+
+  it('never emits subtype/runtime — re-projecting cannot clobber curated values', () => {
+    const out = mergeProjectionUpdate(
+      {
+        description: 'Human edited',
+        subtype: 'postgresql',
+        runtime: { url: 'https://db.internal', platform: 'home-server' },
+      },
+      incoming,
+    )
+    expect('subtype' in out).toBe(false)
+    expect('runtime' in out).toBe(false)
+  })
 })

--- a/orbit-www/src/lib/catalog/projection.ts
+++ b/orbit-www/src/lib/catalog/projection.ts
@@ -68,8 +68,10 @@ interface EntityData {
  * fields the projection owns (name, slug, kind, workspace, health) are always
  * written; curation fields (description, lifecycle, links, metadata) are
  * SET-IF-ABSENT — written only when the existing row has no human-entered value
- * — so re-projecting a source never clobbers manual edits. `source`, `tier` and
- * `owner` are never written by the projection. Pure + unit-tested.
+ * — so re-projecting a source never clobbers manual edits. `source`, `tier`,
+ * `owner`, `subtype` and `runtime` are never written by the projection (the
+ * latter two are pure human curation), so they are always preserved on re-sync.
+ * Pure + unit-tested.
  */
 export function mergeProjectionUpdate(
   existing: {
@@ -77,6 +79,10 @@ export function mergeProjectionUpdate(
     lifecycle?: string | null
     links?: unknown[] | null
     metadata?: unknown
+    // Present on the row but never touched here — projection owns identity, not
+    // these curation refinements. Typed loosely so callers can pass the raw doc.
+    subtype?: unknown
+    runtime?: unknown
   },
   data: EntityData,
 ): Record<string, unknown> {

--- a/orbit-www/src/payload-types.ts
+++ b/orbit-www/src/payload-types.ts
@@ -279,6 +279,9 @@ export interface User {
    * If checked, user can log in immediately after approval without verifying their email.
    */
   skipEmailVerification?: boolean | null;
+  /**
+   * Set when an admin creates this user via an invite link; distinguishes invited users from self-registered ones.
+   */
   invitedAt?: string | null;
   registrationApprovedAt?: string | null;
   registrationApprovedBy?: (string | null) | User;
@@ -3553,6 +3556,10 @@ export interface CatalogEntity {
   description?: string | null;
   kind: 'service' | 'api' | 'resource' | 'datastore' | 'kafka-topic' | 'domain' | 'system' | 'team' | 'environment';
   /**
+   * Free-form refinement of kind, e.g. postgresql (datastore), iot-device (resource), website (service).
+   */
+  subtype?: string | null;
+  /**
    * Security enclave the entity belongs to (absent = global).
    */
   workspace?: (string | null) | Workspace;
@@ -3576,6 +3583,23 @@ export interface CatalogEntity {
         id?: string | null;
       }[]
     | null;
+  /**
+   * Where this entity runs and how to reach it. Topology lives in runs-in relations; this is the human-facing pointer.
+   */
+  runtime?: {
+    /**
+     * Deployed URL — where to reach this entity.
+     */
+    url?: string | null;
+    /**
+     * Hosting substrate (kubernetes, vps, home-server, …).
+     */
+    platform?: ('kubernetes' | 'vps' | 'home-server' | 'paas' | 'serverless' | 'other') | null;
+    /**
+     * Free-form operational notes (access, quirks).
+     */
+    notes?: string | null;
+  };
   /**
    * Provenance back to the backing collection this row projects from.
    */
@@ -4603,6 +4627,7 @@ export interface UsersSelect<T extends boolean = true> {
   role?: T;
   betterAuthId?: T;
   skipEmailVerification?: T;
+  invitedAt?: T;
   registrationApprovedAt?: T;
   registrationApprovedBy?: T;
   updatedAt?: T;
@@ -5944,6 +5969,7 @@ export interface CatalogEntitiesSelect<T extends boolean = true> {
   slug?: T;
   description?: T;
   kind?: T;
+  subtype?: T;
   workspace?: T;
   owner?: T;
   lifecycle?: T;
@@ -5955,6 +5981,13 @@ export interface CatalogEntitiesSelect<T extends boolean = true> {
         url?: T;
         type?: T;
         id?: T;
+      };
+  runtime?:
+    | T
+    | {
+        url?: T;
+        platform?: T;
+        notes?: T;
       };
   source?:
     | T


### PR DESCRIPTION
## Summary

Phase 2 of the [catalog representation gaps plan](https://github.com/drewpayment/orbit/pull/89) (plan doc lands with PR #89): catalog entities can now express **what they are** more precisely and **where they run**, without adding new entity kinds.

- **`subtype`** — free text (≤50, indexed with kind): `datastore · postgresql`, `resource · iot-device`, `service · website`
- **`runtime` group** — `url` (http(s)-validated), `platform` (kubernetes | vps | home-server | paas | serverless | other), `notes`. Complements (doesn't replace) `runs-in` graph edges — this is the human-facing "how do I reach it" pointer.

Both are **curation fields**: editable even on projected entities, and never clobbered by re-projection (`mergeProjectionUpdate` omits them — test asserts key omission, and live QA proved it across a real App-edit → projection-hook → reload cycle).

### Implementation notes
- Shared `RUNTIME_PLATFORMS` constant feeds the schema select, validators, and form from one source
- `runtime` uses `!== undefined` + `normalizeRuntimeWrite` (null → all-null sub-fields) so programmatic `runtime: null` clears the group — Payload group types have no null form
- Subtype stored trimmed; schema-level + client-side `maxLength`
- Scorecard rule-builder offers Subtype as a scoreable field (parity with Description)

### Review process
TDD throughout (15 tests watched red first), Opus adversarial review (1 should-fix — the `runtime: null` silent no-op — plus 3 nits, all fixed), live QA via agent-browser.

## Test plan

- [x] `bunx vitest run src/lib/catalog src/components/features/catalog src/components/features/scorecards` — 243/243
- [x] `bunx tsc --noEmit` — 0 errors
- [x] Live QA (dev env, agent-browser): create datastore with subtype/runtime → header badge, Runtime card (noopener external link), list suffix all render; edit round-trip including full clearing; **projected-entity persistence across a real re-projection** (description updated, subtype/runtime survived, name/kind stayed locked); rule-builder shows Subtype; bad-URL and over-length subtype rejected; all synthetic data removed

## Notes for merging

- `payload-types.ts` regen includes the same benign `invitedAt` doc-comment sync as #89 — whichever PR merges second: resolve the conflict by re-running `bun run generate:types`
- Pre-existing issues found while QA'ing (not this PR): the custom `/api/workspaces` route shadows Payload's generated REST endpoint, breaking the admin panel's Workspace relationship picker (`405` → "An error has occurred" banner) — worth its own issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjAyrKghEcE6ateAHcvtUs